### PR TITLE
Add more flexible print functionality for IFDS/IDE/Mono framework

### DIFF
--- a/include/phasar/PhasarLLVM/IfdsIde/IDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/IDETabulationProblem.h
@@ -23,17 +23,18 @@
 #include <phasar/PhasarLLVM/IfdsIde/EdgeFunctions.h>
 #include <phasar/PhasarLLVM/IfdsIde/IFDSTabulationProblem.h>
 #include <phasar/PhasarLLVM/IfdsIde/JoinLattice.h>
+#include <phasar/PhasarLLVM/Utils/Printer.h>
 
 namespace psr {
 
 template <typename N, typename D, typename M, typename V, typename I>
 class IDETabulationProblem : public IFDSTabulationProblem<N, D, M, I>,
                              public EdgeFunctions<N, D, M, V>,
-                             public JoinLattice<V> {
+                             public JoinLattice<V>,
+                             public ValuePrinter<V> {
 public:
   virtual ~IDETabulationProblem() = default;
   virtual std::shared_ptr<EdgeFunction<V>> allTopFunction() = 0;
-  virtual std::string VtoString(V v) const = 0;
 };
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/IfdsIde/IFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/IFDSTabulationProblem.h
@@ -23,11 +23,15 @@
 
 #include <phasar/PhasarLLVM/IfdsIde/FlowFunctions.h>
 #include <phasar/PhasarLLVM/IfdsIde/SolverConfiguration.h>
+#include <phasar/PhasarLLVM/Utils/Printer.h>
 
 namespace psr {
 
 template <typename N, typename D, typename M, typename I>
-class IFDSTabulationProblem : public FlowFunctions<N, D, M> {
+class IFDSTabulationProblem : public FlowFunctions<N, D, M>,
+                              public NodePrinter<N>,
+                              public DataFlowFactPrinter<D>,
+                              public MethodPrinter<M> {
 public:
   SolverConfiguration solver_config;
   virtual ~IFDSTabulationProblem() = default;
@@ -35,9 +39,6 @@ public:
   virtual std::map<N, std::set<D>> initialSeeds() = 0;
   virtual D zeroValue() = 0;
   virtual bool isZeroValue(D d) const = 0;
-  virtual std::string DtoString(D d) const = 0;
-  virtual std::string NtoString(N n) const = 0;
-  virtual std::string MtoString(M m) const = 0;
   void setSolverConfiguration(SolverConfiguration conf) {
     solver_config = conf;
   }

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.h
@@ -191,13 +191,13 @@ public:
    */
   static v_t executeBinOperation(const unsigned op, v_t lop, v_t rop);
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string VtoString(v_t v) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printValue(std::ostream &os, v_t v) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.h
@@ -116,13 +116,13 @@ public:
     bool equal_to(std::shared_ptr<EdgeFunction<v_t>> other) const override;
   };
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string VtoString(v_t v) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printValue(std::ostream &os, v_t v) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDESolverTest.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDESolverTest.h
@@ -116,13 +116,13 @@ public:
     bool equal_to(std::shared_ptr<EdgeFunction<v_t>> other) const override;
   };
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string VtoString(v_t v) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printValue(std::ostream &os, v_t v) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETaintAnalysis.h
@@ -122,13 +122,13 @@ public:
     bool equal_to(std::shared_ptr<EdgeFunction<v_t>> other) const override;
   };
 
-  std::string DtoString(d_t d) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string VtoString(v_t v) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printValue(std::ostream &os, v_t v) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.h
@@ -108,13 +108,13 @@ public:
 
   std::shared_ptr<EdgeFunction<v_t>> allTopFunction() override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string VtoString(v_t v) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printValue(std::ostream &os, v_t v) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.h
@@ -155,11 +155,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
   /**
    * @note Global Variables are always intialized in llvm IR, and therefore

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
@@ -91,11 +91,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.h
@@ -67,11 +67,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.h
@@ -67,11 +67,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.h
@@ -68,11 +68,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.h
@@ -92,11 +92,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 
   void printLeaks() const;
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.h
@@ -63,11 +63,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.h
@@ -71,11 +71,11 @@ public:
 
   bool isZeroValue(d_t d) const override;
 
-  std::string DtoString(d_t d) const override;
+  void printNode(std::ostream &os, n_t n) const override;
 
-  std::string NtoString(n_t n) const override;
+  void printDataFlowFact(std::ostream &os, d_t d) const override;
 
-  std::string MtoString(m_t m) const override;
+  void printMethod(std::ostream &os, m_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IFDSToIDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IFDSToIDETabulationProblem.h
@@ -137,17 +137,19 @@ public:
     return EdgeIdentity<BinaryDomain>::getInstance();
   }
 
-  std::string DtoString(D d) const override { return problem.DtoString(d); }
-
-  std::string VtoString(BinaryDomain v) const override {
-    std::ostringstream osst;
-    osst << v;
-    return osst.str();
+  void printNode(std::ostream &os, N n) const override {
+    problem.printNode(os, n);
   }
 
-  std::string MtoString(M m) const override { return problem.MtoString(m); }
+  void printDataFlowFact(std::ostream &os, D d) const override {
+    problem.printDataFlowFact(os, d);
+  }
 
-  std::string NtoString(N n) const override { return problem.NtoString(n); }
+  void printMethod(std::ostream &os, M m) const override {
+    problem.printMethod(os, m);
+  }
+
+  void printValue(std::ostream &os, BinaryDomain v) const override { os << v; }
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/ZeroFlowFact.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/ZeroFlowFact.h
@@ -10,9 +10,8 @@
 #ifndef PHASAR_PHASARLLVM_IFDSIDE_ZEROFLOWFACT_H_
 #define PHASAR_PHASARLLVM_IFDSIDE_ZEROFLOWFACT_H_
 
-#include <ostream>
+#include <iosfwd>
 
-#include <iostream>
 #include <phasar/PhasarLLVM/IfdsIde/FlowFact.h>
 
 namespace psr {

--- a/include/phasar/PhasarLLVM/Mono/Contexts/CallString.h
+++ b/include/phasar/PhasarLLVM/Mono/Contexts/CallString.h
@@ -21,7 +21,6 @@
 #include <deque>
 #include <initializer_list>
 #include <iterator>
-#include <ostream>
 
 #include <phasar/PhasarLLVM/Mono/Contexts/ContextBase.h>
 
@@ -45,8 +44,12 @@ protected:
   static const unsigned k = K;
 
 public:
-  CallString() = default;
-  CallString(std::initializer_list<Node_t> ilist) : cs(ilist) {
+  CallString(const NodePrinter<N> *np, const DataFlowFactPrinter<D> *dp)
+      : ContextBase<N, D, CallString<N, D, K>>(np, dp) {}
+
+  CallString(const NodePrinter<N> *np, const DataFlowFactPrinter<D> *dp,
+             std::initializer_list<N> ilist)
+      : ContextBase<N, D, CallString<N, D, K>>(np, dp), cs(ilist) {
     if (ilist.size() > k) {
       throw std::runtime_error(
           "initial call std::string length exceeds maximal length K");
@@ -94,8 +97,10 @@ public:
   }
 
   void print(std::ostream &os) const override {
-    std::copy(cs.begin(), --cs.end(), std::ostream_iterator<Node_t>(os, " * "));
-    os << cs.back();
+    os << "Call string [" << cs.size() << "]: ";
+    for (auto C : cs) {
+      os << this->NP->NtoString(C) << " * ";
+    }
   }
 
   std::size_t size() const { return cs.size(); }

--- a/include/phasar/PhasarLLVM/Mono/Contexts/ContextBase.h
+++ b/include/phasar/PhasarLLVM/Mono/Contexts/ContextBase.h
@@ -18,6 +18,7 @@
 #define PHASAR_PHASARLLVM_MONO_CONTEXTS_CONTEXTBASE_H_
 
 #include <ostream>
+#include <phasar/PhasarLLVM/Utils/Printer.h>
 
 namespace psr {
 
@@ -33,6 +34,8 @@ template <typename N, typename D, typename ConcreteContext> class ContextBase {
 public:
   using Node_t = N;
   using Domain_t = D;
+  const NodePrinter<N> *NP;
+  const DataFlowFactPrinter<D> *DP;
 
 private:
   void ValueBase_check() {
@@ -44,6 +47,9 @@ private:
   }
 
 public:
+  ContextBase(const NodePrinter<N> *np, const DataFlowFactPrinter<D> *dp)
+      : NP(np), DP(dp) {}
+
   /*
    * Update the context at the exit of a function
    */

--- a/include/phasar/PhasarLLVM/Mono/Contexts/ValueBasedContext.h
+++ b/include/phasar/PhasarLLVM/Mono/Contexts/ValueBasedContext.h
@@ -49,7 +49,8 @@ protected:
   Domain_t prev_context;
 
 public:
-  ValueBasedContext() = default;
+  ValueBasedContext(const NodePrinter<N> *np, const DataFlowFactPrinter<D> *dp)
+      : ContextBase<N, D, ValueBasedContext<N, D>>(np, dp) {}
 
   void enterFunction(const Node_t src, const Node_t dest,
                      const Domain_t &In) override {
@@ -136,9 +137,21 @@ protected:
   IdGen_t IdGen;
 
 public:
-  MappedValueBasedContext() = default;
+  MappedValueBasedContext(const NodePrinter<Node> *np,
+                          const DataFlowFactPrinter<Domain_t> *dp)
+      : ContextBase<
+            Node, Map<Key, Value>,
+            MappedValueBasedContext<Node, Key, Value, IdGenerator, Map>>(np,
+                                                                         dp) {}
 
-  MappedValueBasedContext(IdGen_t &_IdGen) : IdGen(_IdGen) {}
+  MappedValueBasedContext(const NodePrinter<Node> *np,
+                          const DataFlowFactPrinter<Domain_t> *dp,
+                          IdGen_t &_IdGen)
+      : ContextBase<
+            Node, Map<Key, Value>,
+            MappedValueBasedContext<Node, Key, Value, IdGenerator, Map>>(np,
+                                                                         dp),
+        IdGen(_IdGen) {}
 
   template <class T>
   MappedValueBasedContext(T &&_args, T &&_prev_context)

--- a/include/phasar/PhasarLLVM/Mono/InterMonoProblem.h
+++ b/include/phasar/PhasarLLVM/Mono/InterMonoProblem.h
@@ -21,11 +21,14 @@
 #include <type_traits>
 
 #include <phasar/Config/ContainerConfiguration.h>
+#include <phasar/PhasarLLVM/Utils/Printer.h>
 
 namespace psr {
 
 template <typename N, typename D, typename M, typename I>
-class InterMonoProblem {
+class InterMonoProblem : public NodePrinter<N>,
+                         public DataFlowFactPrinter<D>,
+                         public MethodPrinter<M> {
 public:
   using Node_t = N;
   using Domain_t = D;
@@ -61,9 +64,6 @@ public:
   virtual Domain_t callToRetFlow(const Node_t CallSite, const Node_t RetSite,
                                  const Domain_t &In) = 0;
   virtual MonoMap<Node_t, Domain_t> initialSeeds() = 0;
-  virtual std::string DtoString(const Domain_t d) = 0;
-  virtual std::string MtoString(const Method_t m) = 0;
-  virtual std::string NtoString(const Node_t n) = 0;
   virtual bool recompute(const Method_t Callee) = 0;
 };
 

--- a/include/phasar/PhasarLLVM/Mono/IntraMonoProblem.h
+++ b/include/phasar/PhasarLLVM/Mono/IntraMonoProblem.h
@@ -20,11 +20,14 @@
 #include <string>
 
 #include <phasar/Config/ContainerConfiguration.h>
+#include <phasar/PhasarLLVM/Utils/Printer.h>
 
 namespace psr {
 
 template <typename N, typename D, typename M, typename C>
-class IntraMonoProblem {
+class IntraMonoProblem : public NodePrinter<N>,
+                         public DataFlowFactPrinter<D>,
+                         public MethodPrinter<M> {
 protected:
   C CFG;
   M Function;
@@ -38,7 +41,6 @@ public:
   virtual bool sqSubSetEqual(const MonoSet<D> &Lhs, const MonoSet<D> &Rhs) = 0;
   virtual MonoSet<D> flow(N S, const MonoSet<D> &In) = 0;
   virtual MonoMap<N, MonoSet<D>> initialSeeds() = 0;
-  virtual std::string DtoString(D d) = 0;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/Mono/Problems/InterMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/InterMonoSolverTest.h
@@ -67,11 +67,11 @@ public:
 
   MonoMap<Node_t, Domain_t> initialSeeds() override;
 
-  std::string DtoString(const Domain_t d) override;
+  void printNode(std::ostream &os, Node_t n) const override;
 
-  std::string MtoString(Method_t m) override;
+  void printDataFlowFact(std::ostream &os, Domain_t d) const override;
 
-  std::string NtoString(Node_t n) override;
+  void printMethod(std::ostream &os, Method_t m) const override;
 
   bool recompute(Method_t Callee) override;
 };

--- a/include/phasar/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.h
@@ -67,11 +67,11 @@ public:
 
   MonoMap<Node_t, Domain_t> initialSeeds() override;
 
-  std::string DtoString(const Domain_t d) override;
+  void printNode(std::ostream &os, Node_t n) const override;
 
-  std::string MtoString(Method_t m) override;
+  void printDataFlowFact(std::ostream &os, Domain_t d) const override;
 
-  std::string NtoString(Node_t n) override;
+  void printMethod(std::ostream &os, Method_t m) const override;
 
   bool recompute(Method_t Callee) override;
 };

--- a/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.h
@@ -37,21 +37,29 @@ class IntraMonoFullConstantPropagation
                               std::pair<const llvm::Value *, unsigned>,
                               const llvm::Function *, LLVMBasedCFG &> {
 public:
-  typedef std::pair<const llvm::Value *, unsigned> DFF;
+  using Node_t = const llvm::Instruction *;
+  using Domain_t = std::pair<const llvm::Value *, unsigned>;
+  using Method_t = const llvm::Function *;
+  using CFG_t = LLVMBasedCFG &;
 
-  IntraMonoFullConstantPropagation(LLVMBasedCFG &Cfg, const llvm::Function *F);
+  IntraMonoFullConstantPropagation(CFG_t Cfg, Method_t F);
   virtual ~IntraMonoFullConstantPropagation() = default;
 
-  MonoSet<DFF> join(const MonoSet<DFF> &Lhs, const MonoSet<DFF> &Rhs) override;
+  MonoSet<Domain_t> join(const MonoSet<Domain_t> &Lhs,
+                         const MonoSet<Domain_t> &Rhs) override;
 
-  bool sqSubSetEqual(const MonoSet<DFF> &Lhs, const MonoSet<DFF> &Rhs) override;
+  bool sqSubSetEqual(const MonoSet<Domain_t> &Lhs,
+                     const MonoSet<Domain_t> &Rhs) override;
 
-  MonoSet<DFF> flow(const llvm::Instruction *S,
-                    const MonoSet<DFF> &In) override;
+  MonoSet<Domain_t> flow(Node_t S, const MonoSet<Domain_t> &In) override;
 
-  MonoMap<const llvm::Instruction *, MonoSet<DFF>> initialSeeds() override;
+  MonoMap<Node_t, MonoSet<Domain_t>> initialSeeds() override;
 
-  std::string DtoString(std::pair<const llvm::Value *, unsigned> d) override;
+  void printNode(std::ostream &os, Node_t n) const override;
+
+  void printDataFlowFact(std::ostream &os, Domain_t d) const override;
+
+  void printMethod(std::ostream &os, Method_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.h
@@ -35,24 +35,29 @@ class IntraMonoSolverTest
     : public IntraMonoProblem<const llvm::Instruction *, const llvm::Value *,
                               const llvm::Function *, LLVMBasedCFG &> {
 public:
-  IntraMonoSolverTest(LLVMBasedCFG &Cfg, const llvm::Function *F);
+  using Node_t = const llvm::Instruction *;
+  using Domain_t = const llvm::Value *;
+  using Method_t = const llvm::Function *;
+  using CFG_t = LLVMBasedCFG &;
+
+  IntraMonoSolverTest(CFG_t Cfg, Method_t F);
   virtual ~IntraMonoSolverTest() = default;
 
-  MonoSet<const llvm::Value *>
-  join(const MonoSet<const llvm::Value *> &Lhs,
-       const MonoSet<const llvm::Value *> &Rhs) override;
+  MonoSet<Domain_t> join(const MonoSet<Domain_t> &Lhs,
+                         const MonoSet<Domain_t> &Rhs) override;
 
-  bool sqSubSetEqual(const MonoSet<const llvm::Value *> &Lhs,
-                     const MonoSet<const llvm::Value *> &Rhs) override;
+  bool sqSubSetEqual(const MonoSet<Domain_t> &Lhs,
+                     const MonoSet<Domain_t> &Rhs) override;
 
-  MonoSet<const llvm::Value *>
-  flow(const llvm::Instruction *S,
-       const MonoSet<const llvm::Value *> &In) override;
+  MonoSet<Domain_t> flow(Node_t S, const MonoSet<Domain_t> &In) override;
 
-  MonoMap<const llvm::Instruction *, MonoSet<const llvm::Value *>>
-  initialSeeds() override;
+  MonoMap<Node_t, MonoSet<Domain_t>> initialSeeds() override;
 
-  std::string DtoString(const llvm::Value *d) override;
+  void printNode(std::ostream &os, Node_t n) const override;
+
+  void printDataFlowFact(std::ostream &os, Domain_t d) const override;
+
+  void printMethod(std::ostream &os, Method_t m) const override;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
@@ -17,6 +17,7 @@
 #ifndef PHASAR_PHASARLLVM_MONO_SOLVER_LLVMINTERMONOSOLVER_H_
 #define PHASAR_PHASARLLVM_MONO_SOLVER_LLVMINTERMONOSOLVER_H_
 
+#include <iostream>
 #include <memory>
 
 #include <llvm/IR/Instruction.h>
@@ -73,9 +74,6 @@ public:
 
   /**
    * Dumps monotone solver results to the commandline.
-   * WARNING: Currently, this will only work with CallStrings! It is only a
-   * temporarily since the Context's print functionality is broken at the moment
-   * :(
    */
   void dumpResults() {
     std::cout << "======= DUMP LLVM-INTER-MONOTONE-SOLVER RESULTS =======\n";
@@ -83,32 +81,13 @@ public:
     for (auto &Node : IMSBase_t::Analysis) {
       std::cout << "------- Mono Start Result Record -------\n";
       std::cout << "F: " << Node.first->getFunction()->getName().str()
-                << "   N: " << llvmIRToString(Node.first) << '\n';
+                << "   N: " << this->IMProblem.NtoString(Node.first) << '\n';
       // Iterate call-string - flow fact set pairs
       for (auto &ContextFactPair : Node.second) {
-        // Print the context
-        // std::cout << "Context:\n";
-        // if (typeid(ContextFactPair.first) ==
-        //     typeid(ValueBasedContext<const llvm::Instruction *, D>)) {
-        //   std::cout << "Args:\n"
-        //             << IMSBase_t::IMProblem.DtoString(
-        //                    ContextFactPair.first.getArgs());
-        //   std::cout << "Prev Args:\n"
-        //             << IMSBase_t::IMProblem.DtoString(
-        //                    ContextFactPair.first.getPrevContext());
-        // } else {
-        std::cout << "Call string [" << ContextFactPair.first.size() << "]: ";
-        for (auto context : ContextFactPair.first.getInternalCS()) {
-          std::cout << llvmIRToString(context) << " * ";
-        }
-        // }
+        std::cout << ContextFactPair.first;
         std::cout << "\nDomain:\n";
         // Print the elements of the corresponding set of flow facts
-        // for (auto Fact : ContextFactPair.second) {
-        std::cout << IMSBase_t::IMProblem.DtoString(ContextFactPair.second)
-                  << '\n';
-        // }
-        // std::cout << "\n\n";
+        std::cout << this->IMProblem.DtoString(ContextFactPair.second) << '\n';
       }
     }
   };

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
@@ -56,12 +56,11 @@ public:
 
   void dumpResults() {
     std::cout << "LLVM-Intra-Monotone solver results:\n"
-                 "------------------------\n";
+                 "-----------------------------------\n";
     for (auto &entry : IntraMonoSolver<const llvm::Instruction *, D,
                                        const llvm::Function *, C>::Analysis) {
-      std::cout << "Instruction:\n";
-      entry.first->print(llvm::outs());
-      std::cout << "Facts:\n";
+      std::cout << "Instruction:\n" << IMP.NtoString(entry.first);
+      std::cout << "\nFacts:\n";
       if (entry.second.empty()) {
         std::cout << "\tEMPTY\n";
       } else {

--- a/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
+++ b/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
@@ -64,16 +64,17 @@ public:
     return isLLVMZeroValue(d);
   }
 
-  std::string DtoString(const llvm::Value *d) const override {
-    return llvmIRToString(d);
+  void printNode(std::ostream &os, const llvm::Instruction *n) const override {
+    os << llvmIRToString(n);
   }
 
-  std::string NtoString(const llvm::Instruction *n) const override {
-    return llvmIRToString(n);
+  void printDataFlowFact(std::ostream &os,
+                         const llvm::Value *d) const override {
+    os << llvmIRToString(d);
   }
 
-  std::string MtoString(const llvm::Function *m) const override {
-    return llvmIRToString(m);
+  void printMethod(std::ostream &os, const llvm::Function *m) const override {
+    os << m->getName().str();
   }
 };
 

--- a/include/phasar/PhasarLLVM/Utils/Printer.h
+++ b/include/phasar/PhasarLLVM/Utils/Printer.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright (c) 2017 Philipp Schubert.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+/*
+ * Printer.h
+ *
+ *  Created on: 07.09.2018
+ *      Author: rleer
+ */
+
+#ifndef PHASAR_PHASARLLVM_UTILS_PRINTER_H_
+#define PHASAR_PHASARLLVM_UTILS_PRINTER_H_
+
+#include <ostream>
+#include <sstream>
+#include <string>
+
+namespace psr {
+
+template <typename N> struct NodePrinter {
+  virtual void printNode(std::ostream &os, N n) const = 0;
+
+  virtual std::string NtoString(N n) const {
+    std::stringstream ss;
+    printNode(ss, n);
+    return ss.str();
+  }
+};
+
+template <typename D> struct DataFlowFactPrinter {
+  virtual void printDataFlowFact(std::ostream &os, D d) const = 0;
+
+  virtual std::string DtoString(D d) const {
+    std::stringstream ss;
+    printDataFlowFact(ss, d);
+    return ss.str();
+  }
+};
+
+template <typename V> struct ValuePrinter {
+  virtual void printValue(std::ostream &os, V v) const = 0;
+
+  virtual std::string VtoString(V v) const {
+    std::stringstream ss;
+    printValue(ss, v);
+    return ss.str();
+  }
+};
+
+template <typename M> struct MethodPrinter {
+  virtual void printMethod(std::ostream &os, M m) const = 0;
+
+  virtual std::string MtoString(M m) const {
+    std::stringstream ss;
+    printMethod(ss, m);
+    return ss.str();
+  }
+};
+
+} // namespace psr
+
+#endif

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -436,7 +436,7 @@ AnalysisController::AnalysisController(
         InterMonoSolverTest inter(ICFG, EntryPoints);
         CallString<typename InterMonoSolverTest::Node_t,
                    typename InterMonoSolverTest::Domain_t, 3>
-            Context;
+            Context(&inter, &inter);
         auto solver = make_LLVMBasedIMS(inter, Context, F, true);
         solver->solve();
         break;
@@ -446,7 +446,7 @@ AnalysisController::AnalysisController(
         InterMonoTaintAnalysis inter(ICFG, EntryPoints);
         CallString<typename InterMonoTaintAnalysis::Node_t,
                    typename InterMonoTaintAnalysis::Domain_t, 10>
-            Context;
+            Context(&inter, &inter);
         auto solver = make_LLVMBasedIMS(inter, Context, F, true);
         solver->solve();
         solver->dumpResults();

--- a/lib/PhasarLLVM/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
+++ b/lib/PhasarLLVM/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
@@ -23,7 +23,7 @@ namespace psr {
 
 MapFactsToCallee::MapFactsToCallee(
     const llvm::ImmutableCallSite &callSite, const llvm::Function *destMthd,
-    std::function<bool(const llvm::Value *)> predicate)
+    function<bool(const llvm::Value *)> predicate)
     : predicate(predicate) {
   // Set up the actual parameters
   for (unsigned idx = 0; idx < callSite.getNumArgOperands(); ++idx) {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -690,27 +690,24 @@ IDELinearConstantAnalysis::v_t IDELinearConstantAnalysis::executeBinOperation(
   return res;
 }
 
-string
-IDELinearConstantAnalysis::DtoString(IDELinearConstantAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IDELinearConstantAnalysis::printNode(
+    ostream &os, IDELinearConstantAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string
-IDELinearConstantAnalysis::VtoString(IDELinearConstantAnalysis::v_t v) const {
-  if (v == BOTTOM) {
-    return "Bottom";
-  }
-  return to_string(v);
+void IDELinearConstantAnalysis::printDataFlowFact(
+    ostream &os, IDELinearConstantAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string
-IDELinearConstantAnalysis::NtoString(IDELinearConstantAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IDELinearConstantAnalysis::printMethod(
+    ostream &os, IDELinearConstantAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
-string
-IDELinearConstantAnalysis::MtoString(IDELinearConstantAnalysis::m_t m) const {
-  return m->getName().str();
+void IDELinearConstantAnalysis::printValue(
+    ostream &os, IDELinearConstantAnalysis::v_t v) const {
+  os << ((v == BOTTOM) ? "Bottom" : to_string(v));
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.cpp
@@ -79,8 +79,8 @@ IDEProtoAnalysis::initialSeeds() {
   cout << "IDEProtoAnalysis::initialSeeds()\n";
   map<IDEProtoAnalysis::n_t, set<IDEProtoAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IDEProtoAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IDEProtoAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -193,20 +193,21 @@ bool IDEProtoAnalysis::IDEProtoAnalysisAllTop::equal_to(
   return false;
 }
 
-string IDEProtoAnalysis::DtoString(IDEProtoAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IDEProtoAnalysis::printNode(ostream &os, IDEProtoAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IDEProtoAnalysis::VtoString(IDEProtoAnalysis::v_t v) const {
-  return llvmIRToString(v);
+void IDEProtoAnalysis::printDataFlowFact(ostream &os,
+                                         IDEProtoAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IDEProtoAnalysis::NtoString(IDEProtoAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IDEProtoAnalysis::printMethod(ostream &os, IDEProtoAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
-string IDEProtoAnalysis::MtoString(IDEProtoAnalysis::m_t m) const {
-  return m->getName().str();
+void IDEProtoAnalysis::printValue(ostream &os, IDEProtoAnalysis::v_t v) const {
+  os << llvmIRToString(v);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDESolverTest.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDESolverTest.cpp
@@ -75,8 +75,8 @@ map<IDESolverTest::n_t, set<IDESolverTest::d_t>> IDESolverTest::initialSeeds() {
   cout << "IDESolverTest::initialSeeds()\n";
   map<IDESolverTest::n_t, set<IDESolverTest::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IDESolverTest::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IDESolverTest::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -186,21 +186,20 @@ bool IDESolverTest::IDESolverTestAllTop::equal_to(
   return false;
 }
 
-string IDESolverTest::DtoString(IDESolverTest::d_t d) const {
-  return llvmIRToString(d);
+void IDESolverTest::printNode(ostream &os, IDESolverTest::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IDESolverTest::VtoString(IDESolverTest::v_t v) const {
-  // return llvmIRToString(v);
-  return "empty V test";
+void IDESolverTest::printDataFlowFact(ostream &os, IDESolverTest::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IDESolverTest::NtoString(IDESolverTest::n_t n) const {
-  return llvmIRToString(n);
+void IDESolverTest::printMethod(ostream &os, IDESolverTest::m_t m) const {
+  os << m->getName().str();
 }
 
-string IDESolverTest::MtoString(IDESolverTest::m_t m) const {
-  return m->getName().str();
+void IDESolverTest::printValue(ostream &os, IDESolverTest::v_t v) const {
+  os << "empty V test";
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDETaintAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDETaintAnalysis.cpp
@@ -75,8 +75,8 @@ IDETaintAnalysis::initialSeeds() {
   // just start in main()
   map<IDETaintAnalysis::n_t, set<IDETaintAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IDETaintAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IDETaintAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -171,20 +171,21 @@ bool IDETaintAnalysis::IDETainAnalysisAllTop::equal_to(
   return false;
 }
 
-string IDETaintAnalysis::DtoString(IDETaintAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IDETaintAnalysis::printNode(ostream &os, IDETaintAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IDETaintAnalysis::VtoString(IDETaintAnalysis::v_t v) const {
-  return llvmIRToString(v);
+void IDETaintAnalysis::printDataFlowFact(ostream &os,
+                                         IDETaintAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IDETaintAnalysis::NtoString(IDETaintAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IDETaintAnalysis::printMethod(ostream &os, IDETaintAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
-string IDETaintAnalysis::MtoString(IDETaintAnalysis::m_t m) const {
-  return m->getName().str();
+void IDETaintAnalysis::printValue(ostream &os, IDETaintAnalysis::v_t v) const {
+  os << llvmIRToString(v);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -247,9 +247,8 @@ IDETypeStateAnalysis::initialSeeds() {
   // just start in main()
   map<IDETypeStateAnalysis::n_t, set<IDETypeStateAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(
-        std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                       set<IDETypeStateAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IDETypeStateAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -320,20 +319,24 @@ IDETypeStateAnalysis::allTopFunction() {
   return make_shared<AllTop<IDETypeStateAnalysis::v_t>>(TOP);
 }
 
-string IDETypeStateAnalysis::DtoString(IDETypeStateAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IDETypeStateAnalysis::printNode(ostream &os,
+                                     IDETypeStateAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IDETypeStateAnalysis::VtoString(IDETypeStateAnalysis::v_t v) const {
-  return to_string(static_cast<int>(v));
+void IDETypeStateAnalysis::printDataFlowFact(
+    ostream &os, IDETypeStateAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IDETypeStateAnalysis::NtoString(IDETypeStateAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IDETypeStateAnalysis::printMethod(ostream &os,
+                                       IDETypeStateAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
-string IDETypeStateAnalysis::MtoString(IDETypeStateAnalysis::m_t m) const {
-  return m->getName().str();
+void IDETypeStateAnalysis::printValue(ostream &os,
+                                      IDETypeStateAnalysis::v_t v) const {
+  os << to_string(static_cast<int>(v));
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -260,16 +260,18 @@ bool IFDSConstAnalysis::isZeroValue(IFDSConstAnalysis::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSConstAnalysis::DtoString(IFDSConstAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IFDSConstAnalysis::printNode(ostream &os, IFDSConstAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSConstAnalysis::NtoString(IFDSConstAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSConstAnalysis::printDataFlowFact(ostream &os,
+                                          IFDSConstAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSConstAnalysis::MtoString(IFDSConstAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSConstAnalysis::printMethod(ostream &os,
+                                    IFDSConstAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
 void IFDSConstAnalysis::printInitMemoryLocations() {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
@@ -23,8 +23,8 @@
 using namespace std;
 using namespace psr;
 
-std::size_t std::hash<LCAPair>::operator()(const LCAPair &k) const {
-  return std::hash<const llvm::Value *>()(k.first) ^ std::hash<int>()(k.second);
+size_t hash<LCAPair>::operator()(const LCAPair &k) const {
+  return hash<const llvm::Value *>()(k.first) ^ hash<int>()(k.second);
 }
 
 namespace psr {
@@ -34,11 +34,11 @@ LCAPair::LCAPair() : first(nullptr), second(0) {}
 LCAPair::LCAPair(const llvm::Value *V, int i) : first(V), second(i) {}
 
 bool operator==(const LCAPair &lhs, const LCAPair &rhs) {
-  return std::tie(lhs.first, lhs.second) == std::tie(rhs.first, rhs.second);
+  return tie(lhs.first, lhs.second) == tie(rhs.first, rhs.second);
 }
 
 bool operator<(const LCAPair &lhs, const LCAPair &rhs) {
-  return std::tie(lhs.first, lhs.second) < std::tie(rhs.first, rhs.second);
+  return tie(lhs.first, lhs.second) < tie(rhs.first, rhs.second);
 }
 
 IFDSLinearConstantAnalysis::IFDSLinearConstantAnalysis(
@@ -109,8 +109,8 @@ IFDSLinearConstantAnalysis::initialSeeds() {
       SeedMap;
   for (auto &EntryPoint : EntryPoints) {
     SeedMap.insert(
-        std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                       set<IFDSLinearConstantAnalysis::d_t>({zeroValue()})));
+        make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                  set<IFDSLinearConstantAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -128,18 +128,19 @@ bool IFDSLinearConstantAnalysis::isZeroValue(
   return d == zerovalue;
 }
 
-string
-IFDSLinearConstantAnalysis::DtoString(IFDSLinearConstantAnalysis::d_t d) const {
-  return '<' + llvmIRToString(d.first) + ", " + to_string(d.second) + '>';
+void IFDSLinearConstantAnalysis::printNode(
+    ostream &os, IFDSLinearConstantAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string
-IFDSLinearConstantAnalysis::NtoString(IFDSLinearConstantAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSLinearConstantAnalysis::printDataFlowFact(
+    ostream &os, IFDSLinearConstantAnalysis::d_t d) const {
+  os << '<' + llvmIRToString(d.first) + ", " + to_string(d.second) + '>';
 }
 
-string
-IFDSLinearConstantAnalysis::MtoString(IFDSLinearConstantAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSLinearConstantAnalysis::printMethod(
+    ostream &os, IFDSLinearConstantAnalysis::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.cpp
@@ -78,8 +78,8 @@ IFDSProtoAnalysis::initialSeeds() {
   cout << "IFDSProtoAnalysis::initialSeeds()\n";
   map<IFDSProtoAnalysis::n_t, set<IFDSProtoAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IFDSProtoAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IFDSProtoAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -93,15 +93,18 @@ bool IFDSProtoAnalysis::isZeroValue(IFDSProtoAnalysis::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSProtoAnalysis::DtoString(IFDSProtoAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IFDSProtoAnalysis::printNode(ostream &os, IFDSProtoAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSProtoAnalysis::NtoString(IFDSProtoAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSProtoAnalysis::printDataFlowFact(ostream &os,
+                                          IFDSProtoAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSProtoAnalysis::MtoString(IFDSProtoAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSProtoAnalysis::printMethod(ostream &os,
+                                    IFDSProtoAnalysis::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.cpp
@@ -73,8 +73,8 @@ IFDSSignAnalysis::initialSeeds() {
   cout << "IFDSSignAnalysis::initialSeeds()\n";
   map<IFDSSignAnalysis::n_t, set<IFDSSignAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IFDSSignAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IFDSSignAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -88,15 +88,17 @@ bool IFDSSignAnalysis::isZeroValue(IFDSSignAnalysis::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSSignAnalysis::DtoString(IFDSSignAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IFDSSignAnalysis::printNode(ostream &os, IFDSSignAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSSignAnalysis::NtoString(IFDSSignAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSSignAnalysis::printDataFlowFact(ostream &os,
+                                         IFDSSignAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSSignAnalysis::MtoString(IFDSSignAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSSignAnalysis::printMethod(ostream &os, IFDSSignAnalysis::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -81,8 +81,8 @@ IFDSSolverTest::initialSeeds() {
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "IFDSSolverTest::initialSeeds()");
   map<IFDSSolverTest::n_t, set<IFDSSolverTest::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IFDSSolverTest::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IFDSSolverTest::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -96,15 +96,17 @@ bool IFDSSolverTest::isZeroValue(IFDSSolverTest::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSSolverTest::DtoString(IFDSSolverTest::d_t d) const {
-  return llvmIRToString(d);
+void IFDSSolverTest::printNode(ostream &os, IFDSSolverTest::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSSolverTest::NtoString(IFDSSolverTest::n_t n) const {
-  return llvmIRToString(n);
+void IFDSSolverTest::printDataFlowFact(ostream &os,
+                                       IFDSSolverTest::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSSolverTest::MtoString(IFDSSolverTest::m_t m) const {
-  return m->getName().str();
+void IFDSSolverTest::printMethod(ostream &os, IFDSSolverTest::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -259,16 +259,18 @@ bool IFDSTaintAnalysis::isZeroValue(IFDSTaintAnalysis::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSTaintAnalysis::DtoString(IFDSTaintAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IFDSTaintAnalysis::printNode(ostream &os, IFDSTaintAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSTaintAnalysis::NtoString(IFDSTaintAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSTaintAnalysis::printDataFlowFact(ostream &os,
+                                          IFDSTaintAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSTaintAnalysis::MtoString(IFDSTaintAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSTaintAnalysis::printMethod(ostream &os,
+                                    IFDSTaintAnalysis::m_t m) const {
+  os << m->getName().str();
 }
 
 void IFDSTaintAnalysis::printLeaks() const {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.cpp
@@ -85,8 +85,8 @@ map<IFDSTypeAnalysis::n_t, set<IFDSTypeAnalysis::d_t>>
 IFDSTypeAnalysis::initialSeeds() {
   map<IFDSTypeAnalysis::n_t, set<IFDSTypeAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
-    SeedMap.insert(std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                                  set<IFDSTypeAnalysis::d_t>({zeroValue()})));
+    SeedMap.insert(make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                             set<IFDSTypeAnalysis::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -99,15 +99,17 @@ bool IFDSTypeAnalysis::isZeroValue(IFDSTypeAnalysis::d_t d) const {
   return isLLVMZeroValue(d);
 }
 
-string IFDSTypeAnalysis::DtoString(IFDSTypeAnalysis::d_t d) const {
-  return llvmIRToString(d);
+void IFDSTypeAnalysis::printNode(ostream &os, IFDSTypeAnalysis::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string IFDSTypeAnalysis::NtoString(IFDSTypeAnalysis::n_t n) const {
-  return llvmIRToString(n);
+void IFDSTypeAnalysis::printDataFlowFact(ostream &os,
+                                         IFDSTypeAnalysis::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string IFDSTypeAnalysis::MtoString(IFDSTypeAnalysis::m_t m) const {
-  return m->getName().str();
+void IFDSTypeAnalysis::printMethod(ostream &os, IFDSTypeAnalysis::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -368,8 +368,8 @@ IFDSUnitializedVariables::initialSeeds() {
       SeedMap;
   for (auto &EntryPoint : EntryPoints) {
     SeedMap.insert(
-        std::make_pair(&icfg.getMethod(EntryPoint)->front().front(),
-                       set<IFDSUnitializedVariables::d_t>({zeroValue()})));
+        make_pair(&icfg.getMethod(EntryPoint)->front().front(),
+                  set<IFDSUnitializedVariables::d_t>({zeroValue()})));
   }
   return SeedMap;
 }
@@ -387,18 +387,19 @@ bool IFDSUnitializedVariables::isZeroValue(
   return isLLVMZeroValue(d);
 }
 
-string
-IFDSUnitializedVariables::DtoString(IFDSUnitializedVariables::d_t d) const {
-  return llvmIRToString(d);
+void IFDSUnitializedVariables::printNode(
+    ostream &os, IFDSUnitializedVariables::n_t n) const {
+  os << llvmIRToString(n);
 }
 
-string
-IFDSUnitializedVariables::NtoString(IFDSUnitializedVariables::n_t n) const {
-  return llvmIRToString(n);
+void IFDSUnitializedVariables::printDataFlowFact(
+    ostream &os, IFDSUnitializedVariables::d_t d) const {
+  os << llvmIRToString(d);
 }
 
-string
-IFDSUnitializedVariables::MtoString(IFDSUnitializedVariables::m_t m) const {
-  return m->getName().str();
+void IFDSUnitializedVariables::printMethod(
+    ostream &os, IFDSUnitializedVariables::m_t m) const {
+  os << m->getName().str();
 }
+
 } // namespace psr

--- a/lib/PhasarLLVM/IfdsIde/ZeroFlowFact.cpp
+++ b/lib/PhasarLLVM/IfdsIde/ZeroFlowFact.cpp
@@ -7,7 +7,7 @@
  *     Philipp Schubert and others
  *****************************************************************************/
 
-#include <iostream>
+#include <ostream>
 
 #include <phasar/PhasarLLVM/IfdsIde/ZeroFlowFact.h>
 
@@ -16,7 +16,7 @@ using namespace psr;
 
 namespace psr {
 
-void ZeroFlowFact::print(std::ostream &os) const { os << "ZeroFlowFact"; }
+void ZeroFlowFact::print(ostream &os) const { os << "ZeroFlowFact"; }
 
 FlowFact *ZeroFlowFact::getInstance() {
   static ZeroFlowFact ZeroFact;

--- a/lib/PhasarLLVM/Mono/Problems/InterMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/Mono/Problems/InterMonoSolverTest.cpp
@@ -90,24 +90,22 @@ MonoMap<Node_t, Domain_t> InterMonoSolverTest::initialSeeds() {
   cout << "InterMonoSolverTest::initialSeeds()\n";
   const Method_t main = ICFG.getMethod("main");
   MonoMap<Node_t, Domain_t> Seeds;
-  Seeds.insert(std::make_pair(&main->front().front(), Domain_t()));
+  Seeds.insert(make_pair(&main->front().front(), Domain_t()));
   return Seeds;
 }
 
-string InterMonoSolverTest::DtoString(const Domain_t d) {
-  string str;
+void InterMonoSolverTest::printNode(ostream &os, Node_t n) const {
+  os << llvmIRToString(n);
+}
+
+void InterMonoSolverTest::printDataFlowFact(ostream &os, Domain_t d) const {
   for (auto fact : d) {
-    str += llvmIRToString(fact) + '\n';
+    os << llvmIRToString(fact) << '\n';
   }
-  return str;
 }
 
-string InterMonoSolverTest::MtoString(const Method_t m) {
-  return m->getName().str();
-}
-
-string InterMonoSolverTest::NtoString(const Node_t n) {
-  return llvmIRToString(n);
+void InterMonoSolverTest::printMethod(ostream &os, Method_t m) const {
+  os << m->getName().str();
 }
 
 bool InterMonoSolverTest::recompute(const Method_t Callee) { return false; }

--- a/lib/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.cpp
@@ -94,24 +94,22 @@ MonoMap<Node_t, Domain_t> InterMonoTaintAnalysis::initialSeeds() {
   cout << "InterMonoTaintAnalysis::initialSeeds()\n";
   const Method_t main = ICFG.getMethod("main");
   MonoMap<Node_t, Domain_t> Seeds;
-  Seeds.insert(std::make_pair(&main->front().front(), Domain_t()));
+  Seeds.insert(make_pair(&main->front().front(), Domain_t()));
   return Seeds;
 }
 
-string InterMonoTaintAnalysis::DtoString(const Domain_t d) {
-  string str;
+void InterMonoTaintAnalysis::printNode(ostream &os, Node_t n) const {
+  os << llvmIRToString(n);
+}
+
+void InterMonoTaintAnalysis::printDataFlowFact(ostream &os, Domain_t d) const {
   for (auto fact : d) {
-    str += llvmIRToString(fact) + '\n';
+    os << llvmIRToString(fact) << '\n';
   }
-  return str;
 }
 
-string InterMonoTaintAnalysis::MtoString(const Method_t m) {
-  return m->getName().str();
-}
-
-string InterMonoTaintAnalysis::NtoString(const Node_t n) {
-  return llvmIRToString(n);
+void InterMonoTaintAnalysis::printMethod(ostream &os, Method_t m) const {
+  os << m->getName().str();
 }
 
 bool InterMonoTaintAnalysis::recompute(const Method_t Callee) { return false; }

--- a/lib/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.cpp
@@ -24,41 +24,55 @@ using namespace psr;
 namespace psr {
 
 IntraMonoFullConstantPropagation::IntraMonoFullConstantPropagation(
-    LLVMBasedCFG &Cfg, const llvm::Function *F)
-    : IntraMonoProblem<const llvm::Instruction *, DFF, const llvm::Function *,
+    LLVMBasedCFG &Cfg, IntraMonoFullConstantPropagation::Method_t F)
+    : IntraMonoProblem<IntraMonoFullConstantPropagation::Node_t,
+                       IntraMonoFullConstantPropagation::Domain_t,
+                       IntraMonoFullConstantPropagation::Method_t,
                        LLVMBasedCFG &>(Cfg, F) {}
 
-MonoSet<IntraMonoFullConstantPropagation::DFF>
-IntraMonoFullConstantPropagation::join(const MonoSet<DFF> &Lhs,
-                                       const MonoSet<DFF> &Rhs) {
-  MonoSet<IntraMonoFullConstantPropagation::DFF> Result;
+MonoSet<IntraMonoFullConstantPropagation::Domain_t>
+IntraMonoFullConstantPropagation::join(
+    const MonoSet<IntraMonoFullConstantPropagation::Domain_t> &Lhs,
+    const MonoSet<IntraMonoFullConstantPropagation::Domain_t> &Rhs) {
+  MonoSet<IntraMonoFullConstantPropagation::Domain_t> Result;
   set_union(Lhs.begin(), Lhs.end(), Rhs.begin(), Rhs.end(),
             inserter(Result, Result.begin()));
   return Result;
 }
 
-bool IntraMonoFullConstantPropagation::sqSubSetEqual(const MonoSet<DFF> &Lhs,
-                                                     const MonoSet<DFF> &Rhs) {
+bool IntraMonoFullConstantPropagation::sqSubSetEqual(
+    const MonoSet<IntraMonoFullConstantPropagation::Domain_t> &Lhs,
+    const MonoSet<IntraMonoFullConstantPropagation::Domain_t> &Rhs) {
   return includes(Rhs.begin(), Rhs.end(), Lhs.begin(), Lhs.end());
 }
 
-MonoSet<IntraMonoFullConstantPropagation::DFF>
-IntraMonoFullConstantPropagation::flow(const llvm::Instruction *S,
-                                       const MonoSet<DFF> &In) {
-  return MonoSet<IntraMonoFullConstantPropagation::DFF>();
+MonoSet<IntraMonoFullConstantPropagation::Domain_t>
+IntraMonoFullConstantPropagation::flow(
+    IntraMonoFullConstantPropagation::Node_t S,
+    const MonoSet<IntraMonoFullConstantPropagation::Domain_t> &In) {
+  return MonoSet<IntraMonoFullConstantPropagation::Domain_t>();
 }
 
-MonoMap<const llvm::Instruction *,
-        MonoSet<IntraMonoFullConstantPropagation::DFF>>
+MonoMap<IntraMonoFullConstantPropagation::Node_t,
+        MonoSet<IntraMonoFullConstantPropagation::Domain_t>>
 IntraMonoFullConstantPropagation::initialSeeds() {
-  return MonoMap<const llvm::Instruction *,
-                 MonoSet<IntraMonoFullConstantPropagation::DFF>>();
+  return MonoMap<IntraMonoFullConstantPropagation::Node_t,
+                 MonoSet<IntraMonoFullConstantPropagation::Domain_t>>();
 }
 
-string IntraMonoFullConstantPropagation::DtoString(
-    pair<const llvm::Value *, unsigned> d) {
-  string s = "< " + llvmIRToString(d.first);
-  s += ", " + to_string(d.second) + " >";
-  return s;
+void IntraMonoFullConstantPropagation::printNode(
+    ostream &os, IntraMonoFullConstantPropagation::Node_t n) const {
+  os << llvmIRToString(n);
 }
+
+void IntraMonoFullConstantPropagation::printDataFlowFact(
+    ostream &os, IntraMonoFullConstantPropagation::Domain_t d) const {
+  os << "< " + llvmIRToString(d.first) << ", " + to_string(d.second) + " >";
+}
+
+void IntraMonoFullConstantPropagation::printMethod(
+    ostream &os, IntraMonoFullConstantPropagation::Method_t m) const {
+  os << m->getName().str();
+}
+
 } // namespace psr

--- a/lib/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.cpp
@@ -30,33 +30,34 @@ using namespace psr;
 
 namespace psr {
 
-IntraMonoSolverTest::IntraMonoSolverTest(LLVMBasedCFG &Cfg,
-                                         const llvm::Function *F)
-    : IntraMonoProblem<const llvm::Instruction *, const llvm::Value *,
-                       const llvm::Function *, LLVMBasedCFG &>(Cfg, F) {}
+IntraMonoSolverTest::IntraMonoSolverTest(IntraMonoSolverTest::CFG_t Cfg,
+                                         IntraMonoSolverTest::Method_t F)
+    : IntraMonoProblem<
+          IntraMonoSolverTest::Node_t, IntraMonoSolverTest::Domain_t,
+          IntraMonoSolverTest::Method_t, IntraMonoSolverTest::CFG_t>(Cfg, F) {}
 
-MonoSet<const llvm::Value *>
-IntraMonoSolverTest::join(const MonoSet<const llvm::Value *> &Lhs,
-                          const MonoSet<const llvm::Value *> &Rhs) {
+MonoSet<IntraMonoSolverTest::Domain_t>
+IntraMonoSolverTest::join(const MonoSet<IntraMonoSolverTest::Domain_t> &Lhs,
+                          const MonoSet<IntraMonoSolverTest::Domain_t> &Rhs) {
   cout << "IntraMonoSolverTest::join()\n";
-  MonoSet<const llvm::Value *> Result;
+  MonoSet<IntraMonoSolverTest::Domain_t> Result;
   set_union(Lhs.begin(), Lhs.end(), Rhs.begin(), Rhs.end(),
             inserter(Result, Result.begin()));
   return Result;
 }
 
 bool IntraMonoSolverTest::sqSubSetEqual(
-    const MonoSet<const llvm::Value *> &Lhs,
-    const MonoSet<const llvm::Value *> &Rhs) {
+    const MonoSet<IntraMonoSolverTest::Domain_t> &Lhs,
+    const MonoSet<IntraMonoSolverTest::Domain_t> &Rhs) {
   cout << "IntraMonoSolverTest::sqSubSetEqual()\n";
   return includes(Rhs.begin(), Rhs.end(), Lhs.begin(), Lhs.end());
 }
 
-MonoSet<const llvm::Value *>
-IntraMonoSolverTest::flow(const llvm::Instruction *S,
-                          const MonoSet<const llvm::Value *> &In) {
+MonoSet<IntraMonoSolverTest::Domain_t>
+IntraMonoSolverTest::flow(IntraMonoSolverTest::Node_t S,
+                          const MonoSet<IntraMonoSolverTest::Domain_t> &In) {
   cout << "IntraMonoSolverTest::flow()\n";
-  MonoSet<const llvm::Value *> Result;
+  MonoSet<IntraMonoSolverTest::Domain_t> Result;
   Result.insert(In.begin(), In.end());
   if (const auto Store = llvm::dyn_cast<llvm::StoreInst>(S)) {
     Result.insert(Store);
@@ -64,14 +65,25 @@ IntraMonoSolverTest::flow(const llvm::Instruction *S,
   return Result;
 }
 
-MonoMap<const llvm::Instruction *, MonoSet<const llvm::Value *>>
+MonoMap<IntraMonoSolverTest::Node_t, MonoSet<IntraMonoSolverTest::Domain_t>>
 IntraMonoSolverTest::initialSeeds() {
   cout << "IntraMonoSolverTest::initialSeeds()\n";
   return {};
 }
 
-string IntraMonoSolverTest::DtoString(const llvm::Value *d) {
-  return llvmIRToString(d);
+void IntraMonoSolverTest::printNode(ostream &os,
+                                    IntraMonoSolverTest::Node_t n) const {
+  os << llvmIRToString(n);
+}
+
+void IntraMonoSolverTest::printDataFlowFact(
+    ostream &os, IntraMonoSolverTest::Domain_t d) const {
+  os << llvmIRToString(d);
+}
+
+void IntraMonoSolverTest::printMethod(ostream &os,
+                                      IntraMonoSolverTest::Method_t m) const {
+  os << m->getName().str();
 }
 
 } // namespace psr


### PR DESCRIPTION
For each template parameter <N,D,M,V> of IFDS/IDE/Mono exist a wrapper
class for printing objects of that particular type. Those wrapper
provide the formerly used XtoString() methods, thus the old print
interface does not change.