### PR TITLE
add slash after target dir

### DIFF
--- a/utils/install-llvm-5.0.1.sh
+++ b/utils/install-llvm-5.0.1.sh
@@ -14,8 +14,8 @@ target_dir=$2
 
 echo "Getting the complete LLVM source code"
 echo "Get llvm"
-svn co http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_501/final/ "${target_dir}llvm-5.0.1"
-cd ${target_dir}llvm-5.0.1/tools
+svn co http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_501/final/ "${target_dir}/llvm-5.0.1"
+cd ${target_dir}/llvm-5.0.1/tools
 echo "Get clang"
 svn co http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_501/final/ clang
 cd clang/tools


### PR DESCRIPTION
The LLVM installation script assumes target_dir to be specified with a trailing `/`. Not sure if this is intended or not. If I run the script with `./install-llvm-5.0.1.sh 40 ~/software/llvm`, it will clone the projects into `~/software/llvmllvm-5.0.1`. This patch always appends a `/` in the target_dir path, which doesn't hurt even if the target_dir is specified with a `/`.