### PR TITLE
Plugins: allow custom entry points

### DIFF
--- a/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
+++ b/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
@@ -43,7 +43,7 @@ AnalysisPluginController::AnalysisPluginController(
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
                       << "Solving plugin: " << Problem.first);
         unique_ptr<IFDSTabulationProblemPlugin> plugin(
-            Problem.second(ICFG, {"main"}));
+            Problem.second(ICFG, EntryPoints));
         cout << "DONE" << endl;
         LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmifdstestsolver(
             *plugin, true);


### PR DESCRIPTION
Hello,

Since I started to use my Phasar plugin on Clang and Fortran/Flang programs, I need to have a customizable entry point, like `MAIN_` over `main`.

Since it has been hardcoded for `main`, the `-E` parameter values are completely discarded, for no obvious reasons I guess -- and there is already a proper default in `AnalysisController`.

Regards