### PR TITLE
fix UAF in PAMM

### DIFF
--- a/lib/Utils/PAMM.cpp
+++ b/lib/Utils/PAMM.cpp
@@ -271,7 +271,7 @@ void PAMM::exportMeasuredData(std::string OutputPath) {
 
   // add timer data
   while (!RunningTimer.empty()) {
-    stopTimer(RunningTimer.begin()->first);
+    stopTimer(std::string(RunningTimer.begin()->first));
   }
   json jTimer;
   for (auto timer : StoppedTimer) {


### PR DESCRIPTION
element destruction in PAMM.cpp:66 invalidates reference parameter TimerId, causing memory corruption