### PR TITLE
Fixed CMake deps for llvm-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required (VERSION 3.0)
 
-project (phasar)
-set(CMAKE_PROJECT_NAME "phasar")
+# Check if we build within the llvm source tree
+if (DEFINED LLVM_MAIN_SRC_DIR)
+  set(PHASAR_IN_TREE 1)
+endif()
+
+if (NOT PHASAR_IN_TREE)
+  project (phasar)
+  set(CMAKE_PROJECT_NAME "phasar")
+endif ()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
 set(CMAKE_CXX_STANDARD 17)
@@ -83,9 +90,11 @@ add_subdirectory(external/json EXCLUDE_FROM_ALL)
 include_directories(external/json/single_include/nlohmann)
 
 # Googletest
-add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
-include_directories(external/googletest/googletest/include)
-include_directories(external/googletest/googlemock/include)
+if (NOT PHASAR_IN_TREE)
+  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+  include_directories(external/googletest/googletest/include)
+  include_directories(external/googletest/googlemock/include)
+endif()
 
 # WALi-OpenNWA
 add_subdirectory(external/WALi-OpenNWA)

--- a/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
+++ b/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 target_link_libraries(phasar_ifdside
   phasar_config
+
+  LLVMCore
 )
 
 set_target_properties(phasar_ifdside

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -1,13 +1,6 @@
 file(GLOB_RECURSE PLUGINS_SRC *.h *.cpp)
 file(GLOB_RECURSE PLUGINS_SO *.cxx)
 
-# Handle all plugins
-foreach(plugin ${PLUGINS_SO}) 
-	get_filename_component(plugin_name ${plugin} NAME_WE)
-	add_library(${plugin_name} SHARED ${plugin})
-	set_target_properties(${plugin_name} PROPERTIES PREFIX "")
-endforeach()
-
 # Handle the library files
 if(BUILD_SHARED_LIBS)
 	add_phasar_library(phasar_plugins
@@ -24,6 +17,20 @@ endif()
 target_link_libraries(phasar_plugins
 
 )
+
+# Handle all plugins
+foreach(plugin ${PLUGINS_SO})
+  get_filename_component(plugin_name ${plugin} NAME_WE)
+  add_library(${plugin_name} SHARED ${plugin})
+  set_target_properties(${plugin_name} PROPERTIES PREFIX "")
+  target_link_libraries(${plugin_name}
+    phasar_plugins
+    phasar_config
+    phasar_utils
+    phasar_ifdside
+    LLVMCore
+    )
+endforeach()
 
 set_target_properties(phasar_plugins
 	PROPERTIES

--- a/lib/PhasarPass/CMakeLists.txt
+++ b/lib/PhasarPass/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(phasar_pass
 
   phasar_config
   phasar_controlflow
-  phasar_db_without
+  phasar_db
   phasar_ifdside
   phasar_mono
   phasar_passes


### PR DESCRIPTION
Fixed cmake dependencies after llvm-8 update and small issues with building phasar as llvm drop in.
- Added deps to plugins
- Only include gtest for out of tree builds, otherwise, llvm provides gtest