### PR TITLE
Prevents ObjectSlicing on InterMonoSolver and Printers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ find_all_symbols_db.yaml
 # Emacs convenience metadata
 TAGS
 
+# vim swp files
+*.*.swp
+
 # config files
 compiler_info.txt
 standard_header_paths.conf

--- a/include/phasar/PhasarClang/RandomChangeASTConsumer.h
+++ b/include/phasar/PhasarClang/RandomChangeASTConsumer.h
@@ -35,7 +35,7 @@ private:
 public:
   RandomChangeASTConsumer(clang::Rewriter &R);
 
-  virtual void HandleTranslationUnit(clang::ASTContext &Context) override;
+  void HandleTranslationUnit(clang::ASTContext &Context) override;
 
   // virtual bool HandleTopLevelDecl(DeclGroupRef DG);
 };

--- a/include/phasar/PhasarClang/RandomChangeFrontendAction.h
+++ b/include/phasar/PhasarClang/RandomChangeFrontendAction.h
@@ -27,7 +27,7 @@
 
 namespace clang {
 class CompilerInstance;
-}
+} // namespace clang
 
 namespace psr {
 

--- a/include/phasar/PhasarClang/RandomChangeVisitor.h
+++ b/include/phasar/PhasarClang/RandomChangeVisitor.h
@@ -47,6 +47,7 @@ private:
 
 public:
   RandomChangeVisitor(clang::Rewriter &R);
+  virtual ~RandomChangeVisitor() = default;
   virtual bool VisitVarDecl(clang::VarDecl *V);
   virtual bool VisitTypeDecl(clang::TypeDecl *T);
   virtual bool VisitStmt(clang::Stmt *S);

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -37,7 +37,7 @@ using json = nlohmann::json;
 
 template <typename N, typename M> class ICFG : public virtual CFG<N, M> {
 public:
-  virtual ~ICFG() = default;
+  ~ICFG() override = default;
 
   virtual bool isCallStmt(N stmt) = 0;
 

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -59,7 +59,7 @@ public:
                          const llvm::Module &M, CallGraphAnalysisType CGType,
                          std::vector<std::string> EntryPoints = {});
 
-  virtual ~LLVMBasedBackwardsICFG() = default;
+  ~LLVMBasedBackwardsICFG() override = default;
 
   std::set<const llvm::Function *> getAllMethods();
 

--- a/include/phasar/PhasarLLVM/IfdsIde/DefaultIFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/DefaultIFDSTabulationProblem.h
@@ -40,9 +40,9 @@ public:
     this->solver_config.computePersistedSummaries = true;
   }
 
-  virtual ~DefaultIFDSTabulationProblem() = default;
+  ~DefaultIFDSTabulationProblem() override = default;
 
-  virtual std::shared_ptr<FlowFunction<D>>
+  std::shared_ptr<FlowFunction<D>>
   getSummaryFlowFunction(N callStmt, M destMthd) override {
     return nullptr;
   }

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
@@ -56,7 +56,7 @@ public:
    * Target value computation is implemented as
    *     G(F(source))
    */
-  virtual V computeTarget(V source) override {
+  V computeTarget(V source) override {
     return G->computeTarget(F->computeTarget(source));
   }
 
@@ -67,7 +67,7 @@ public:
    * However, it is advised to immediately reduce the resulting edge function
    * by providing an own implementation of this function.
    */
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   composeWith(std::shared_ptr<EdgeFunction<V>> secondFunction) override {
     if (auto *EI = dynamic_cast<EdgeIdentity<V> *>(secondFunction.get())) {
       return this->shared_from_this();
@@ -78,14 +78,14 @@ public:
   // virtual std::shared_ptr<EdgeFunction<V>>
   // joinWith(std::shared_ptr<EdgeFunction<V>> otherFunction) = 0;
 
-  virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
+  bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
     if (auto EFC = dynamic_cast<EdgeFunctionComposer<V> *>(other.get())) {
       return F->equal_to(EFC->F) && G->equal_to(EFC->G);
     }
     return false;
   }
 
-  virtual void print(std::ostream &OS, bool isForDebug = false) const override {
+  void print(std::ostream &OS, bool isForDebug = false) const override {
     OS << "EFComposer_" << EFComposer_Id << "[ " << F.get()->str() << " , "
        << G.get()->str() << " ]";
   }

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllBottom.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllBottom.h
@@ -39,11 +39,11 @@ private:
 public:
   AllBottom(V bottomElement) : bottomElement(bottomElement) {}
 
-  virtual ~AllBottom() = default;
+  ~AllBottom() override = default;
 
   V computeTarget(V source) override { return bottomElement; }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   composeWith(std::shared_ptr<EdgeFunction<V>> secondFunction) override {
     if (EdgeIdentity<V> *ei =
             dynamic_cast<EdgeIdentity<V> *>(secondFunction.get()))
@@ -51,7 +51,7 @@ public:
     return secondFunction;
   }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   joinWith(std::shared_ptr<EdgeFunction<V>> otherFunction) override {
     if (otherFunction.get() == this ||
         otherFunction->equal_to(this->shared_from_this()))
@@ -64,14 +64,14 @@ public:
     return this->shared_from_this();
   }
 
-  virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
+  bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
     if (AllBottom<V> *allbottom = dynamic_cast<AllBottom<V> *>(other.get())) {
       return (allbottom->bottomElement == bottomElement);
     }
     return false;
   }
 
-  virtual void print(std::ostream &OS, bool isForDebug = false) const override {
+  void print(std::ostream &OS, bool isForDebug = false) const override {
     OS << "AllBottom";
   }
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllTop.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/AllTop.h
@@ -33,27 +33,27 @@ private:
 public:
   AllTop(V topElement) : topElement(topElement) {}
 
-  virtual ~AllTop() = default;
+  ~AllTop() override = default;
 
-  virtual V computeTarget(V source) override { return topElement; }
+  V computeTarget(V source) override { return topElement; }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   composeWith(std::shared_ptr<EdgeFunction<V>> secondFunction) override {
     return this->shared_from_this();
   }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   joinWith(std::shared_ptr<EdgeFunction<V>> otherFunction) override {
     return otherFunction;
   }
 
-  virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
+  bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
     if (AllTop<V> *alltop = dynamic_cast<AllTop<V> *>(other.get()))
       return (alltop->topElement == topElement);
     return false;
   }
 
-  virtual void print(std::ostream &OS, bool isForDebug = false) const override {
+  void print(std::ostream &OS, bool isForDebug = false) const override {
     OS << "AllTop";
   }
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
@@ -40,16 +40,16 @@ public:
 
   EdgeIdentity &operator=(const EdgeIdentity &ei) = delete;
 
-  virtual ~EdgeIdentity() = default;
+  ~EdgeIdentity() override = default;
 
-  virtual V computeTarget(V source) override { return source; }
+  V computeTarget(V source) override { return source; }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   composeWith(std::shared_ptr<EdgeFunction<V>> secondFunction) override {
     return secondFunction;
   }
 
-  virtual std::shared_ptr<EdgeFunction<V>>
+  std::shared_ptr<EdgeFunction<V>>
   joinWith(std::shared_ptr<EdgeFunction<V>> otherFunction) override {
     if ((otherFunction.get() == this) ||
         otherFunction->equal_to(this->shared_from_this()))
@@ -62,7 +62,7 @@ public:
     return otherFunction->joinWith(this->shared_from_this());
   }
 
-  virtual bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
+  bool equal_to(std::shared_ptr<EdgeFunction<V>> other) const override {
     return this == other.get();
   }
 
@@ -72,7 +72,7 @@ public:
     return instance;
   }
 
-  virtual void print(std::ostream &OS, bool isForDebug = false) const override {
+  void print(std::ostream &OS, bool isForDebug = false) const override {
     OS << "EdgeIdentity";
   }
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/IDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/IDETabulationProblem.h
@@ -32,7 +32,7 @@ class IDETabulationProblem : public virtual IFDSTabulationProblem<N, D, M, I>,
                              public virtual JoinLattice<V>,
                              public virtual ValuePrinter<V> {
 public:
-  virtual ~IDETabulationProblem() = default;
+  ~IDETabulationProblem() override = default;
   virtual std::shared_ptr<EdgeFunction<V>> allTopFunction() = 0;
   virtual void printIDEReport(std::ostream &os, SolverResults<N, D, V> &SR) {
     os << "No IDE report available!\n";

--- a/include/phasar/PhasarLLVM/IfdsIde/IFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/IFDSTabulationProblem.h
@@ -35,7 +35,7 @@ class IFDSTabulationProblem : public virtual FlowFunctions<N, D, M>,
                               public virtual MethodPrinter<M> {
 public:
   SolverConfiguration solver_config;
-  virtual ~IFDSTabulationProblem() = default;
+  ~IFDSTabulationProblem() override = default;
   virtual I interproceduralCFG() = 0;
   virtual std::map<N, std::set<D>> initialSeeds() = 0;
   virtual D zeroValue() = 0;

--- a/include/phasar/PhasarLLVM/IfdsIde/LLVMDefaultIDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/LLVMDefaultIDETabulationProblem.h
@@ -38,7 +38,7 @@ public:
                                     const llvm::Function *, V, I>(icfg),
         th(th), irdb(irdb) {}
 
-  virtual ~LLVMDefaultIDETabulationProblem() = default;
+  ~LLVMDefaultIDETabulationProblem() override = default;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/LLVMDefaultIFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/LLVMDefaultIFDSTabulationProblem.h
@@ -41,7 +41,7 @@ public:
                                      const llvm::Function *, I>(icfg),
         th(th), irdb(irdb) {}
 
-  virtual ~LLVMDefaultIFDSTabulationProblem() = default;
+  ~LLVMDefaultIFDSTabulationProblem() override = default;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/LLVMZeroValue.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/LLVMZeroValue.h
@@ -27,7 +27,7 @@
 
 namespace llvm {
 class Value;
-}
+} // namespace llvm
 
 namespace psr {
 

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDESolverTest.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDESolverTest.h
@@ -43,7 +43,7 @@ public:
   IDESolverTest(i_t icfg, const LLVMTypeHierarchy &th, const ProjectIRDB &irdb,
                 std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IDESolverTest() = default;
+  ~IDESolverTest() override = default;
 
   // start formulating our analysis by specifying the parts required for IFDS
 

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.h
@@ -93,7 +93,7 @@ public:
                        const ProjectIRDB &irdb, const TypeStateDescription &tsd,
                        std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IDETypeStateAnalysis() = default;
+  ~IDETypeStateAnalysis() override = default;
 
   // start formulating our analysis by specifying the parts required for IFDS
 

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.h
@@ -60,7 +60,7 @@ public:
                     const ProjectIRDB &irdb, std::set<d_t> AllMemLocs,
                     std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSConstAnalysis() = default;
+  ~IFDSConstAnalysis() override = default;
 
   /**
    * If the current instruction is a store instruction, the memory locations's

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
@@ -65,7 +65,7 @@ public:
                              const ProjectIRDB &irdb,
                              std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSLinearConstantAnalysis() = default;
+  ~IFDSLinearConstantAnalysis() override = default;
 
   std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
                                                            n_t succ) override;

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.h
@@ -43,7 +43,7 @@ public:
   IFDSSolverTest(i_t icfg, const LLVMTypeHierarchy &th, const ProjectIRDB &irdb,
                  std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSSolverTest() = default;
+  ~IFDSSolverTest() override = default;
 
   std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
                                                            n_t succ) override;

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.h
@@ -66,7 +66,7 @@ public:
                     const ProjectIRDB &irdb, TaintSensitiveFunctions TSF,
                     std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSTaintAnalysis() = default;
+  ~IFDSTaintAnalysis() override = default;
 
   std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
                                                            n_t succ) override;

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.h
@@ -42,7 +42,7 @@ public:
                    const ProjectIRDB &irdb,
                    std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSTypeAnalysis() = default;
+  ~IFDSTypeAnalysis() override = default;
 
   std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
                                                            n_t succ) override;

--- a/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.h
@@ -44,7 +44,7 @@ public:
                            const ProjectIRDB &irdb,
                            std::vector<std::string> EntryPoints = {"main"});
 
-  virtual ~IFDSUnitializedVariables() = default;
+  ~IFDSUnitializedVariables() override = default;
 
   std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
                                                            n_t succ) override;

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
@@ -94,7 +94,7 @@ public:
     // std::cout << "called IDESolver::IDESolver() ctor with IDEProblem"
     //           << std::endl;
   }
-
+  IDESolver &operator=(IDESolver &&) = delete;
   virtual ~IDESolver() = default;
 
   json getAsJson() {

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IFDSSolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IFDSSolver.h
@@ -36,7 +36,7 @@ public:
     //  << std::endl;
   }
 
-  virtual ~IFDSSolver() = default;
+  ~IFDSSolver() override = default;
 
   std::set<D> ifdsResultsAt(N stmt) {
     std::set<D> keyset;

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
@@ -51,7 +51,7 @@ public:
         Problem(problem), DUMP_RESULTS(dumpResults), PRINT_REPORT(printReport) {
   }
 
-  virtual ~LLVMIDESolver() = default;
+  ~LLVMIDESolver() override = default;
 
   void solve() override {
     IDESolver<const llvm::Instruction *, D, const llvm::Function *, V,

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
@@ -45,7 +45,7 @@ private:
   const bool PRINT_REPORT;
 
 public:
-  virtual ~LLVMIFDSSolver() = default;
+  ~LLVMIFDSSolver() override = default;
 
   LLVMIFDSSolver(IFDSTabulationProblem<const llvm::Instruction *, D,
                                        const llvm::Function *, I> &problem,
@@ -55,7 +55,7 @@ public:
         Problem(problem), DUMP_RESULTS(dumpResults), PRINT_REPORT(printReport) {
   }
 
-  virtual void solve() override {
+  void solve() override {
     // Solve the analaysis problem
     IFDSSolver<const llvm::Instruction *, D, const llvm::Function *,
                I>::solve();

--- a/include/phasar/PhasarLLVM/Mono/IntraMonoProblem.h
+++ b/include/phasar/PhasarLLVM/Mono/IntraMonoProblem.h
@@ -35,7 +35,7 @@ protected:
 
 public:
   IntraMonoProblem(C Cfg, M F) : CFG(Cfg), Function(F) {}
-  virtual ~IntraMonoProblem() = default;
+  ~IntraMonoProblem() override = default;
   C getCFG() { return CFG; }
   M getFunction() { return Function; }
   virtual MonoSet<D> join(const MonoSet<D> &Lhs, const MonoSet<D> &Rhs) = 0;

--- a/include/phasar/PhasarLLVM/Mono/Problems/InterMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/InterMonoSolverTest.h
@@ -41,7 +41,7 @@ protected:
 public:
   InterMonoSolverTest(LLVMBasedICFG &Icfg,
                       std::vector<std::string> EntryPoints = {"main"});
-  virtual ~InterMonoSolverTest() = default;
+  ~InterMonoSolverTest() override = default;
 
   MonoSet<const llvm::Value *>
   join(const MonoSet<const llvm::Value *> &Lhs,

--- a/include/phasar/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/InterMonoTaintAnalysis.h
@@ -43,7 +43,7 @@ private:
 public:
   InterMonoTaintAnalysis(LLVMBasedICFG &Icfg,
                          std::vector<std::string> EntryPoints = {"main"});
-  virtual ~InterMonoTaintAnalysis() = default;
+  ~InterMonoTaintAnalysis() override = default;
 
   MonoSet<const llvm::Value *>
   join(const MonoSet<const llvm::Value *> &Lhs,

--- a/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoFullConstantPropagation.h
@@ -38,7 +38,7 @@ class IntraMonoFullConstantPropagation
                               const llvm::Function *, LLVMBasedCFG &> {
 public:
   IntraMonoFullConstantPropagation(LLVMBasedCFG &Cfg, const llvm::Function *F);
-  virtual ~IntraMonoFullConstantPropagation() = default;
+  ~IntraMonoFullConstantPropagation() override = default;
 
   MonoSet<std::pair<const llvm::Value *, unsigned>>
   join(const MonoSet<std::pair<const llvm::Value *, unsigned>> &Lhs,

--- a/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/Mono/Problems/IntraMonoSolverTest.h
@@ -36,7 +36,7 @@ class IntraMonoSolverTest
                               const llvm::Function *, LLVMBasedCFG &> {
 public:
   IntraMonoSolverTest(LLVMBasedCFG &Cfg, const llvm::Function *F);
-  virtual ~IntraMonoSolverTest() = default;
+  ~IntraMonoSolverTest() override = default;
 
   MonoSet<const llvm::Value *>
   join(const MonoSet<const llvm::Value *> &Lhs,

--- a/include/phasar/PhasarLLVM/Mono/Solver/InterMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/InterMonoSolver.h
@@ -134,6 +134,10 @@ protected:
 public:
   InterMonoSolver(InterMonoProblem<N, D, M, I> &IMP)
       : IMProblem(IMP), ICFG(IMP.getICFG()) {}
+  InterMonoSolver(const InterMonoSolver &) = delete;
+  InterMonoSolver &operator=(const InterMonoSolver &) = delete;
+  InterMonoSolver(InterMonoSolver &&) = delete;
+  InterMonoSolver &operator=(InterMonoSolver &&) = delete;
   virtual ~InterMonoSolver() = default;
 
   MonoMap<N, MonoMap<CallStringCTX<D, N, K>, MonoSet<D>>> getAnalysis() {

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
@@ -18,6 +18,7 @@
 #define PHASAR_PHASARLLVM_MONO_SOLVER_LLVMINTRAMONOSOLVER_H_
 
 #include <iosfwd>
+#include <iostream>
 
 #include <llvm/IR/Instruction.h>
 
@@ -34,7 +35,7 @@ protected:
 
 public:
   LLVMIntraMonoSolver();
-  virtual ~LLVMIntraMonoSolver() = default;
+  ~LLVMIntraMonoSolver() override = default;
 
   LLVMIntraMonoSolver(IntraMonoProblem<const llvm::Instruction *, D,
                                        const llvm::Function *, C> &problem,
@@ -43,7 +44,7 @@ public:
                         C>(problem),
         DUMP_RESULTS(dumpResults) {}
 
-  virtual void solve() override {
+  void solve() override {
     // do the solving of the analaysis problem
     IntraMonoSolver<const llvm::Instruction *, D, const llvm::Function *,
                     C>::solve();

--- a/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
+++ b/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
@@ -53,7 +53,7 @@ public:
         EntryPoints(EntryPoints) {
     DefaultIFDSTabulationProblem::zerovalue = createZeroValue();
   }
-  ~IFDSTabulationProblemPlugin() = default;
+  ~IFDSTabulationProblemPlugin() override = default;
 
   const llvm::Value *createZeroValue() override {
     // create a special value to represent the zero value!

--- a/include/phasar/PhasarLLVM/Utils/Printer.h
+++ b/include/phasar/PhasarLLVM/Utils/Printer.h
@@ -24,6 +24,11 @@
 namespace psr {
 
 template <typename N> struct NodePrinter {
+  NodePrinter() = default;
+  NodePrinter(const NodePrinter &) = delete;
+  NodePrinter &operator=(const NodePrinter &) = delete;
+  NodePrinter(NodePrinter &&) = delete;
+  NodePrinter &operator=(NodePrinter &&) = delete;
   virtual ~NodePrinter() = default;
 
   virtual void printNode(std::ostream &os, N n) const = 0;
@@ -36,6 +41,11 @@ template <typename N> struct NodePrinter {
 };
 
 template <typename D> struct DataFlowFactPrinter {
+  DataFlowFactPrinter() = default;
+  DataFlowFactPrinter(const DataFlowFactPrinter &) = delete;
+  DataFlowFactPrinter &operator=(const DataFlowFactPrinter &) = delete;
+  DataFlowFactPrinter(DataFlowFactPrinter &&) = delete;
+  DataFlowFactPrinter &operator=(DataFlowFactPrinter &&) = delete;
   virtual ~DataFlowFactPrinter() = default;
 
   virtual void printDataFlowFact(std::ostream &os, D d) const = 0;
@@ -48,6 +58,11 @@ template <typename D> struct DataFlowFactPrinter {
 };
 
 template <typename V> struct ValuePrinter {
+  ValuePrinter() = default;
+  ValuePrinter(const ValuePrinter &) = delete;
+  ValuePrinter &operator=(const ValuePrinter &) = delete;
+  ValuePrinter(ValuePrinter &&) = delete;
+  ValuePrinter &operator=(ValuePrinter &&) = delete;
   virtual ~ValuePrinter() = default;
 
   virtual void printValue(std::ostream &os, V v) const = 0;
@@ -60,6 +75,11 @@ template <typename V> struct ValuePrinter {
 };
 
 template <typename M> struct MethodPrinter {
+  MethodPrinter() = default;
+  MethodPrinter(const MethodPrinter &) = delete;
+  MethodPrinter &operator=(const MethodPrinter &) = delete;
+  MethodPrinter(MethodPrinter &&) = delete;
+  MethodPrinter &operator=(MethodPrinter &&) = delete;
   virtual ~MethodPrinter() = default;
 
   virtual void printMethod(std::ostream &os, M m) const = 0;

--- a/include/phasar/Utils/Macros.h
+++ b/include/phasar/Utils/Macros.h
@@ -18,7 +18,7 @@
 
 namespace llvm {
 class Type;
-}
+} // namespace llvm
 
 namespace psr {
 


### PR DESCRIPTION
Deletes Copy/Move ctor and assign to disallow copying of Printer base classes, this prevents unintentional object slicing.
Plus minor clean up; adding missing override keywords and removing redundant virtuals.