### PR TITLE
Add Edge-Function-Composer

### DIFF
--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunction.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunction.h
@@ -17,8 +17,9 @@
 #ifndef PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTION_H_
 #define PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTION_H_
 
-#include <iostream> // std::cout in dump, better replace it with a ostream
 #include <memory>
+#include <ostream>
+#include <sstream>
 #include <string>
 
 namespace psr {
@@ -38,7 +39,7 @@ public:
   virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const = 0;
 
   virtual void print(std::ostream &OS, bool isForDebug = false) const {
-    OS << "edge_function";
+    OS << "EdgeFunction";
   }
 
   std::string str() {

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright (c) 2017 Philipp Schubert.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+#ifndef PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONCOMPOSER_H
+#define PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONCOMPOSER_H
+
+#include <gtest/gtest_prod.h>
+#include <memory>
+#include <phasar/PhasarLLVM/IfdsIde/EdgeFunction.h>
+#include <phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllBottom.h>
+#include <phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h>
+
+namespace psr {
+
+/**
+ * This abstract class models edge function composition. It holds two edge
+ * functions. The edge function computation order is implemented as
+ *  F -> G -> otherFunction
+ * i.e. F is computed before G, G is computed before otherFunction.
+ *
+ * Note that an own implementation for the join function is required, since
+ * this varies between different analyses, and is not implemented by this
+ * class.
+ * It is also advised to provide a more precise compose function, which is able
+ * to reduce the result of the composition, rather than using the default
+ * implementation. By default, an explicit composition is used. Such a function
+ * definition can grow unduly large.
+ */
+template <typename V>
+class EdgeFunctionComposer
+    : public EdgeFunction<V>,
+      public std::enable_shared_from_this<EdgeFunctionComposer<V>> {
+private:
+  // For debug purpose only
+  const unsigned EFComposer_Id;
+  static unsigned CurrEFComposer_Id;
+
+protected:
+  /// First edge function
+  std::shared_ptr<EdgeFunction<V>> F;
+  /// Second edge function
+  std::shared_ptr<EdgeFunction<V>> G;
+
+public:
+  EdgeFunctionComposer(std::shared_ptr<EdgeFunction<V>> F,
+                       std::shared_ptr<EdgeFunction<V>> G)
+      : EFComposer_Id(++CurrEFComposer_Id), F(F), G(G) {}
+
+  /**
+   * Target value computation is implemented as
+   *     G(F(source))
+   */
+  virtual V computeTarget(V source) override {
+    return G->computeTarget(F->computeTarget(source));
+  }
+
+  /**
+   * Function composition is implemented as an explicit composition, i.e.
+   *     (secondFunction * G) * F = EFC(F, EFC(G , otherFunction))
+   *
+   * However, it is advised to immediately reduce the resulting edge function
+   * by providing an own implementation of this function.
+   */
+  virtual std::shared_ptr<EdgeFunction<V>>
+  composeWith(std::shared_ptr<EdgeFunction<V>> secondFunction) override {
+    if (auto *EI = dynamic_cast<EdgeIdentity<V> *>(secondFunction.get())) {
+      return this->shared_from_this();
+    }
+    return F->composeWith(G->composeWith(secondFunction));
+  }
+
+  // virtual std::shared_ptr<EdgeFunction<V>>
+  // joinWith(std::shared_ptr<EdgeFunction<V>> otherFunction) = 0;
+
+  virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
+    if (auto EFC = dynamic_cast<EdgeFunctionComposer<V> *>(other.get())) {
+      return F->equal_to(EFC->F) && G->equal_to(EFC->G);
+    }
+    return false;
+  }
+
+  virtual void print(std::ostream &OS, bool isForDebug = false) const override {
+    OS << "EFComposer_" << EFComposer_Id << "[ " << F.get()->str() << " , "
+       << G.get()->str() << " ]";
+  }
+};
+
+template <typename V> unsigned EdgeFunctionComposer<V>::CurrEFComposer_Id = 0;
+
+} // namespace psr
+
+#endif

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllBottom.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllBottom.h
@@ -72,7 +72,7 @@ public:
   }
 
   virtual void print(std::ostream &OS, bool isForDebug = false) const override {
-    OS << "all_bottom";
+    OS << "AllBottom";
   }
 };
 

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllTop.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllTop.h
@@ -54,7 +54,7 @@ public:
   }
 
   virtual void print(std::ostream &OS, bool isForDebug = false) const override {
-    OS << "all_top";
+    OS << "AllTop";
   }
 };
 

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
@@ -73,7 +73,7 @@ public:
   }
 
   virtual void print(std::ostream &OS, bool isForDebug = false) const override {
-    OS << "edge_identity";
+    OS << "EdgeIdentity";
   }
 };
 

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -275,10 +275,7 @@ AnalysisController::AnalysisController(
           for (auto exit : ICFG.getExitPointsOf(f)) {
             cout << "Exit     : " << lcaproblem.NtoString(exit) << endl;
             for (auto res : llvmlcasolver.resultsAt(exit, true)) {
-              cout << "Value: "
-                   << (res.second == lcaproblem.bottomElement()
-                           ? "BOT"
-                           : lcaproblem.VtoString(res.second))
+              cout << "Value: " << lcaproblem.VtoString(res.second)
                    << "\tat " << lcaproblem.DtoString(res.first) << endl;
             }
           }

--- a/unittests/PhasarLLVM/IfdsIde/CMakeLists.txt
+++ b/unittests/PhasarLLVM/IfdsIde/CMakeLists.txt
@@ -1,1 +1,9 @@
 add_subdirectory(Problems)
+
+set(IfdsIdeSources
+	EdgeFunctionComposerTest.cpp
+)
+
+foreach(TEST_SRC ${IfdsIdeSources})
+	add_phasar_unittest(${TEST_SRC})
+endforeach(TEST_SRC)

--- a/unittests/PhasarLLVM/IfdsIde/EdgeFunctionComposerTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/EdgeFunctionComposerTest.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h>
+#include <phasar/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.h>
+#include <string>
+
+using namespace psr;
+
+static unsigned CurrMulTwoEF_Id = 0;
+static unsigned CurrAddTwoEF_Id = 0;
+
+struct MyEFC : EdgeFunctionComposer<int> {
+  MyEFC(std::shared_ptr<EdgeFunction<int>> F,
+        std::shared_ptr<EdgeFunction<int>> G)
+      : EdgeFunctionComposer<int>(F, G){};
+  std::shared_ptr<EdgeFunction<int>>
+  joinWith(std::shared_ptr<EdgeFunction<int>> otherFunction) override {
+    return std::make_shared<AllBottom<int>>(-1);
+  };
+};
+
+struct MulTwoEF : EdgeFunction<int>, std::enable_shared_from_this<MulTwoEF> {
+private:
+  const unsigned MulTwoEF_Id;
+
+public:
+  MulTwoEF(unsigned id) : MulTwoEF_Id(id){};
+  int computeTarget(int source) override { return source * 2; };
+  std::shared_ptr<EdgeFunction<int>>
+  composeWith(std::shared_ptr<EdgeFunction<int>> secondFunction) override {
+    return std::make_shared<MyEFC>(this->shared_from_this(), secondFunction);
+  }
+  std::shared_ptr<EdgeFunction<int>>
+  joinWith(std::shared_ptr<EdgeFunction<int>> otherFunction) override {
+    return std::make_shared<AllBottom<int>>(-1);
+  };
+  bool equal_to(std::shared_ptr<EdgeFunction<int>> other) const override {
+    return this == other.get();
+  }
+  void print(std::ostream &os, bool isForDebug = false) const override {
+    os << "MulTwoEF_" << MulTwoEF_Id;
+  }
+};
+
+struct AddTwoEF : EdgeFunction<int>, std::enable_shared_from_this<AddTwoEF> {
+private:
+  const unsigned AddTwoEF_Id;
+
+public:
+  AddTwoEF(unsigned id) : AddTwoEF_Id(id){};
+  int computeTarget(int source) override { return source + 2; };
+  std::shared_ptr<EdgeFunction<int>>
+  composeWith(std::shared_ptr<EdgeFunction<int>> secondFunction) override {
+    return std::make_shared<MyEFC>(this->shared_from_this(), secondFunction);
+  }
+  std::shared_ptr<EdgeFunction<int>>
+  joinWith(std::shared_ptr<EdgeFunction<int>> otherFunction) override {
+    return std::make_shared<AllBottom<int>>(-1);
+  };
+  bool equal_to(std::shared_ptr<EdgeFunction<int>> other) const override {
+    return this == other.get();
+  }
+  void print(std::ostream &os, bool isForDebug = false) const override {
+    os << "AddTwoEF_" << AddTwoEF_Id;
+  }
+};
+
+TEST(EdgeFunctionComposerTest, HandleEFIDs) {
+  auto EF1 = std::make_shared<AddTwoEF>(++CurrAddTwoEF_Id);
+  auto EF2 = std::make_shared<AddTwoEF>(++CurrAddTwoEF_Id);
+  std::cout << "My EF : " << EF1->str() << " " << EF2->str() << '\n';
+  EXPECT_EQ("AddTwoEF_1", EF1->str());
+  EXPECT_EQ("AddTwoEF_2", EF2->str());
+  auto EFC1 = std::make_shared<MyEFC>(EF1, EF2);
+  auto EFC2 = std::make_shared<MyEFC>(EF2, EdgeIdentity<int>::getInstance());
+  std::cout << "My EFC: " << EFC1->str() << " " << EFC2->str() << '\n';
+  EXPECT_EQ("EFComposer_1[ AddTwoEF_1 , AddTwoEF_2 ]", EFC1->str());
+  EXPECT_EQ("EFComposer_2[ AddTwoEF_2 , EdgeIdentity ]", EFC2->str());
+  // Reset ID's for next test
+  CurrAddTwoEF_Id = 0;
+}
+
+TEST(EdgeFunctionComposerTest, HandleEFComposition) {
+  // ((3 + 2) * 2) + 2
+  int initialValue = 3;
+  auto AddEF1 = std::make_shared<AddTwoEF>(++CurrAddTwoEF_Id);
+  auto AddEF2 = std::make_shared<AddTwoEF>(++CurrAddTwoEF_Id);
+  auto MulEF = std::make_shared<MulTwoEF>(++CurrMulTwoEF_Id);
+  auto ComposedEF = (AddEF1->composeWith(MulEF))->composeWith(AddEF2);
+  std::cout << "Compose: " << ComposedEF->str() << '\n';
+  int result = ComposedEF->computeTarget(initialValue);
+  std::cout << "Result: " << result << '\n';
+  EXPECT_EQ(12, result);
+  EXPECT_FALSE(AddEF1->equal_to(AddEF2));
+}
+
+// main function for the test case
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -1,4 +1,3 @@
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h>
@@ -63,7 +62,7 @@ protected:
         }
       }
     }
-    EXPECT_THAT(results, ::testing::ContainerEq(groundTruth));
+    EXPECT_EQ(results, groundTruth);
   }
 }; // Test Fixture
 

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
@@ -1,4 +1,3 @@
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h>
@@ -63,7 +62,7 @@ protected:
       }
       FoundLeaks.insert(make_pair(SinkId, LeakedValueIds));
     }
-    EXPECT_THAT(FoundLeaks, ::testing::ContainerEq(GroundTruth));
+    EXPECT_EQ(FoundLeaks, GroundTruth);
   }
 }; // Test Fixture
 


### PR DESCRIPTION
The Edge-Function-Composer is no longer a nested class of the
Linear-Constant Analysis. Unittests were added to test edge function
compositon.