### PR TITLE
Emit Exploded Super Graph as .dot graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ include("phasar_macros")
 
 option(PHASAR_BUILD_UNITTESTS "Build all tests (default is OFF)" OFF)
 
+option(PHASAR_BUILD_IR "Build IR test code (default is OFF)" OFF)
+
 option(PHASAR_BUILD_DOC "Build documentation" OFF)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (default is ON)" ON)
@@ -378,11 +380,16 @@ target_link_libraries(boomerangtest
   ${llvm_libs}
 )
 
-# Add Phasar unittests and .ll file generation
+# Add Phasar unittests and build all IR test code
 if (PHASAR_BUILD_UNITTESTS)
   message("Phasar unittests")
   add_subdirectory(unittests)
-  message("Generation of .ll files")
+  set(PHASAR_BUILD_IR ON)
+endif()
+
+# Build all IR test code
+if (PHASAR_BUILD_IR)
+  message("Building IR test code")
   add_subdirectory(test)
 endif()
 

--- a/config/DOTGraphConfig.json
+++ b/config/DOTGraphConfig.json
@@ -1,0 +1,49 @@
+{
+	"CFNode": {
+		"style": "filled",
+		"shape": "record"
+	},
+	"CFIntraEdge": {
+	},
+	"CFInterEdge": {
+		"weight": "1"
+	},
+	"FactNode": {
+		"style": "rounded"
+	},
+	"FactIDEdge": {
+		"style": "dotted",
+		"arrowhead": "normal",
+		"fontsize": "11",
+		"arrowsize": "0.7"
+	},
+	"FactCrossEdge": {
+    "style": "dotted",
+		"arrowhead": "normal",
+		"fontsize": "11",
+		"arrowsize": "0.7"
+	},
+	"FactInterEdge": {
+    "weight": "0.1",
+		"style": "dashed",
+		"arrowhead": "normal",
+		"fontsize": "11",
+		"arrowsize": "0.7"
+	},
+	"LambdaNode": {
+		"style": "rounded"
+	},
+	"LambdaIDEdge": {
+		"style": "dotted",
+		"arrowhead": "normal",
+		"fontsize": "11",
+		"arrowsize": "0.7"
+	},
+	"LambdaInterEdge": {
+    "weight": "0.1",
+		"style": "dashed",
+		"arrowhead": "normal",
+		"fontsize": "11",
+		"arrowsize": "0.7"
+	}
+}

--- a/include/phasar/DB/ProjectIRDB.h
+++ b/include/phasar/DB/ProjectIRDB.h
@@ -144,7 +144,7 @@ public:
   PointsToGraph *getPointsToGraph(const std::string &FunctionName) const;
   void insertPointsToGraph(const std::string &FunctionName, PointsToGraph *ptg);
   void print();
-  void printPreprocessedIR(std::ostream &os, bool shortendIR);
+  void emitPreprocessedIR(std::ostream &os, bool shortendIR);
   void exportPATBCJSON();
   /**
    * Allows the (de-)serialization of Instructions, Arguments, GlobalValues and

--- a/include/phasar/DB/ProjectIRDB.h
+++ b/include/phasar/DB/ProjectIRDB.h
@@ -144,6 +144,7 @@ public:
   PointsToGraph *getPointsToGraph(const std::string &FunctionName) const;
   void insertPointsToGraph(const std::string &FunctionName, PointsToGraph *ptg);
   void print();
+  void printPreprocessedIR(std::ostream &os, bool shortendIR);
   void exportPATBCJSON();
   /**
    * Allows the (de-)serialization of Instructions, Arguments, GlobalValues and

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctionComposer.h
@@ -86,7 +86,7 @@ public:
   }
 
   void print(std::ostream &OS, bool isForDebug = false) const override {
-    OS << "EFComposer_" << EFComposer_Id << "[ " << F.get()->str() << " , "
+    OS << "Comp_" << EFComposer_Id << "[ " << F.get()->str() << " , "
        << G.get()->str() << " ]";
   }
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/EdgeFunctions/EdgeIdentity.h
@@ -73,7 +73,7 @@ public:
   }
 
   void print(std::ostream &OS, bool isForDebug = false) const override {
-    OS << "EdgeIdentity";
+    OS << "EdgeId";
   }
 };
 

--- a/include/phasar/PhasarLLVM/IfdsIde/FlowEdgeFunctionCache.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/FlowEdgeFunctionCache.h
@@ -104,8 +104,18 @@ public:
 
   std::shared_ptr<FlowFunction<D>> getNormalFlowFunction(N curr, N succ) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Normal flow function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Curr Inst : " << problem.NtoString(curr));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Succ Inst : " << problem.NtoString(succ));
     auto key = std::tie(curr, succ);
     if (NormalFlowFunctionCache.count(key)) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Flow function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       INC_COUNTER("Normal-FF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
       return NormalFlowFunctionCache.at(key);
     } else {
@@ -115,14 +125,26 @@ public:
                           problem.getNormalFlowFunction(curr, succ), zeroValue)
                     : problem.getNormalFlowFunction(curr, succ);
       NormalFlowFunctionCache.insert(make_pair(key, ff));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Flow function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ff;
     }
   }
 
   std::shared_ptr<FlowFunction<D>> getCallFlowFunction(N callStmt, M destMthd) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Call flow function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Stmt : " << problem.NtoString(callStmt));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(M) Dest Mthd : " << problem.MtoString(destMthd));
     auto key = std::tie(callStmt, destMthd);
     if (CallFlowFunctionCache.count(key)) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Flow function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       INC_COUNTER("Call-FF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
       return CallFlowFunctionCache.at(key);
     } else {
@@ -133,6 +155,8 @@ public:
                     problem.getCallFlowFunction(callStmt, destMthd), zeroValue)
               : problem.getCallFlowFunction(callStmt, destMthd);
       CallFlowFunctionCache.insert(std::make_pair(key, ff));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Flow function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ff;
     }
   }
@@ -140,8 +164,22 @@ public:
   std::shared_ptr<FlowFunction<D>> getRetFlowFunction(N callSite, M calleeMthd,
                                                       N exitStmt, N retSite) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Return flow function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Site : " << problem.NtoString(callSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(M) Callee    : " << problem.MtoString(calleeMthd));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Exit Stmt : " << problem.NtoString(exitStmt));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Ret Site  : " << problem.NtoString(retSite));
     auto key = std::tie(callSite, calleeMthd, exitStmt, retSite);
     if (ReturnFlowFunctionCache.count(key)) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Flow function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       INC_COUNTER("Return-FF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
       return ReturnFlowFunctionCache.at(key);
     } else {
@@ -154,6 +192,8 @@ public:
                     : problem.getRetFlowFunction(callSite, calleeMthd, exitStmt,
                                                  retSite);
       ReturnFlowFunctionCache.insert(std::make_pair(key, ff));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Flow function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ff;
     }
   }
@@ -161,8 +201,23 @@ public:
   std::shared_ptr<FlowFunction<D>>
   getCallToRetFlowFunction(N callSite, N retSite, std::set<M> callees) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Call-to-Return flow function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Site : " << problem.NtoString(callSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Ret Site  : " << problem.NtoString(retSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "(M) Callee's  : ");
+    for (auto callee : callees) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "  " << problem.MtoString(callee));
+    }
     auto key = std::tie(callSite, retSite, callees);
     if (CallToRetFlowFunctionCache.count(key)) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Flow function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       INC_COUNTER("CallToRet-FF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
       return CallToRetFlowFunctionCache.at(key);
     } else {
@@ -175,6 +230,8 @@ public:
                     zeroValue)
               : problem.getCallToRetFlowFunction(callSite, retSite, callees);
       CallToRetFlowFunctionCache.insert(std::make_pair(key, ff));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Flow function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ff;
     }
   }
@@ -183,6 +240,14 @@ public:
                                                           M destMthd) {
     // PAMM_GET_INSTANCE;
     // INC_COUNTER("Summary-FF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Summary flow function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Stmt : " << problem.NtoString(callStmt));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(M) Dest Mthd : " << problem.MtoString(destMthd));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
     auto ff = problem.getSummaryFlowFunction(callStmt, destMthd);
     return ff;
   }
@@ -190,14 +255,30 @@ public:
   std::shared_ptr<EdgeFunction<V>> getNormalEdgeFunction(N curr, D currNode,
                                                          N succ, D succNode) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Normal edge function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Curr Inst : " << problem.NtoString(curr));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Curr Node : " << problem.DtoString(currNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Succ Inst : " << problem.NtoString(succ));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Succ Node : " << problem.DtoString(succNode));
     auto key = std::tie(curr, currNode, succ, succNode);
     if (NormalEdgeFunctionCache.count(key)) {
       INC_COUNTER("Normal-EF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Edge function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return NormalEdgeFunctionCache.at(key);
     } else {
       INC_COUNTER("Normal-EF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
       auto ef = problem.getNormalEdgeFunction(curr, currNode, succ, succNode);
       NormalEdgeFunctionCache.insert(std::make_pair(key, ef));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Edge function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ef;
     }
   }
@@ -205,15 +286,32 @@ public:
   std::shared_ptr<EdgeFunction<V>>
   getCallEdgeFunction(N callStmt, D srcNode, M destinationMethod, D destNode) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Call edge function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Stmt : " << problem.NtoString(callStmt));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Src Node  : " << problem.DtoString(srcNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(M) Dest Mthd : "
+                  << problem.MtoString(destinationMethod));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Dest Node : " << problem.DtoString(destNode));
     auto key = std::tie(callStmt, srcNode, destinationMethod, destNode);
     if (CallEdgeFunctionCache.count(key)) {
       INC_COUNTER("Call-EF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Edge function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return CallEdgeFunctionCache.at(key);
     } else {
       INC_COUNTER("Call-EF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
       auto ef = problem.getCallEdgeFunction(callStmt, srcNode,
                                             destinationMethod, destNode);
       CallEdgeFunctionCache.insert(std::make_pair(key, ef));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Edge function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ef;
     }
   }
@@ -223,16 +321,36 @@ public:
                                                          N exitStmt, D exitNode,
                                                          N reSite, D retNode) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Return edge function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Site : " << problem.NtoString(callSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(M) Callee    : " << problem.MtoString(calleeMethod));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Exit Stmt : " << problem.NtoString(exitStmt));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Exit Node : " << problem.DtoString(exitNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Ret Site  : " << problem.NtoString(reSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Ret Node  : " << problem.DtoString(retNode));
     auto key =
         std::tie(callSite, calleeMethod, exitStmt, exitNode, reSite, retNode);
     if (ReturnEdgeFunctionCache.count(key)) {
       INC_COUNTER("Return-EF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Edge function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ReturnEdgeFunctionCache.at(key);
     } else {
       INC_COUNTER("Return-EF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
       auto ef = problem.getReturnEdgeFunction(callSite, calleeMethod, exitStmt,
                                               exitNode, reSite, retNode);
       ReturnEdgeFunctionCache.insert(std::make_pair(key, ef));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Edge function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ef;
     }
   }
@@ -241,15 +359,36 @@ public:
   getCallToRetEdgeFunction(N callSite, D callNode, N retSite, D retSiteNode,
                            std::set<M> callees) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Call-to-Return edge function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Site : " << problem.NtoString(callSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Call Node : " << problem.DtoString(callNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Ret Site  : " << problem.NtoString(retSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Ret Node  : " << problem.DtoString(retSiteNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "(M) Callee's  : ");
+    for (auto callee : callees) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "  " << problem.MtoString(callee));
+    }
     auto key = std::tie(callSite, callNode, retSite, retSiteNode);
     if (CallToRetEdgeFunctionCache.count(key)) {
       INC_COUNTER("CallToRet-EF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Edge function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return CallToRetEdgeFunctionCache.at(key);
     } else {
       INC_COUNTER("CallToRet-EF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
       auto ef = problem.getCallToRetEdgeFunction(callSite, callNode, retSite,
                                                  retSiteNode, callees);
       CallToRetEdgeFunctionCache.insert(std::make_pair(key, ef));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Edge function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ef;
     }
   }
@@ -257,15 +396,32 @@ public:
   std::shared_ptr<EdgeFunction<V>>
   getSummaryEdgeFunction(N callSite, D callNode, N retSite, D retSiteNode) {
     PAMM_GET_INSTANCE;
+    auto &lg = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "Summary edge function factory call");
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Call Site : " << problem.NtoString(callSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Call Node : " << problem.DtoString(callNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(N) Ret Site  : " << problem.NtoString(retSite));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                  << "(D) Ret Node  : " << problem.DtoString(retSiteNode));
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
     auto key = std::tie(callSite, callNode, retSite, retSiteNode);
     if (SummaryEdgeFunctionCache.count(key)) {
       INC_COUNTER("Summary-EF Cache Hit", 1, PAMM_SEVERITY_LEVEL::Full);
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                    << "Edge function fetched from cache");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return SummaryEdgeFunctionCache.at(key);
     } else {
       INC_COUNTER("Summary-EF Construction", 1, PAMM_SEVERITY_LEVEL::Full);
       auto ef = problem.getSummaryEdgeFunction(callSite, callNode, retSite,
                                                retSiteNode);
       SummaryEdgeFunctionCache.insert(std::make_pair(key, ef));
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Edge function constructed");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
       return ef;
     }
   }
@@ -319,7 +475,7 @@ public:
                             "Return-FF Construction",
                             "CallToRet-FF Construction" /*,
                 "Summary-FF Construction"*/}));
-      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << " ");
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << ' ');
       LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
                     << "Normal edge function cache hits: "
                     << GET_COUNTER("Normal-EF Cache Hit"));

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
@@ -400,7 +400,7 @@ protected:
   bool followReturnPastSeeds;
   bool computePersistedSummaries;
   bool recordEdges;
-  bool emitESG = VariablesMap.count("emit-esg-as-dot");
+  bool emitESG = PhasarConfig::VariablesMap().count("emit-esg-as-dot");
   unsigned PathEdgeCount;
 
   FlowEdgeFunctionCache<N, D, M, V, I> cachedFlowEdgeFunctions;

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
@@ -1362,8 +1362,9 @@ protected:
 
     // Sort intra-procedural path edges
     auto cells = computedIntraPathEdges.cellVec();
+    StmtLess stmtless(icfg);
     sort(cells.begin(), cells.end(),
-         [](auto a, auto b) { return lessThanOnValueID(a.r, b.r); });
+         [&stmtless](auto a, auto b) { return stmtless(a.r, b.r); });
     for (auto cell : cells) {
       auto Edge = std::make_pair(cell.r, cell.c);
       std::string n2_label = ideTabulationProblem.NtoString(Edge.second);
@@ -1390,7 +1391,7 @@ protected:
     // Sort intra-procedural path edges
     cells = computedInterPathEdges.cellVec();
     sort(cells.begin(), cells.end(),
-         [](auto a, auto b) { return lessThanOnValueID(a.r, b.r); });
+         [&stmtless](auto a, auto b) { return stmtless(a.r, b.r); });
     for (auto cell : cells) {
       auto Edge = std::make_pair(cell.r, cell.c);
       std::string n2_label = ideTabulationProblem.NtoString(Edge.second);
@@ -1641,8 +1642,9 @@ protected:
 
     // Sort intra-procedural path edges
     auto cells = computedIntraPathEdges.cellVec();
+    StmtLess stmtless(icfg);
     sort(cells.begin(), cells.end(),
-         [](auto a, auto b) { return lessThanOnValueID(a.r, b.r); });
+         [&stmtless](auto a, auto b) { return stmtless(a.r, b.r); });
     for (auto cell : cells) {
       auto Edge = std::make_pair(cell.r, cell.c);
       std::string n1_label = ideTabulationProblem.NtoString(Edge.first);
@@ -1728,7 +1730,7 @@ protected:
                   << "Process inter-procedural path egdes");
     cells = computedInterPathEdges.cellVec();
     sort(cells.begin(), cells.end(),
-         [](auto a, auto b) { return lessThanOnValueID(a.r, b.r); });
+         [&stmtless](auto a, auto b) { return stmtless(a.r, b.r); });
     for (auto cell : cells) {
       auto Edge = std::make_pair(cell.r, cell.c);
       std::string n1_label = ideTabulationProblem.NtoString(Edge.first);
@@ -1796,6 +1798,16 @@ protected:
     dotFile << G;
     dotFile.close();
   }
+
+  /// @brief: Allows less-than comparison based on the statement ID.
+  struct StmtLess {
+    I &icfg;
+    stringIDLess strIDLess;
+    StmtLess(I &icfg) : icfg(icfg), strIDLess(stringIDLess()) {}
+    bool operator()(N lhs, N rhs) {
+      return strIDLess(icfg.getStatementId(lhs), icfg.getStatementId(rhs));
+    }
+  };
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/IDESolver.h
@@ -1667,6 +1667,7 @@ protected:
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
                   << "=============================================");
     DOTGraph<D> G;
+    DOTConfig::importDOTConfig();
     DOTFunctionSubGraph *FG = nullptr;
 
     // Sort intra-procedural path edges

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/JumpFunctions.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/JumpFunctions.h
@@ -18,6 +18,7 @@
 #define PHASAR_PHASARLLVM_IFDSIDE_SOLVER_JUMPFUNCTIONS_H_
 
 #include <memory>
+#include <ostream>
 #include <unordered_map>
 
 #include <phasar/PhasarLLVM/IfdsIde/EdgeFunction.h>
@@ -157,73 +158,65 @@ public:
     nonEmptyLookupByTargetNode.clear();
   }
 
-  void printJumpFunctions() {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Jump Functions:");
+  void printJumpFunctions(std::ostream &os) {
+    os << "\n******************************************************";
+    os << "\n*              Print all Jump Functions              *";
+    os << "\n******************************************************\n";
     for (auto &entry : nonEmptyLookupByTargetNode) {
-      LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                    << "Node: " << problem.NtoString(entry.first));
+      std::string nLabel = problem.NtoString(entry.first);
+      os << "\nN: " << nLabel << "\n---" << std::string(nLabel.size(), '-')
+         << '\n';
       for (auto cell : entry.second.cellSet()) {
-        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                      << "fact at src: " << problem.DtoString(cell.r));
-        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                      << "fact at dst: " << problem.DtoString(cell.c));
-        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                      << "edge fnct: " << cell.v->str());
+        os << "D1: " << problem.DtoString(cell.r) << '\n'
+           << "\tD2: " << problem.DtoString(cell.c) << '\n'
+           << "\tEF: " << cell.v->str() << "\n\n";
       }
     }
   }
 
-  void printNonEmptyReverseLookup() {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "DUMP nonEmptyReverseLookup");
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                  << "Table<N, D, std::unordered_map<D, "
-                     "std::shared_ptr<EdgeFunction<L>>>>");
-    auto cellset = nonEmptyReverseLookup.cellSet();
-    for (auto cell : cellset) {
-      cell.r->dump();
-      cell.c->dump();
-      for (auto edgefunction : cell.v) {
-        edgefunction.first->dump();
-        edgefunction.second->dump();
+  void printNonEmptyReverseLookup(std::ostream &os) {
+    os << "DUMP nonEmptyReverseLookup\nTable<N, D, std::unordered_map<D, "
+          "std::shared_ptr<EdgeFunction<L>>>>\n";
+    auto cellvec = nonEmptyReverseLookup.cellVec();
+    for (auto cell : cellvec) {
+      os << "N : " << problem.NtoString(cell.r)
+         << "\nD1: " << problem.DtoString(cell.c) << '\n';
+      for (auto D2ToEF : cell.v) {
+        os << "D2: " << problem.DtoString(D2ToEF.first)
+           << "\nEF: " << D2ToEF.second->str() << '\n';
       }
+      os << '\n';
     }
   }
 
-  void printNonEmptyForwardLookup() {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "DUMP nonEmptyForwardLookup");
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                  << "Table<D, N, std::unordered_map<D, "
-                     "std::shared_ptr<EdgeFunction<L>>>>");
-    auto cellset = nonEmptyForwardLookup.cellSet();
-    for (auto cell : cellset) {
-      cell.r->dump();
-      cell.c->dump();
-      for (auto edgefunction : cell.v) {
-        edgefunction.first->dump();
-        edgefunction.second->dump();
+  void printNonEmptyForwardLookup(std::ostream &os) {
+    os << "DUMP nonEmptyForwardLookup\nTable<D, N, std::unordered_map<D, "
+          "std::shared_ptr<EdgeFunction<L>>>>\n";
+    auto cellvec = nonEmptyForwardLookup.cellVec();
+    for (auto cell : cellvec) {
+      os << "D1: " << problem.DtoString(cell.r)
+         << "\nN : " << problem.NtoString(cell.c) << '\n';
+      for (auto D2ToEF : cell.v) {
+        os << "D2: " << problem.DtoString(D2ToEF.first)
+           << "\nEF: " << D2ToEF.second->str() << '\n';
       }
+      os << '\n';
     }
   }
 
-  void printNonEmptyLookupByTargetNode() {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                  << "DUMP nonEmptyLookupByTargetNode");
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                  << "std::unordered_map<N, Table<D, D, "
-                     "std::shared_ptr<EdgeFunction<L>>>>");
+  void printNonEmptyLookupByTargetNode(std::ostream &os) {
+    os << "DUMP nonEmptyLookupByTargetNode\nstd::unordered_map<N, Table<D, D, "
+          "std::shared_ptr<EdgeFunction<L>>>>\n";
     for (auto node : nonEmptyLookupByTargetNode) {
-      node.first->dump();
+      os << "\nN : " << problem.NtoString(node.first) << '\n';
       auto table = nonEmptyLookupByTargetNode[node.first];
-      auto cellset = table.cellSet();
-      for (auto cell : cellset) {
-        cell.r->dump();
-        cell.c->dump();
-        cell.v->dump();
+      auto cellvec = table.cellVec();
+      for (auto cell : cellvec) {
+        os << "D1: " << problem.DtoString(cell.r)
+           << "\nD2: " << problem.DtoString(cell.c) << "\nEF: " << cell.v->str()
+           << '\n';
       }
+      os << '\n';
     }
   }
 };

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
@@ -55,7 +55,7 @@ public:
     IDESolver<const llvm::Instruction *, D, const llvm::Function *, V,
               I>::solve();
     bl::core::get()->flush();
-    if (VariablesMap.count("emit-raw-results")) {
+    if (PhasarConfig::VariablesMap().count("emit-raw-results")) {
       dumpResults();
     }
     if (PRINT_REPORT) {

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
@@ -18,7 +18,7 @@
 #define PHASAR_PHASARLLVM_IFDSIDE_SOLVER_LLVMIDESOLVER_H_
 
 #include <algorithm>
-// #include <iostream>
+#include <iostream>
 #include <vector>
 
 #include <llvm/IR/Function.h>
@@ -39,17 +39,15 @@ class LLVMIDESolver : public IDESolver<const llvm::Instruction *, D,
 private:
   IDETabulationProblem<const llvm::Instruction *, D, const llvm::Function *, V,
                        I> &Problem;
-  const bool DUMP_RESULTS;
   const bool PRINT_REPORT;
 
 public:
   LLVMIDESolver(IDETabulationProblem<const llvm::Instruction *, D,
                                      const llvm::Function *, V, I> &problem,
-                bool dumpResults = false, bool printReport = true)
+                bool printReport = true)
       : IDESolver<const llvm::Instruction *, D, const llvm::Function *, V, I>(
             problem),
-        Problem(problem), DUMP_RESULTS(dumpResults), PRINT_REPORT(printReport) {
-  }
+        Problem(problem), PRINT_REPORT(printReport) {}
 
   ~LLVMIDESolver() override = default;
 
@@ -57,7 +55,7 @@ public:
     IDESolver<const llvm::Instruction *, D, const llvm::Function *, V,
               I>::solve();
     bl::core::get()->flush();
-    if (DUMP_RESULTS) {
+    if (VariablesMap.count("emit-raw-results")) {
       dumpResults();
     }
     if (PRINT_REPORT) {
@@ -74,13 +72,13 @@ public:
   void dumpResults() {
     PAMM_GET_INSTANCE;
     START_TIMER("DFA IDE Result Dumping", PAMM_SEVERITY_LEVEL::Full);
-    std::cout << "### DUMP LLVMIDESolver results\n";
-    // for the following line have a look at:
-    // http://stackoverflow.com/questions/1120833/derived-template-class-access-to-base-class-member-data
-    // https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members
+    std::cout
+        << "\n***************************************************************\n"
+        << "*                  Raw LLVMIDESolver results                  *\n"
+        << "***************************************************************\n";
     auto cells = this->valtab.cellVec();
     if (cells.empty()) {
-      std::cout << "EMPTY" << std::endl;
+      std::cout << "No results computed!" << std::endl;
     } else {
       std::sort(cells.begin(), cells.end(),
                 [](typename Table<const llvm::Instruction *, D, V>::Cell a,
@@ -99,16 +97,21 @@ public:
                 });
       const llvm::Instruction *prev = nullptr;
       const llvm::Instruction *curr;
+      const llvm::Function *prevFn = nullptr;
+      const llvm::Function *currFn;
       for (unsigned i = 0; i < cells.size(); ++i) {
         curr = cells[i].r;
+        currFn = curr->getFunction();
+        if (prevFn != currFn) {
+          prevFn = currFn;
+          std::cout << "\n\n============ Results for function '" +
+                           currFn->getName().str() + "' ============\n";
+        }
         if (prev != curr) {
           prev = curr;
-          std::cout << "\n--- IDE START RESULT RECORD ---\n";
-          std::cout << "N: " << Problem.NtoString(cells[i].r) << " | Fn: ";
-          if (const llvm::Instruction *inst =
-                  llvm::dyn_cast<llvm::Instruction>(cells[i].r)) {
-            std::cout << inst->getFunction()->getName().str() << '\n';
-          }
+          std::string NString = Problem.NtoString(curr);
+          std::string line(NString.size(), '-');
+          std::cout << "\n\nN: " << NString << "\n---" << line << '\n';
         }
         std::cout << "\tD: " << Problem.DtoString(cells[i].c)
                   << " | V: " << Problem.VtoString(cells[i].v) << '\n';

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIDESolver.h
@@ -80,20 +80,21 @@ public:
     if (cells.empty()) {
       std::cout << "No results computed!" << std::endl;
     } else {
+      llvmValueIDLess llvmIDLess;
       std::sort(cells.begin(), cells.end(),
-                [](typename Table<const llvm::Instruction *, D, V>::Cell a,
-                   typename Table<const llvm::Instruction *, D, V>::Cell b) {
-                  if (!lessThanOnValueID(a.r, b.r) &&
-                      !lessThanOnValueID(b.r, a.r)) {
+                [&llvmIDLess](
+                    typename Table<const llvm::Instruction *, D, V>::Cell a,
+                    typename Table<const llvm::Instruction *, D, V>::Cell b) {
+                  if (!llvmIDLess(a.r, b.r) && !llvmIDLess(b.r, a.r)) {
                     if constexpr (std::is_same<D, const llvm::Value *>::value) {
-                      return lessThanOnValueID(a.c, b.c);
+                      return llvmIDLess(a.c, b.c);
                     } else {
                       // If D is user defined we should use the user defined
                       // less-than comparison
                       return a.c < b.c;
                     }
                   }
-                  return lessThanOnValueID(a.r, b.r);
+                  return llvmIDLess(a.r, b.r);
                 });
       const llvm::Instruction *prev = nullptr;
       const llvm::Instruction *curr;

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
@@ -58,7 +58,7 @@ public:
     IFDSSolver<const llvm::Instruction *, D, const llvm::Function *,
                I>::solve();
     bl::core::get()->flush();
-    if (VariablesMap.count("emit-raw-results")) {
+    if (PhasarConfig::VariablesMap().count("emit-raw-results")) {
       dumpResults();
     }
     if (PRINT_REPORT) {

--- a/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
+++ b/include/phasar/PhasarLLVM/IfdsIde/Solver/LLVMIFDSSolver.h
@@ -85,22 +85,24 @@ public:
     if (cells.empty()) {
       std::cout << "No results computed!\n";
     } else {
-      sort(
-          cells.begin(), cells.end(),
-          [](typename Table<const llvm::Instruction *, D, BinaryDomain>::Cell a,
-             typename Table<const llvm::Instruction *, D, BinaryDomain>::Cell
-                 b) {
-            if (!lessThanOnValueID(a.r, b.r) && !lessThanOnValueID(b.r, a.r)) {
-              if constexpr (std::is_same<D, const llvm::Value *>::value) {
-                return lessThanOnValueID(a.c, b.c);
-              } else {
-                // If D is user defined we should use the user defined
-                // less-than comparison
-                return a.c < b.c;
-              }
-            }
-            return lessThanOnValueID(a.r, b.r);
-          });
+      llvmValueIDLess llvmIDLess;
+      sort(cells.begin(), cells.end(),
+           [&llvmIDLess](
+               typename Table<const llvm::Instruction *, D, BinaryDomain>::Cell
+                   a,
+               typename Table<const llvm::Instruction *, D, BinaryDomain>::Cell
+                   b) {
+             if (!llvmIDLess(a.r, b.r) && !llvmIDLess(b.r, a.r)) {
+               if constexpr (std::is_same<D, const llvm::Value *>::value) {
+                 return llvmIDLess(a.c, b.c);
+               } else {
+                 // If D is user defined we should use the user defined
+                 // less-than comparison
+                 return a.c < b.c;
+               }
+             }
+             return llvmIDLess(a.r, b.r);
+           });
       const llvm::Instruction *prev = nullptr;
       const llvm::Instruction *curr;
       const llvm::Function *prevFn = nullptr;

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
@@ -31,16 +31,11 @@ template <typename D, typename I, unsigned K>
 class LLVMInterMonoSolver
     : public InterMonoSolver<const llvm::Instruction *, D,
                              const llvm::Function *, I, K> {
-protected:
-  bool DUMP_RESULTS;
-
 public:
   LLVMInterMonoSolver(InterMonoProblem<const llvm::Instruction *, D,
-                                       const llvm::Function *, I> &problem,
-                      bool dumpResults = false)
+                                       const llvm::Function *, I> &problem)
       : InterMonoSolver<const llvm::Instruction *, D, const llvm::Function *, I,
-                        K>(problem),
-        DUMP_RESULTS(dumpResults) {}
+                        K>(problem) {}
 
   ~LLVMInterMonoSolver() override = default;
 
@@ -53,8 +48,9 @@ public:
     // do the solving of the analaysis problem
     InterMonoSolver<const llvm::Instruction *, D, const llvm::Function *, I,
                     K>::solve();
-    if (DUMP_RESULTS)
+    if (VariablesMap.count("emit-raw-results")) {
       dumpResults();
+    }
   }
 
   /**

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMInterMonoSolver.h
@@ -48,7 +48,7 @@ public:
     // do the solving of the analaysis problem
     InterMonoSolver<const llvm::Instruction *, D, const llvm::Function *, I,
                     K>::solve();
-    if (VariablesMap.count("emit-raw-results")) {
+    if (PhasarConfig::VariablesMap().count("emit-raw-results")) {
       dumpResults();
     }
   }

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
@@ -30,26 +30,22 @@ namespace psr {
 template <typename D, typename C>
 class LLVMIntraMonoSolver : public IntraMonoSolver<const llvm::Instruction *, D,
                                                    const llvm::Function *, C> {
-protected:
-  bool DUMP_RESULTS;
-
 public:
   LLVMIntraMonoSolver();
   ~LLVMIntraMonoSolver() override = default;
 
   LLVMIntraMonoSolver(IntraMonoProblem<const llvm::Instruction *, D,
-                                       const llvm::Function *, C> &problem,
-                      bool dumpResults = false)
+                                       const llvm::Function *, C> &problem)
       : IntraMonoSolver<const llvm::Instruction *, D, const llvm::Function *,
-                        C>(problem),
-        DUMP_RESULTS(dumpResults) {}
+                        C>(problem) {}
 
   void solve() override {
     // do the solving of the analaysis problem
     IntraMonoSolver<const llvm::Instruction *, D, const llvm::Function *,
                     C>::solve();
-    if (DUMP_RESULTS)
+    if (VariablesMap.count("emit-raw-results")) {
       dumpResults();
+    }
   }
 
   void dumpResults() {

--- a/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/Mono/Solver/LLVMIntraMonoSolver.h
@@ -43,7 +43,7 @@ public:
     // do the solving of the analaysis problem
     IntraMonoSolver<const llvm::Instruction *, D, const llvm::Function *,
                     C>::solve();
-    if (VariablesMap.count("emit-raw-results")) {
+    if (PhasarConfig::VariablesMap().count("emit-raw-results")) {
       dumpResults();
     }
   }

--- a/include/phasar/PhasarLLVM/Utils/DOTGraph.h
+++ b/include/phasar/PhasarLLVM/Utils/DOTGraph.h
@@ -19,9 +19,9 @@
 
 #include <iosfwd>
 #include <map>
+#include <phasar/Utils/Macros.h>
 #include <set>
 #include <string>
-#include <phasar/Utils/Macros.h>
 
 namespace psr {
 
@@ -139,6 +139,7 @@ struct DOTFunctionSubGraph {
 
   std::string str(std::string indent = "") const;
   DOTFactSubGraph *getOrCreateFactSG(unsigned factID, std::string &label);
+  // TODO: pass the actual lambda EF name and value as parameter from DOTGraph
   std::string generateLambdaSG(std::string indent = "") const;
   void createLayoutCFNodes();
   void createLayoutFactNodes();
@@ -166,6 +167,15 @@ template <typename D> struct DOTGraph {
       DtoFactId[fact] = factIDCount++;
     }
     return id;
+  }
+
+  bool containsFactSG(std::string fName, unsigned factID) {
+    if (functions.count(fName)) {
+      if (functions[fName].facts.count(factID)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   std::string str() const {

--- a/include/phasar/PhasarLLVM/Utils/DOTGraph.h
+++ b/include/phasar/PhasarLLVM/Utils/DOTGraph.h
@@ -21,12 +21,9 @@
 #include <map>
 #include <set>
 #include <string>
+#include <phasar/Utils/Macros.h>
 
 namespace psr {
-
-struct cmpStmtIdByValue {
-  bool operator()(const std::string &lhs, const std::string &rhs) const;
-};
 
 class DOTConfig {
 public:
@@ -110,7 +107,7 @@ struct DOTFactSubGraph {
   unsigned factId;
   std::string label;
   // stmt-id -> fact-node
-  std::map<std::string, DOTNode, cmpStmtIdByValue> nodes;
+  std::map<std::string, DOTNode, stringIDLess> nodes;
   std::set<DOTEdge> edges;
 
   std::string str(std::string indent = "") const;

--- a/include/phasar/PhasarLLVM/Utils/DOTGraph.h
+++ b/include/phasar/PhasarLLVM/Utils/DOTGraph.h
@@ -1,0 +1,210 @@
+/******************************************************************************
+ * Copyright (c) 2017 Philipp Schubert.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+/*
+ * DOTGraph.h
+ *
+ *  Created on: 31.08.2019
+ *      Author: rleer
+ */
+
+#ifndef PHASAR_PHASARLLVM_UTILS_DOTGRAPH_H_
+#define PHASAR_PHASARLLVM_UTILS_DOTGRAPH_H_
+
+#include <iosfwd>
+#include <map>
+#include <set>
+#include <string>
+
+namespace psr {
+
+struct cmpStmtIdByValue {
+  bool operator()(const std::string &lhs, const std::string &rhs) const;
+};
+
+class DOTConfig {
+public:
+  static const std::string CFNodeAttr() {
+    return "node [style=filled, shape=record]";
+  }
+  static const std::string CFIntraEdgeAttr() { return "edge []"; }
+  static const std::string CFInterEdgeAttr() { return "edge [weight=0.1]"; }
+  static const std::string FactNodeAttr() { return "node [style=rounded]"; }
+  static const std::string FactIdentityEdgeAttr() {
+    return "edge [style=dotted, arrowhead=normal, " + fontSize + ", " +
+           arrowSize + ']';
+  }
+  static const std::string FactCrossEdgeAttr() {
+    return FactIdentityEdgeAttr();
+  }
+  static const std::string LambdaInterEdgeAttr() {
+    return "edge[weight=0.1, style=dotted, " + fontSize + ", " + arrowSize +
+           ']';
+  }
+  static const std::string FactInterEdgeAttr() {
+    return "edge [weight=0.1, style=dashed, " + fontSize + ", " + arrowSize +
+           ']';
+  }
+
+  static DOTConfig &getDOTConfig();
+  ~DOTConfig() = default;
+  DOTConfig(const DOTConfig &) = delete;
+  DOTConfig(DOTConfig &&) = delete;
+
+private:
+  DOTConfig() = default;
+  inline static const std::string fontSize = "fontsize=11";
+  inline static const std::string arrowSize = "arrowsize=0.7";
+};
+
+struct DOTNode {
+  /* stmt id = <func-name>_<stmt-id>
+   * e.g. foo_42 for the statement w/ id 42 in function foo
+   *
+   * fact id = <func-name>_<fact-id>_<stmt-id>
+   * e.g. fact i in main valid at statement 3 : main_1_3
+   * Note that in this example fact i is the very first valid fact
+   * encountered so the fact-id is 1 (zero value has fact-id 0)
+   */
+  std::string id;
+  std::string funcName;
+  std::string label;
+  std::string stmtId;
+  unsigned factId;
+  bool isVisible = true;
+
+  DOTNode() = default;
+  DOTNode(std::string fName, std::string l, std::string sId, unsigned fId = 0,
+          bool isStmt = true, bool isv = true);
+  std::string str(std::string indent = "") const;
+};
+
+bool operator<(const DOTNode &lhs, const DOTNode &rhs);
+bool operator==(const DOTNode &lhs, const DOTNode &rhs);
+std::ostream &operator<<(std::ostream &os, const DOTNode &node);
+
+struct DOTEdge {
+  DOTNode source;
+  DOTNode target;
+  bool isVisible;
+  std::string edgeFnLabel;
+  std::string valueLabel;
+
+  DOTEdge(DOTNode src, DOTNode tar, bool isv = true, std::string efl = "",
+          std::string vl = "");
+  std::string str(std::string indent = "") const;
+};
+
+bool operator<(const DOTEdge &lhs, const DOTEdge &rhs);
+std::ostream &operator<<(std::ostream &os, const DOTEdge &edge);
+
+struct DOTFactSubGraph {
+  // fact subgraph id = <func-name>_<fact-id>
+  std::string id;
+  unsigned factId;
+  std::string label;
+  // stmt-id -> fact-node
+  std::map<std::string, DOTNode, cmpStmtIdByValue> nodes;
+  std::set<DOTEdge> edges;
+
+  std::string str(std::string indent = "") const;
+};
+
+std::ostream &operator<<(std::ostream &os, const DOTFactSubGraph &factSG);
+
+struct DOTFunctionSubGraph {
+  // function subgraph id = <func-name>
+  std::string id;
+  std::set<DOTNode> stmts;
+  // fact-id -> fact-subgraph
+  std::map<unsigned, DOTFactSubGraph> facts;
+  std::set<DOTEdge> intraCFEdges;
+  /// d1 -> d2 where d1 != d2
+  std::set<DOTEdge> crossFactEdges;
+
+  std::string str(std::string indent = "") const;
+  DOTFactSubGraph *getOrCreateFactSG(unsigned factID, std::string &label);
+  std::string generateLambdaSG(std::string indent = "") const;
+  void createLayoutCFNodes();
+  void createLayoutFactNodes();
+  void createLayoutFactEdges();
+};
+
+std::ostream &operator<<(std::ostream &os,
+                         const DOTFunctionSubGraph &functionSG);
+
+template <typename D> struct DOTGraph {
+  std::string label;
+  std::map<std::string, DOTFunctionSubGraph> functions;
+  std::set<DOTEdge> interCFEdges;
+  std::set<DOTEdge> interLambdaEdges;
+  std::set<DOTEdge> interFactEdges;
+
+  DOTGraph() = default;
+
+  unsigned getFactID(D fact) {
+    unsigned id = 0;
+    if (DtoFactId.count(fact)) {
+      id = DtoFactId[fact];
+    } else {
+      id = factIDCount;
+      DtoFactId[fact] = factIDCount++;
+    }
+    return id;
+  }
+
+  std::string str() const {
+    std::string indent = "  ";
+    std::string str = "digraph {\n" + indent + "label=\"" + label + "\"\n";
+    // Print function subgraphs
+    str += '\n' + indent + "// Function sub graphs\n";
+    for (auto fsg : functions) {
+      fsg.second.createLayoutCFNodes();
+      fsg.second.createLayoutFactNodes();
+      fsg.second.createLayoutFactEdges();
+      str += fsg.second.str(indent) + "\n\n";
+    }
+
+    // Print inter control flow edges
+    str += indent + "// Inter-procedural control flow edges\n" + indent +
+           DOTConfig::CFInterEdgeAttr() + '\n';
+    for (DOTEdge e : interCFEdges) {
+      str += e.str(indent) + '\n';
+    }
+
+    // Print inter lambda edges
+    str += '\n' + indent + "// Inter-procedural lambda edges\n" + indent +
+           DOTConfig::LambdaInterEdgeAttr() + '\n';
+    for (DOTEdge e : interLambdaEdges) {
+      str += e.str(indent) + '\n';
+    }
+
+    // Print inter fact edges
+    str += '\n' + indent + "// Inter-procedural fact edges\n" + indent +
+           DOTConfig::FactInterEdgeAttr() + '\n';
+    for (DOTEdge e : interFactEdges) {
+      str += e.str(indent) + '\n';
+    }
+    return str + '}';
+  }
+
+  friend std::ostream &operator<<(std::ostream &os, const DOTGraph<D> &graph) {
+    return os << graph.str();
+  }
+
+private:
+  // We introduce a fact-ID for data-flow facts D since only statements N have
+  // an ID
+  unsigned factIDCount = 1;
+  std::map<D, unsigned> DtoFactId;
+};
+
+} // namespace psr
+
+#endif

--- a/include/phasar/PhasarLLVM/Utils/DOTGraph.h
+++ b/include/phasar/PhasarLLVM/Utils/DOTGraph.h
@@ -27,27 +27,20 @@ namespace psr {
 
 class DOTConfig {
 public:
-  static const std::string CFNodeAttr() {
-    return "node [style=filled, shape=record]";
-  }
-  static const std::string CFIntraEdgeAttr() { return "edge []"; }
-  static const std::string CFInterEdgeAttr() { return "edge [weight=0.1]"; }
-  static const std::string FactNodeAttr() { return "node [style=rounded]"; }
-  static const std::string FactIdentityEdgeAttr() {
-    return "edge [style=dotted, arrowhead=normal, " + fontSize + ", " +
-           arrowSize + ']';
-  }
-  static const std::string FactCrossEdgeAttr() {
-    return FactIdentityEdgeAttr();
-  }
-  static const std::string LambdaInterEdgeAttr() {
-    return "edge[weight=0.1, style=dotted, " + fontSize + ", " + arrowSize +
-           ']';
-  }
-  static const std::string FactInterEdgeAttr() {
-    return "edge [weight=0.1, style=dashed, " + fontSize + ", " + arrowSize +
-           ']';
-  }
+  static const std::string CFNodeAttr() { return CFNode; }
+  static const std::string CFIntraEdgeAttr() { return CFIntraEdge; }
+  static const std::string CFInterEdgeAttr() { return CFInterEdge; }
+
+  static const std::string FactNodeAttr() { return FactNode; }
+  static const std::string FactIDEdgeAttr() { return FactIDEdge; }
+  static const std::string FactCrossEdgeAttr() { return FactCrossEdge; }
+  static const std::string FactInterEdgeAttr() { return FactInterEdge; }
+
+  static const std::string LambdaNodeAttr() { return LambdaNode; }
+  static const std::string LambdaIDEdgeAttr() { return LambdaIDEdge; }
+  static const std::string LambdaInterEdgeAttr() { return LambdaInterEdge; }
+
+  static void importDOTConfig();
 
   static DOTConfig &getDOTConfig();
   ~DOTConfig() = default;
@@ -58,6 +51,25 @@ private:
   DOTConfig() = default;
   inline static const std::string fontSize = "fontsize=11";
   inline static const std::string arrowSize = "arrowsize=0.7";
+
+  inline static std::string CFNode = "node [style=filled, shape=record]";
+  inline static std::string CFIntraEdge = "edge []";
+  inline static std::string CFInterEdge = "edge [weight=0.1]";
+  inline static std::string FactNode = "node [style=rounded]";
+  inline static std::string FactIDEdge =
+      "edge [style=dotted, arrowhead=normal, " + fontSize + ", " + arrowSize +
+      ']';
+  inline static std::string FactCrossEdge =
+      "edge [style=dotted, arrowhead=normal, " + fontSize + ", " + arrowSize +
+      ']';
+  inline static std::string FactInterEdge =
+      "edge [weight=0.1, style=dashed, " + fontSize + ", " + arrowSize + ']';
+  inline static std::string LambdaNode = "node [style=rounded]";
+  inline static std::string LambdaIDEdge =
+      "edge [style=dotted, arrowhead=normal, " + fontSize + ", " + arrowSize +
+      ']';
+  inline static std::string LambdaInterEdge =
+      "edge [weight=0.1, style=dashed, " + fontSize + ", " + arrowSize + ']';
 };
 
 struct DOTNode {

--- a/include/phasar/Utils/BitVectorSet.h
+++ b/include/phasar/Utils/BitVectorSet.h
@@ -31,11 +31,11 @@ namespace psr {
  * @brief Implements a set that only requires minimal space.
  */
 template <typename T> class BitVectorSet {
- private:
+private:
   inline static std::map<T, size_t> Position;
   std::vector<bool> Bits;
 
- public:
+public:
   BitVectorSet() = default;
 
   BitVectorSet(std::initializer_list<T> Ilist) {
@@ -44,9 +44,9 @@ template <typename T> class BitVectorSet {
     }
   }
 
-	BitVectorSet(const BitVectorSet&) = default;
+  BitVectorSet(const BitVectorSet &) = default;
 
-	BitVectorSet(BitVectorSet&&) = default;
+  BitVectorSet(BitVectorSet &&) = default;
 
   ~BitVectorSet() = default;
 

--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -85,6 +85,12 @@ bool matchesSignature(const llvm::Function *F, const llvm::FunctionType *FType);
 std::string llvmIRToString(const llvm::Value *V);
 
 /**
+ * @brief Same as @link(llvmIRToString) but tries to shorten the
+ *        resulting string
+ */
+std::string llvmIRToShortString(const llvm::Value *V);
+
+/**
  * @brief Returns all LLVM Global Values that are used in the given LLVM
  * Function.
  */

--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -17,6 +17,7 @@
 #ifndef PHASAR_UTILS_LLVMSHORTHANDS_H_
 #define PHASAR_UTILS_LLVMSHORTHANDS_H_
 
+#include <phasar/Utils/Macros.h>
 #include <string>
 #include <vector>
 
@@ -112,12 +113,16 @@ globalValuesUsedinFunction(const llvm::Function *F);
 std::string getMetaDataID(const llvm::Value *V);
 
 /**
- * @brief Does a '<' comparison of the annotated ID.
+ * @brief Does less-than comparison based on the annotated ID.
  *
  * This is useful, since Instructions/Globals and Arguments have different
  * underlying types for their ID's, size_t and string respectively.
  */
-bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2);
+struct llvmValueIDLess {
+  stringIDLess sless;
+  llvmValueIDLess();
+  bool operator()(const llvm::Value *lhs, const llvm::Value *rhs) const;
+};
 
 /**
  * @brief Returns position of a formal function argument.

--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -99,15 +99,25 @@ globalValuesUsedinFunction(const llvm::Function *F);
 
 /**
  * Only Instructions and GlobalVariables have 'real' ID's, i.e. annotated meta
- * data. Formal arguments will not be annotated with an ID during
- * ValueAnnotationPass. Instead, a formal arguments ID will look like this:
+ * data. Formal arguments cannot be annotated with metadata in LLVM. Therefore, 
+ * a formal arguments ID will look like this:
  *    <function_name>.<#argument>
  *
+ * ZeroValue will have -1 as ID by default.
+ * 
  * @brief Returns the ID of a given LLVM Value.
  * @return Meta data ID as a string or -1, if it's not
  * an Instruction, GlobalVariable or Argument.
  */
 std::string getMetaDataID(const llvm::Value *V);
+
+/**
+ * @brief Does a '<' comparison of the annotated ID.
+ * 
+ * This is useful, since Instructions/Globals and Arguments have different underlying 
+ * types for their ID's, size_t and string respectively. 
+ */
+bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2);
 
 /**
  * @brief Returns position of a formal function argument.

--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -99,12 +99,12 @@ globalValuesUsedinFunction(const llvm::Function *F);
 
 /**
  * Only Instructions and GlobalVariables have 'real' ID's, i.e. annotated meta
- * data. Formal arguments cannot be annotated with metadata in LLVM. Therefore, 
+ * data. Formal arguments cannot be annotated with metadata in LLVM. Therefore,
  * a formal arguments ID will look like this:
  *    <function_name>.<#argument>
  *
  * ZeroValue will have -1 as ID by default.
- * 
+ *
  * @brief Returns the ID of a given LLVM Value.
  * @return Meta data ID as a string or -1, if it's not
  * an Instruction, GlobalVariable or Argument.
@@ -113,9 +113,9 @@ std::string getMetaDataID(const llvm::Value *V);
 
 /**
  * @brief Does a '<' comparison of the annotated ID.
- * 
- * This is useful, since Instructions/Globals and Arguments have different underlying 
- * types for their ID's, size_t and string respectively. 
+ *
+ * This is useful, since Instructions/Globals and Arguments have different
+ * underlying types for their ID's, size_t and string respectively.
  */
 bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2);
 

--- a/include/phasar/Utils/Macros.h
+++ b/include/phasar/Utils/Macros.h
@@ -91,6 +91,11 @@ std::set<std::set<T>> computePowerSet(const std::set<T> &s) {
 }
 
 std::ostream &operator<<(std::ostream &os, const std::vector<bool> &bits);
+
+struct stringIDLess {
+  bool operator()(const std::string &lhs, const std::string &rhs) const;
+};
+
 } // namespace psr
 
 #endif

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -116,7 +116,7 @@ AnalysisController::AnalysisController(
   IRDB.preprocessIR();
 
   // output (shortend) IR with ID annotations
-  if (VariablesMap.count("emit-ir")) {
+  if (PhasarConfig::VariablesMap().count("emit-ir")) {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
                   << "Emit pre-processed and annotated IR module(s) as "
                      "'annotated-ir.ll'");
@@ -162,7 +162,7 @@ AnalysisController::AnalysisController(
   //
   // ofs_ch << CHJson.dump();
   // WARNING
-  // if (VariablesMap.count("classhierarchy_analysis")) {
+  // if (PhasarConfig::VariablesMap().count("classhierarchy_analysis")) {
   //   CH.print();
   //   CH.printAsDot("ch.dot");
   // }
@@ -187,12 +187,12 @@ AnalysisController::AnalysisController(
     // Add the ICFG to final results
 
     // FinalResultsJson += ICFG.getAsJson();
-    // if (VariablesMap.count("callgraph-analysis")) {
+    // if (PhasarConfig::VariablesMap().count("callgraph-analysis")) {
     //   ICFG.print();
     //   ICFG.printAsDot("icfg.dot");
     // }
     // FinalResultsJson += ICFG.getWholeModulePTG().getAsJson();
-    // if (VariablesMap.count("pointer-analysis")) {
+    // if (PhasarConfig::VariablesMap().count("pointer-analysis")) {
     //   ICFG.getWholeModulePTG().print();
     //   ICFG.getWholeModulePTG().printAsDot("wptg.dot");
     // }

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -114,8 +114,11 @@ AnalysisController::AnalysisController(
   }
   IRDB.preprocessIR();
 
-  // print (shortend) IR with ID annotations
-  if (VariablesMap.count("print-ir")) {
+  // output (shortend) IR with ID annotations
+  if (VariablesMap.count("output-ir")) {
+    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
+                  << "Output pre-processed and annotated IR module(s) to "
+                     "'annotated-ir.ll'");
     std::ofstream irFile("annotated-ir.ll", std::ios::binary);
     IRDB.printPreprocessedIR(irFile, true);
     irFile.close();

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -259,7 +259,7 @@ AnalysisController::AnalysisController(
         IFDSUninitializedVariables uninitializedvarproblem(ICFG, CH, IRDB,
                                                            EntryPoints);
         LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmunivsolver(
-            uninitializedvarproblem, false);
+            uninitializedvarproblem, true);
         cout << "IFDS UninitVar Analysis ..." << endl;
         llvmunivsolver.solve();
         cout << "IFDS UninitVar Analysis ended" << endl;

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -114,6 +114,12 @@ AnalysisController::AnalysisController(
   }
   IRDB.preprocessIR();
 
+  // print (shortend) IR with ID annotations
+  if (VariablesMap.count("print-ir")) {
+    std::ofstream irFile("annotated-ir.ll", std::ios::binary);
+    IRDB.printPreprocessedIR(irFile, true);
+    irFile.close();
+  }
   // START_TIMER("DB Start Up", PAMM_SEVERITY_LEVEL::Full);
   // DBConn &db = DBConn::getInstance();
   // STOP_TIMER("DB Start Up", PAMM_SEVERITY_LEVEL::Full);

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -437,7 +437,7 @@ void ProjectIRDB::print() {
   }
 }
 
-void ProjectIRDB::printPreprocessedIR(std::ostream &os, bool shortenIR) {
+void ProjectIRDB::emitPreprocessedIR(std::ostream &os, bool shortenIR) {
   for (auto &entry : modules) {
     os << "IR module: " << entry.first << '\n';
     // print globals

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -442,14 +442,15 @@ void ProjectIRDB::printPreprocessedIR(std::ostream &os, bool shortenIR) {
   for (auto &entry : modules) {
     os << "\nIR module: " << entry.first << '\n';
     for (auto F : getAllFunctions()) {
-      if (getModuleDefiningFunction(F->getName().str())->getModuleIdentifier() == entry.first) {
+      if (getModuleDefiningFunction(F->getName().str())
+              ->getModuleIdentifier() == entry.first) {
         os << F->getName().str() << " {\n";
         for (auto &BB : *F) {
           // do not print the label of the first BB
           if (BB.getPrevNode()) {
             std::string BBLabel;
             llvm::raw_string_ostream RSO(BBLabel);
-            BB.printAsOperand(RSO,false);
+            BB.printAsOperand(RSO, false);
             RSO.flush();
             os << "\n<label " << BBLabel << ">\n";
           }

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -437,6 +437,39 @@ void ProjectIRDB::print() {
   }
 }
 
+void ProjectIRDB::printPreprocessedIR(std::ostream &os, bool shortenIR) {
+  os << " === Print pre-processed IR module(s) === \n";
+  for (auto &entry : modules) {
+    os << "\nIR module: " << entry.first << '\n';
+    for (auto F : getAllFunctions()) {
+      if (getModuleDefiningFunction(F->getName().str())->getModuleIdentifier() == entry.first) {
+        os << F->getName().str() << " {\n";
+        for (auto &BB : *F) {
+          // do not print the label of the first BB
+          if (BB.getPrevNode()) {
+            std::string BBLabel;
+            llvm::raw_string_ostream RSO(BBLabel);
+            BB.printAsOperand(RSO,false);
+            RSO.flush();
+            os << "\n<label " << BBLabel << ">\n";
+          }
+          for (auto &I : BB) {
+            os << "  ";
+            if (shortenIR) {
+              os << llvmIRToShortString(&I);
+            } else {
+              os << llvmIRToString(&I);
+            }
+            os << '\n';
+          }
+        }
+        os << "}\n\n";
+      }
+    }
+    os << '\n';
+  }
+}
+
 void ProjectIRDB::exportPATBCJSON() {
   std::cout << "ProjectIRDB::exportPATBCJSON\n";
 }

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -438,9 +438,18 @@ void ProjectIRDB::print() {
 }
 
 void ProjectIRDB::printPreprocessedIR(std::ostream &os, bool shortenIR) {
-  os << " === Print pre-processed IR module(s) === \n";
   for (auto &entry : modules) {
-    os << "\nIR module: " << entry.first << '\n';
+    os << "IR module: " << entry.first << '\n';
+    // print globals
+    for (auto &glob : entry.second->globals()) {
+      if (shortenIR) {
+        os << llvmIRToShortString(&glob);
+      } else {
+        os << llvmIRToString(&glob);
+      }
+      os << '\n';
+    }
+    os << '\n';
     for (auto F : getAllFunctions()) {
       if (getModuleDefiningFunction(F->getName().str())
               ->getModuleIdentifier() == entry.first) {
@@ -454,6 +463,7 @@ void ProjectIRDB::printPreprocessedIR(std::ostream &os, bool shortenIR) {
             RSO.flush();
             os << "\n<label " << BBLabel << ">\n";
           }
+          // print all instructions
           for (auto &I : BB) {
             os << "  ";
             if (shortenIR) {

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -202,9 +202,9 @@ void LLVMBasedICFG::constructionWalker(const llvm::Function *F,
       // check if function call can be resolved statically
       if (cs.getCalledFunction() != nullptr) {
         possible_targets.insert(cs.getCalledFunction());
+        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Found static call-site: ");
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                      << "Found static call-site: "
-                      << llvmIRToString(cs.getInstruction()));
+                      << "  " << llvmIRToString(cs.getInstruction()));
       } else {
         // still try to resolve the called function statically
         const llvm::Value *v = cs.getCalledValue();
@@ -217,8 +217,9 @@ void LLVMBasedICFG::constructionWalker(const llvm::Function *F,
         } else {
           // the function call must be resolved dynamically
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                        << "Found dynamic call-site: "
-                        << llvmIRToString(cs.getInstruction()));
+                        << "Found dynamic call-site: ");
+          LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+                        << "  " << llvmIRToString(cs.getInstruction()));
           // call the resolve routine
           set<string> possible_target_names;
           if (isVirtualFunctionCall(cs)) {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -764,12 +764,12 @@ IDELinearConstantAnalysis::v_t IDELinearConstantAnalysis::executeBinOperation(
 
 void IDELinearConstantAnalysis::printNode(
     ostream &os, IDELinearConstantAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+  os << llvmIRToShortString(n);
 }
 
 void IDELinearConstantAnalysis::printDataFlowFact(
     ostream &os, IDELinearConstantAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+  os << llvmIRToShortString(d);
 }
 
 void IDELinearConstantAnalysis::printMethod(

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -70,8 +70,10 @@ shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
 IDELinearConstantAnalysis::getNormalFlowFunction(
     IDELinearConstantAnalysis::n_t curr, IDELinearConstantAnalysis::n_t succ) {
   if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
-    return make_shared<Gen<IDELinearConstantAnalysis::d_t>>(Alloca,
-                                                            zeroValue());
+    if (Alloca->getAllocatedType()->isIntegerTy()) {
+      return make_shared<Gen<IDELinearConstantAnalysis::d_t>>(Alloca,
+                                                              zeroValue());
+    }
   }
   // Check store instructions. Store instructions override previous value
   // of their pointer operand, i.e. kills previous fact (= pointer operand).

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -69,9 +69,10 @@ IDELinearConstantAnalysis::~IDELinearConstantAnalysis() {
 shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
 IDELinearConstantAnalysis::getNormalFlowFunction(
     IDELinearConstantAnalysis::n_t curr, IDELinearConstantAnalysis::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getNormalFlowFunction()");
+  if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
+    return make_shared<Gen<IDELinearConstantAnalysis::d_t>>(Alloca,
+                                                            zeroValue());
+  }
   // Check store instructions. Store instructions override previous value
   // of their pointer operand, i.e. kills previous fact (= pointer operand).
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
@@ -149,10 +150,6 @@ shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
 IDELinearConstantAnalysis::getCallFlowFunction(
     IDELinearConstantAnalysis::n_t callStmt,
     IDELinearConstantAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getCallFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
   // Map the actual parameters into the formal parameters
   if (llvm::isa<llvm::CallInst>(callStmt) ||
       llvm::isa<llvm::InvokeInst>(callStmt)) {
@@ -227,10 +224,6 @@ IDELinearConstantAnalysis::getRetFlowFunction(
     IDELinearConstantAnalysis::m_t calleeMthd,
     IDELinearConstantAnalysis::n_t exitStmt,
     IDELinearConstantAnalysis::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getRetFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
   // Handle the case: %x = call i32 ...
   if (callSite->getType()->isIntegerTy()) {
     auto Return = llvm::dyn_cast<llvm::ReturnInst>(exitStmt);
@@ -266,10 +259,6 @@ shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
 IDELinearConstantAnalysis::getCallToRetFlowFunction(
     IDELinearConstantAnalysis::n_t callSite,
     IDELinearConstantAnalysis::n_t retSite, set<m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getCallToRetFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
   return Identity<IDELinearConstantAnalysis::d_t>::getInstance();
 }
 
@@ -277,10 +266,6 @@ shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
 IDELinearConstantAnalysis::getSummaryFlowFunction(
     IDELinearConstantAnalysis::n_t callStmt,
     IDELinearConstantAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getSummaryFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << ' ');
   return nullptr;
 }
 
@@ -329,20 +314,6 @@ IDELinearConstantAnalysis::getNormalEdgeFunction(
     IDELinearConstantAnalysis::n_t succ,
     IDELinearConstantAnalysis::d_t succNode) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getNormalEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Curr Inst : "
-                << IDELinearConstantAnalysis::NtoString(curr));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Curr Node :   "
-                << IDELinearConstantAnalysis::DtoString(currNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Succ Inst : "
-                << IDELinearConstantAnalysis::NtoString(succ));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Succ Node :   "
-                << IDELinearConstantAnalysis::DtoString(succNode));
   // All_Bottom for zero value
   if (isZeroValue(currNode) && isZeroValue(succNode)) {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Case: Zero value.");
@@ -467,7 +438,7 @@ IDELinearConstantAnalysis::getNormalEdgeFunction(
       }
 
       void print(ostream &OS, bool isForDebug = false) const override {
-        OS << "Binary_" << EdgeFunctionID;
+        OS << "Bin_" << EdgeFunctionID;
       }
     };
     return make_shared<LCAEF>(OP, lop, rop, currNode);
@@ -483,21 +454,6 @@ IDELinearConstantAnalysis::getCallEdgeFunction(
     IDELinearConstantAnalysis::d_t srcNode,
     IDELinearConstantAnalysis::m_t destinationMethod,
     IDELinearConstantAnalysis::d_t destNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getCallEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Call Stmt   : "
-                << IDELinearConstantAnalysis::NtoString(callStmt));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Src Node    :   "
-                << IDELinearConstantAnalysis::DtoString(srcNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(M) Dest Method : "
-                << IDELinearConstantAnalysis::MtoString(destinationMethod));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Dest Node   :   "
-                << IDELinearConstantAnalysis::DtoString(destNode));
   // Case: Passing constant integer as parameter
   if (isZeroValue(srcNode) && !isZeroValue(destNode)) {
     if (auto A = llvm::dyn_cast<llvm::Argument>(destNode)) {
@@ -520,27 +476,6 @@ IDELinearConstantAnalysis::getReturnEdgeFunction(
     IDELinearConstantAnalysis::d_t exitNode,
     IDELinearConstantAnalysis::n_t reSite,
     IDELinearConstantAnalysis::d_t retNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getReturnEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Call Site : "
-                << IDELinearConstantAnalysis::NtoString(callSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(M) Callee    : "
-                << IDELinearConstantAnalysis::MtoString(calleeMethod));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Exit Stmt : "
-                << IDELinearConstantAnalysis::NtoString(exitStmt));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Exit Node :   "
-                << IDELinearConstantAnalysis::DtoString(exitNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Ret Site  : "
-                << IDELinearConstantAnalysis::NtoString(reSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Ret Node  :   "
-                << IDELinearConstantAnalysis::DtoString(retNode));
   // Case: Returning constant integer
   if (isZeroValue(exitNode) && !isZeroValue(retNode)) {
     auto Return = llvm::dyn_cast<llvm::ReturnInst>(exitStmt);
@@ -560,9 +495,6 @@ IDELinearConstantAnalysis::getCallToRetEdgeFunction(
     IDELinearConstantAnalysis::n_t retSite,
     IDELinearConstantAnalysis::d_t retSiteNode,
     set<IDELinearConstantAnalysis::m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getCallToRetEdgeFunction()");
   return EdgeIdentity<IDELinearConstantAnalysis::v_t>::getInstance();
 }
 
@@ -572,9 +504,6 @@ IDELinearConstantAnalysis::getSummaryEdgeFunction(
     IDELinearConstantAnalysis::d_t callNode,
     IDELinearConstantAnalysis::n_t retSite,
     IDELinearConstantAnalysis::d_t retSiteNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDELinearConstantAnalysis::getSummaryEdgeFunction()");
   return EdgeIdentity<IDELinearConstantAnalysis::v_t>::getInstance();
 }
 
@@ -680,7 +609,7 @@ bool IDELinearConstantAnalysis::GenConstant::equal_to(
 
 void IDELinearConstantAnalysis::GenConstant::print(ostream &OS,
                                                    bool isForDebug) const {
-  OS << "GenConstant_" << GenConstant_Id;
+  OS << "Const_" << GenConstant_Id;
 }
 
 IDELinearConstantAnalysis::LCAIdentity::LCAIdentity()
@@ -720,7 +649,7 @@ bool IDELinearConstantAnalysis::LCAIdentity::equal_to(
 
 void IDELinearConstantAnalysis::LCAIdentity::print(ostream &OS,
                                                    bool isForDebug) const {
-  OS << "LCAIdentity_" << LCAID_Id;
+  OS << "LCAID_" << LCAID_Id;
 }
 
 IDELinearConstantAnalysis::v_t IDELinearConstantAnalysis::executeBinOperation(

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDEProtoAnalysis.cpp
@@ -43,14 +43,12 @@ IDEProtoAnalysis::IDEProtoAnalysis(IDEProtoAnalysis::i_t icfg,
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
 IDEProtoAnalysis::getNormalFlowFunction(IDEProtoAnalysis::n_t curr,
                                         IDEProtoAnalysis::n_t succ) {
-  cout << "IDEProtoAnalysis::getNormalFlowFunction()\n";
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
 IDEProtoAnalysis::getCallFlowFunction(IDEProtoAnalysis::n_t callStmt,
                                       IDEProtoAnalysis::m_t destMthd) {
-  cout << "IDEProtoAnalysis::getCallFlowFunction()\n";
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
@@ -59,7 +57,6 @@ IDEProtoAnalysis::getRetFlowFunction(IDEProtoAnalysis::n_t callSite,
                                      IDEProtoAnalysis::m_t calleeMthd,
                                      IDEProtoAnalysis::n_t exitStmt,
                                      IDEProtoAnalysis::n_t retSite) {
-  cout << "IDEProtoAnalysis::getRetFlowFunction()\n";
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
@@ -67,7 +64,6 @@ shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
 IDEProtoAnalysis::getCallToRetFlowFunction(IDEProtoAnalysis::n_t callSite,
                                            IDEProtoAnalysis::n_t retSite,
                                            set<IDEProtoAnalysis::m_t> callees) {
-  cout << "IDEProtoAnalysis::getCallToRetFlowFunction()\n";
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
@@ -105,7 +101,6 @@ IDEProtoAnalysis::getNormalEdgeFunction(IDEProtoAnalysis::n_t curr,
                                         IDEProtoAnalysis::d_t currNode,
                                         IDEProtoAnalysis::n_t succ,
                                         IDEProtoAnalysis::d_t succNode) {
-  cout << "IDEProtoAnalysis::getNormalEdgeFunction()\n";
   return EdgeIdentity<IDEProtoAnalysis::v_t>::getInstance();
 }
 
@@ -114,7 +109,6 @@ IDEProtoAnalysis::getCallEdgeFunction(IDEProtoAnalysis::n_t callStmt,
                                       IDEProtoAnalysis::d_t srcNode,
                                       IDEProtoAnalysis::m_t destinationMethod,
                                       IDEProtoAnalysis::d_t destNode) {
-  cout << "IDEProtoAnalysis::getCallEdgeFunction()\n";
   return EdgeIdentity<IDEProtoAnalysis::v_t>::getInstance();
 }
 
@@ -125,7 +119,6 @@ IDEProtoAnalysis::getReturnEdgeFunction(IDEProtoAnalysis::n_t callSite,
                                         IDEProtoAnalysis::d_t exitNode,
                                         IDEProtoAnalysis::n_t reSite,
                                         IDEProtoAnalysis::d_t retNode) {
-  cout << "IDEProtoAnalysis::getReturnEdgeFunction()\n";
   return EdgeIdentity<IDEProtoAnalysis::v_t>::getInstance();
 }
 
@@ -135,7 +128,6 @@ IDEProtoAnalysis::getCallToRetEdgeFunction(IDEProtoAnalysis::n_t callSite,
                                            IDEProtoAnalysis::n_t retSite,
                                            IDEProtoAnalysis::d_t retSiteNode,
                                            set<IDEProtoAnalysis::m_t> callees) {
-  cout << "IDEProtoAnalysis::getCallToRetEdgeFunction()\n";
   return EdgeIdentity<IDEProtoAnalysis::v_t>::getInstance();
 }
 
@@ -144,7 +136,6 @@ IDEProtoAnalysis::getSummaryEdgeFunction(IDEProtoAnalysis::n_t callSite,
                                          IDEProtoAnalysis::d_t callNode,
                                          IDEProtoAnalysis::n_t retSite,
                                          IDEProtoAnalysis::d_t retSiteNode) {
-  cout << "IDEProtoAnalysis::getSummaryEdgeFunction()\n";
   return EdgeIdentity<IDEProtoAnalysis::v_t>::getInstance();
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDESolverTest.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDESolverTest.cpp
@@ -42,21 +42,18 @@ IDESolverTest::IDESolverTest(IDESolverTest::i_t icfg,
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
 IDESolverTest::getNormalFlowFunction(IDESolverTest::n_t curr,
                                      IDESolverTest::n_t succ) {
-  cout << "IDESolverTest::getNormalFlowFunction()\n";
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
 IDESolverTest::getCallFlowFunction(IDESolverTest::n_t callStmt,
                                    IDESolverTest::m_t destMthd) {
-  cout << "IDESolverTest::getCallFlowFunction()\n";
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>> IDESolverTest::getRetFlowFunction(
     IDESolverTest::n_t callSite, IDESolverTest::m_t calleeMthd,
     IDESolverTest::n_t exitStmt, IDESolverTest::n_t retSite) {
-  cout << "IDESolverTest::getRetFlowFunction()\n";
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
@@ -64,7 +61,6 @@ shared_ptr<FlowFunction<IDESolverTest::d_t>>
 IDESolverTest::getCallToRetFlowFunction(IDESolverTest::n_t callSite,
                                         IDESolverTest::n_t retSite,
                                         set<IDESolverTest::m_t> callees) {
-  cout << "IDESolverTest::getCallToRetFlowFunction()\n";
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
@@ -101,14 +97,12 @@ IDESolverTest::getNormalEdgeFunction(IDESolverTest::n_t curr,
                                      IDESolverTest::d_t currNode,
                                      IDESolverTest::n_t succ,
                                      IDESolverTest::d_t succNode) {
-  cout << "IDESolverTest::getNormalEdgeFunction()\n";
   return EdgeIdentity<IDESolverTest::v_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::v_t>> IDESolverTest::getCallEdgeFunction(
     IDESolverTest::n_t callStmt, IDESolverTest::d_t srcNode,
     IDESolverTest::m_t destinationMethod, IDESolverTest::d_t destNode) {
-  cout << "IDESolverTest::getCallEdgeFunction()\n";
   return EdgeIdentity<IDESolverTest::v_t>::getInstance();
 }
 
@@ -119,7 +113,6 @@ IDESolverTest::getReturnEdgeFunction(IDESolverTest::n_t callSite,
                                      IDESolverTest::d_t exitNode,
                                      IDESolverTest::n_t reSite,
                                      IDESolverTest::d_t retNode) {
-  cout << "IDESolverTest::getReturnEdgeFunction()\n";
   return EdgeIdentity<IDESolverTest::v_t>::getInstance();
 }
 
@@ -129,7 +122,6 @@ IDESolverTest::getCallToRetEdgeFunction(IDESolverTest::n_t callSite,
                                         IDESolverTest::n_t retSite,
                                         IDESolverTest::d_t retSiteNode,
                                         set<IDESolverTest::m_t> callees) {
-  cout << "IDESolverTest::getCallToRetEdgeFunction()\n";
   return EdgeIdentity<IDESolverTest::v_t>::getInstance();
 }
 
@@ -138,7 +130,6 @@ IDESolverTest::getSummaryEdgeFunction(IDESolverTest::n_t callStmt,
                                       IDESolverTest::d_t callNode,
                                       IDESolverTest::n_t retSite,
                                       IDESolverTest::d_t retSiteNode) {
-  cout << "IDESolverTest::getSummaryEdgeFunction()\n";
   return EdgeIdentity<IDESolverTest::v_t>::getInstance();
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -54,9 +54,6 @@ IDETypeStateAnalysis::IDETypeStateAnalysis(IDETypeStateAnalysis::i_t icfg,
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
                                             IDETypeStateAnalysis::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getNormalFlowFunction()");
   // Check if Alloca's type matches the target type. If so, generate from zero
   // value.
   if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
@@ -128,9 +125,6 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t callStmt,
                                           IDETypeStateAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getCallFlowFunction()");
   // Kill all data-flow facts if we hit a function of the target API.
   // Those functions are modled within Call-To-Return.
   if (TSD.isAPIFunction(cxx_demangle(destMthd->getName().str()))) {
@@ -151,10 +145,6 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
                                          IDETypeStateAnalysis::m_t calleeMthd,
                                          IDETypeStateAnalysis::n_t exitStmt,
                                          IDETypeStateAnalysis::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getRetFlowFunction()");
-
   // Besides mapping the formal parameter back into the actual parameter and
   // propagating the return value into the caller context, we also propagate
   // all related alloca's of the formal parameter and the return value.
@@ -247,9 +237,6 @@ shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getCallToRetFlowFunction(
     IDETypeStateAnalysis::n_t callSite, IDETypeStateAnalysis::n_t retSite,
     set<IDETypeStateAnalysis::m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getCallToRetFlowFunction()");
   const llvm::ImmutableCallSite CS(callSite);
   for (auto Callee : callees) {
     std::string demangledFname = cxx_demangle(Callee->getName().str());
@@ -303,9 +290,6 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getSummaryFlowFunction(
     IDETypeStateAnalysis::n_t callStmt, IDETypeStateAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getSummaryFlowFunction()");
   return nullptr;
 }
 
@@ -335,19 +319,6 @@ shared_ptr<EdgeFunction<IDETypeStateAnalysis::v_t>>
 IDETypeStateAnalysis::getNormalEdgeFunction(
     IDETypeStateAnalysis::n_t curr, IDETypeStateAnalysis::d_t currNode,
     IDETypeStateAnalysis::n_t succ, IDETypeStateAnalysis::d_t succNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getNormalEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Curr Inst : " << IDETypeStateAnalysis::NtoString(curr));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Curr Node :   "
-                << IDETypeStateAnalysis::DtoString(currNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Succ Inst : " << IDETypeStateAnalysis::NtoString(succ));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Succ Node :   "
-                << IDETypeStateAnalysis::DtoString(succNode));
   // Set alloca instructions of target type to uninitialized.
   if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
     if (hasMatchingType(Alloca)) {
@@ -363,7 +334,7 @@ IDETypeStateAnalysis::getNormalEdgeFunction(
           }
 
           void print(std::ostream &OS, bool isForDebug = false) const override {
-            OS << "TSAllocaEF(" << TSD.stateToString(CurrentState) << ")";
+            OS << "Alloca(" << TSD.stateToString(CurrentState) << ")";
           }
         };
         return make_shared<TSAllocaEF>(TSD, "alloca instruction");
@@ -378,21 +349,6 @@ IDETypeStateAnalysis::getCallEdgeFunction(
     IDETypeStateAnalysis::n_t callStmt, IDETypeStateAnalysis::d_t srcNode,
     IDETypeStateAnalysis::m_t destinationMethod,
     IDETypeStateAnalysis::d_t destNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getCallEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Call Stmt : "
-                << IDETypeStateAnalysis::NtoString(callStmt));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Src Node  :   "
-                << IDETypeStateAnalysis::DtoString(srcNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(M) Callee    : "
-                << IDETypeStateAnalysis::MtoString(destinationMethod));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Dest Node :   "
-                << IDETypeStateAnalysis::DtoString(destNode));
   return EdgeIdentity<IDETypeStateAnalysis::v_t>::getInstance();
 }
 
@@ -401,27 +357,6 @@ IDETypeStateAnalysis::getReturnEdgeFunction(
     IDETypeStateAnalysis::n_t callSite, IDETypeStateAnalysis::m_t calleeMethod,
     IDETypeStateAnalysis::n_t exitStmt, IDETypeStateAnalysis::d_t exitNode,
     IDETypeStateAnalysis::n_t reSite, IDETypeStateAnalysis::d_t retNode) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getReturnEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Call Site : "
-                << IDETypeStateAnalysis::NtoString(callSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(M) Callee    : "
-                << IDETypeStateAnalysis::MtoString(calleeMethod));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Exit Stmt : "
-                << IDETypeStateAnalysis::NtoString(exitStmt));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Exit Node :   "
-                << IDETypeStateAnalysis::DtoString(exitNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Ret Site  : "
-                << IDETypeStateAnalysis::NtoString(reSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Ret Node  :   "
-                << IDETypeStateAnalysis::DtoString(retNode));
   return EdgeIdentity<IDETypeStateAnalysis::v_t>::getInstance();
 }
 
@@ -431,25 +366,6 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
     IDETypeStateAnalysis::n_t retSite, IDETypeStateAnalysis::d_t retSiteNode,
     std::set<IDETypeStateAnalysis::m_t> callees) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IDETypeStateAnalysis::getCallToRetEdgeFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Call Site : "
-                << IDETypeStateAnalysis::NtoString(callSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Call Node :   "
-                << IDETypeStateAnalysis::DtoString(callNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(N) Ret Site  : "
-                << IDETypeStateAnalysis::NtoString(retSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "(D) Ret Node  :   "
-                << IDETypeStateAnalysis::DtoString(retSiteNode));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "(M) Callees   : ");
-  for (auto Callee : callees) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                  << "  " << IDETypeStateAnalysis::MtoString(Callee));
-  }
   const llvm::ImmutableCallSite CS(callSite);
   for (auto Callee : callees) {
     std::string demangledFname = cxx_demangle(Callee->getName().str());
@@ -470,7 +386,7 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
           }
 
           void print(std::ostream &OS, bool isForDebug = false) const override {
-            OS << "TSFactoryEF(" << TSD.stateToString(CurrentState) << ")";
+            OS << "Factory(" << TSD.stateToString(CurrentState) << ")";
           }
         };
         return make_shared<TSFactoryEF>(TSD, demangledFname);
@@ -612,7 +528,7 @@ bool IDETypeStateAnalysis::TSEdgeFunction::equal_to(
 
 void IDETypeStateAnalysis::TSEdgeFunction::print(ostream &OS,
                                                  bool isForDebug) const {
-  OS << "TSEdgeFunc(" << TSD.stateToString(CurrentState) << ")";
+  OS << "TSEF(" << TSD.stateToString(CurrentState) << ")";
 }
 
 std::set<IDETypeStateAnalysis::d_t>

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -52,8 +52,6 @@ shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
 IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t curr,
                                          IFDSConstAnalysis::n_t succ) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::getNormalFlowFunction()");
   // Check all store instructions.
   if (const llvm::StoreInst *Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
     // If the store instruction sets up or updates the vtable, i.e. value
@@ -131,8 +129,6 @@ shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
 IFDSConstAnalysis::getCallFlowFunction(IFDSConstAnalysis::n_t callStmt,
                                        IFDSConstAnalysis::m_t destMthd) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::getCallFlowFunction()");
   // Handle one of the three llvm memory intrinsics (memcpy, memmove or memset)
   if (llvm::isa<llvm::MemIntrinsic>(callStmt)) {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
@@ -165,20 +161,6 @@ IFDSConstAnalysis::getRetFlowFunction(IFDSConstAnalysis::n_t callSite,
                                       IFDSConstAnalysis::n_t exitStmt,
                                       IFDSConstAnalysis::n_t retSite) {
   // return KillAll<IFDSConstAnalysis::d_t>::getInstance();
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::getRetFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Call site: " << llvmIRToString(callSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Caller context: "
-                << callSite->getFunction()->getName().str());
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Retrun site: " << llvmIRToString(retSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Callee method: " << calleeMthd->getName().str());
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Callee exit statement: " << llvmIRToString(exitStmt));
   // Map formal parameter back to the actual parameter in the caller.
   return make_shared<MapFactsToCaller>(
       llvm::ImmutableCallSite(callSite), calleeMthd, exitStmt,
@@ -196,12 +178,6 @@ IFDSConstAnalysis::getCallToRetFlowFunction(
     IFDSConstAnalysis::n_t callSite, IFDSConstAnalysis::n_t retSite,
     set<IFDSConstAnalysis::m_t> callees) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::getCallToRetFlowFunction()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Call site: " << llvmIRToString(callSite));
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Return site: " << llvmIRToString(retSite));
   // Process the effects of a llvm memory intrinsic function.
   if (llvm::isa<llvm::MemIntrinsic>(callSite)) {
     IFDSConstAnalysis::d_t pointerOp = callSite->getOperand(0);
@@ -233,18 +209,11 @@ IFDSConstAnalysis::getCallToRetFlowFunction(
 shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
 IFDSConstAnalysis::getSummaryFlowFunction(IFDSConstAnalysis::n_t callStmt,
                                           IFDSConstAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::getSummaryFlowFunction()");
-
   return nullptr;
 }
 
 map<IFDSConstAnalysis::n_t, set<IFDSConstAnalysis::d_t>>
 IFDSConstAnalysis::initialSeeds() {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSConstAnalysis::initialSeeds()");
   // just start in main()
   map<IFDSConstAnalysis::n_t, set<IFDSConstAnalysis::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSEnvironmentVariableTracing.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSEnvironmentVariableTracing.cpp
@@ -208,6 +208,10 @@ IFDSEnvironmentVariableTracing::initialSeeds() {
   for (const auto &entryPoint : this->EntryPoints) {
     if (taintConfig.isSink(entryPoint))
       continue;
+<<<<<<< HEAD
+=======
+
+>>>>>>> Revise solver output
     seedMap.insert(std::make_pair(&icfg.getMethod(entryPoint)->front().front(),
                                   std::set<ExtendedValue>({zeroValue()})));
   }

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSEnvironmentVariableTracing.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSEnvironmentVariableTracing.cpp
@@ -208,10 +208,6 @@ IFDSEnvironmentVariableTracing::initialSeeds() {
   for (const auto &entryPoint : this->EntryPoints) {
     if (taintConfig.isSink(entryPoint))
       continue;
-<<<<<<< HEAD
-=======
-
->>>>>>> Revise solver output
     seedMap.insert(std::make_pair(&icfg.getMethod(entryPoint)->front().front(),
                                   std::set<ExtendedValue>({zeroValue()})));
   }

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
@@ -57,9 +57,6 @@ shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getNormalFlowFunction(
     IFDSLinearConstantAnalysis::n_t curr,
     IFDSLinearConstantAnalysis::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSLinearConstantAnalysis::getNormalFlowFunction()");
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
@@ -67,9 +64,6 @@ shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getCallFlowFunction(
     IFDSLinearConstantAnalysis::n_t callStmt,
     IFDSLinearConstantAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSLinearConstantAnalysis::getCallFlowFunction()");
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
@@ -79,9 +73,6 @@ IFDSLinearConstantAnalysis::getRetFlowFunction(
     IFDSLinearConstantAnalysis::m_t calleeMthd,
     IFDSLinearConstantAnalysis::n_t exitStmt,
     IFDSLinearConstantAnalysis::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSLinearConstantAnalysis::getRetFlowFunction()");
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
@@ -90,9 +81,6 @@ IFDSLinearConstantAnalysis::getCallToRetFlowFunction(
     IFDSLinearConstantAnalysis::n_t callSite,
     IFDSLinearConstantAnalysis::n_t retSite,
     set<IFDSLinearConstantAnalysis::m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSLinearConstantAnalysis::getCallToRetFlowFunction()");
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
@@ -100,9 +88,6 @@ shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getSummaryFlowFunction(
     IFDSLinearConstantAnalysis::n_t callStmt,
     IFDSLinearConstantAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSLinearConstantAnalysis::getSummaryFlowFunction()");
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSProtoAnalysis.cpp
@@ -37,7 +37,6 @@ IFDSProtoAnalysis::IFDSProtoAnalysis(IFDSProtoAnalysis::i_t icfg,
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
 IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t curr,
                                          IFDSProtoAnalysis::n_t succ) {
-  cout << "IFDSProtoAnalysis::getNormalFlowFunction()\n";
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
     return make_shared<Gen<IFDSProtoAnalysis::d_t>>(
         Store->getPointerOperand(), DefaultIFDSTabulationProblem::zerovalue);
@@ -48,7 +47,6 @@ IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t curr,
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
 IFDSProtoAnalysis::getCallFlowFunction(IFDSProtoAnalysis::n_t callStmt,
                                        IFDSProtoAnalysis::m_t destMthd) {
-  cout << "IFDSProtoAnalysis::getCallFlowFunction()\n";
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
@@ -57,7 +55,6 @@ IFDSProtoAnalysis::getRetFlowFunction(IFDSProtoAnalysis::n_t callSite,
                                       IFDSProtoAnalysis::m_t calleeMthd,
                                       IFDSProtoAnalysis::n_t exitStmt,
                                       IFDSProtoAnalysis::n_t retSite) {
-  cout << "IFDSProtoAnalysis::getRetFlowFunction()\n";
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
@@ -65,14 +62,12 @@ shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
 IFDSProtoAnalysis::getCallToRetFlowFunction(
     IFDSProtoAnalysis::n_t callSite, IFDSProtoAnalysis::n_t retSite,
     set<IFDSProtoAnalysis::m_t> callees) {
-  cout << "IFDSProtoAnalysis::getCallToRetFlowFunction()\n";
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
 IFDSProtoAnalysis::getSummaryFlowFunction(IFDSProtoAnalysis::n_t callStmt,
                                           IFDSProtoAnalysis::m_t destMthd) {
-  cout << "IFDSProtoAnalysis::getSummaryFlowFunction()\n";
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSSignAnalysis.cpp
@@ -36,14 +36,12 @@ IFDSSignAnalysis::IFDSSignAnalysis(IFDSSignAnalysis::i_t icfg,
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
 IFDSSignAnalysis::getNormalFlowFunction(IFDSSignAnalysis::n_t curr,
                                         IFDSSignAnalysis::n_t succ) {
-  cout << "IFDSSignAnalysis::getNormalFlowFunction()\n";
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
 IFDSSignAnalysis::getCallFlowFunction(IFDSSignAnalysis::n_t callStmt,
                                       IFDSSignAnalysis::m_t destMthd) {
-  cout << "IFDSSignAnalysis::getCallFlowFunction()\n";
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
@@ -52,7 +50,6 @@ IFDSSignAnalysis::getRetFlowFunction(IFDSSignAnalysis::n_t callSite,
                                      IFDSSignAnalysis::m_t calleeMthd,
                                      IFDSSignAnalysis::n_t exitStmt,
                                      IFDSSignAnalysis::n_t retSite) {
-  cout << "IFDSSignAnalysis::getRetFlowFunction()\n";
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
@@ -60,14 +57,12 @@ shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
 IFDSSignAnalysis::getCallToRetFlowFunction(IFDSSignAnalysis::n_t callSite,
                                            IFDSSignAnalysis::n_t retSite,
                                            set<IFDSSignAnalysis::m_t> callees) {
-  cout << "IFDSSignAnalysis::getCallToRetFlowFunction()\n";
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
 IFDSSignAnalysis::getSummaryFlowFunction(IFDSSignAnalysis::n_t callStmt,
                                          IFDSSignAnalysis::m_t destMthd) {
-  cout << "IFDSSignAnalysis::getSummaryFlowFunction()\n";
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -36,18 +36,12 @@ IFDSSolverTest::IFDSSolverTest(IFDSSolverTest::i_t icfg,
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
 IFDSSolverTest::getNormalFlowFunction(IFDSSolverTest::n_t curr,
                                       IFDSSolverTest::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSSolverTest::getNormalFlowFunction()");
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
 IFDSSolverTest::getCallFlowFunction(IFDSSolverTest::n_t callStmt,
                                     IFDSSolverTest::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSSolverTest::getCallFlowFunction()");
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
@@ -56,9 +50,6 @@ IFDSSolverTest::getRetFlowFunction(IFDSSolverTest::n_t callSite,
                                    IFDSSolverTest::m_t calleeMthd,
                                    IFDSSolverTest::n_t exitStmt,
                                    IFDSSolverTest::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSSolverTest::getRetFlowFunction()");
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
@@ -66,9 +57,6 @@ shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
 IFDSSolverTest::getCallToRetFlowFunction(IFDSSolverTest::n_t callSite,
                                          IFDSSolverTest::n_t retSite,
                                          set<IFDSSolverTest::m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSSolverTest::getCallToRetFlowFunction()");
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -44,9 +44,6 @@ IFDSTaintAnalysis::IFDSTaintAnalysis(
 shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
 IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t curr,
                                          IFDSTaintAnalysis::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSTaintAnalysis::getNormalFlowFunction()");
   // If a tainted value is stored, the store location must be tainted too
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
     struct TAFF : FlowFunction<IFDSTaintAnalysis::d_t> {
@@ -89,9 +86,6 @@ IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t curr,
 shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
 IFDSTaintAnalysis::getCallFlowFunction(IFDSTaintAnalysis::n_t callStmt,
                                        IFDSTaintAnalysis::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSTaintAnalysis::getCallFlowFunction()");
   string FunctionName = cxx_demangle(destMthd->getName().str());
   // Check if a source or sink function is called:
   // We then can kill all data-flow facts not following the called function.
@@ -116,9 +110,6 @@ IFDSTaintAnalysis::getRetFlowFunction(IFDSTaintAnalysis::n_t callSite,
                                       IFDSTaintAnalysis::m_t calleeMthd,
                                       IFDSTaintAnalysis::n_t exitStmt,
                                       IFDSTaintAnalysis::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSTaintAnalysis::getRetFlowFunction()");
   // We must check if the return value and formal parameter are tainted, if so
   // we must taint all user's of the function call. We are only interested in
   // formal parameters of pointer/reference type.
@@ -135,8 +126,6 @@ IFDSTaintAnalysis::getCallToRetFlowFunction(
     IFDSTaintAnalysis::n_t callSite, IFDSTaintAnalysis::n_t retSite,
     set<IFDSTaintAnalysis::m_t> callees) {
   auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSTaintAnalysis::getCallToRetFlowFunction()");
   // Process the effects of source or sink functions that are called
   for (auto *Callee : icfg.getCalleesOfCallAt(callSite)) {
     string FunctionName = cxx_demangle(Callee->getName().str());

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSTypeAnalysis.cpp
@@ -32,7 +32,6 @@ IFDSTypeAnalysis::IFDSTypeAnalysis(IFDSTypeAnalysis::i_t icfg,
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
 IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t curr,
                                         IFDSTypeAnalysis::n_t succ) {
-  cout << "type analysis getNormalFlowFunction()" << endl;
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
     computeTargets(IFDSTypeAnalysis::d_t source) override {
@@ -45,7 +44,6 @@ IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t curr,
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
 IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t callStmt,
                                       IFDSTypeAnalysis::m_t destMthd) {
-  cout << "type analysis getCallFlowFunction()" << endl;
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
     computeTargets(IFDSTypeAnalysis::d_t source) override {
@@ -60,7 +58,6 @@ IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
                                      IFDSTypeAnalysis::m_t calleeMthd,
                                      IFDSTypeAnalysis::n_t exitStmt,
                                      IFDSTypeAnalysis::n_t retSite) {
-  cout << "type analysis getRetFlowFunction()" << endl;
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
     computeTargets(IFDSTypeAnalysis::d_t source) override {
@@ -74,7 +71,6 @@ shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
 IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
                                            IFDSTypeAnalysis::n_t retSite,
                                            set<IFDSTypeAnalysis::m_t> callees) {
-  cout << "type analysis getCallToRetFlowFunction()" << endl;
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
     computeTargets(IFDSTypeAnalysis::d_t source) override {

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -44,9 +44,6 @@ shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getNormalFlowFunction(
     IFDSUninitializedVariables::n_t curr,
     IFDSUninitializedVariables::n_t succ) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSUninitializedVariables::getNormalFlowFunction()");
   //----------------------------------------------------------------------------------
   // Why do we need this case?
   // Every alloca is reached eventually by this function
@@ -237,9 +234,6 @@ shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getCallFlowFunction(
     IFDSUninitializedVariables::n_t callStmt,
     IFDSUninitializedVariables::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSUninitializedVariables::getCallFlowFunction()");
   if (llvm::isa<llvm::CallInst>(callStmt) ||
       llvm::isa<llvm::InvokeInst>(callStmt)) {
     llvm::ImmutableCallSite callSite(callStmt);
@@ -324,9 +318,6 @@ IFDSUninitializedVariables::getRetFlowFunction(
     IFDSUninitializedVariables::m_t calleeMthd,
     IFDSUninitializedVariables::n_t exitStmt,
     IFDSUninitializedVariables::n_t retSite) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSUninitializedVariables::getRetFlowFunction()");
   if (llvm::isa<llvm::CallInst>(callSite) ||
       llvm::isa<llvm::InvokeInst>(callSite)) {
     llvm::ImmutableCallSite CS(callSite);
@@ -371,9 +362,6 @@ IFDSUninitializedVariables::getCallToRetFlowFunction(
     IFDSUninitializedVariables::n_t callSite,
     IFDSUninitializedVariables::n_t retSite,
     set<IFDSUninitializedVariables::m_t> callees) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSUninitializedVariables::getCallToRetFlowFunction()");
   //----------------------------------------------------------------------
   // Handle pointer/reference parameters
   //----------------------------------------------------------------------
@@ -402,9 +390,6 @@ shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getSummaryFlowFunction(
     IFDSUninitializedVariables::n_t callStmt,
     IFDSUninitializedVariables::m_t destMthd) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "IFDSUninitializedVariables::getSummaryFlowFunction()");
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -438,12 +438,12 @@ bool IFDSUninitializedVariables::isZeroValue(
 
 void IFDSUninitializedVariables::printNode(
     ostream &os, IFDSUninitializedVariables::n_t n) const {
-  os << llvmIRToString(n);
+  os << llvmIRToShortString(n);
 }
 
 void IFDSUninitializedVariables::printDataFlowFact(
     ostream &os, IFDSUninitializedVariables::d_t d) const {
-  os << llvmIRToString(d);
+  os << llvmIRToShortString(d);
 }
 
 void IFDSUninitializedVariables::printMethod(

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsPass.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsPass.cpp
@@ -151,7 +151,7 @@ bool GeneralStatisticsPass::doFinalization(llvm::Module &M) {
   if (bl::core::get()->get_logging_enabled()) {
     auto &lg = lg::get();
     BOOST_LOG_SEV(lg, INFO) << "GeneralStatisticsPass summary for module: '"
-                            << M.getName().str() << "'\n";
+                            << M.getName().str() << "'";
     BOOST_LOG_SEV(lg, INFO) << "Allocated Types    : " << allocatedTypes.size();
     BOOST_LOG_SEV(lg, INFO) << "Allocation Sites   : " << allocationsites;
     BOOST_LOG_SEV(lg, INFO) << "Basic Blocks       : " << basicblocks;

--- a/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
+++ b/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
@@ -58,8 +58,9 @@ AnalysisPluginController::AnalysisPluginController(
             Problem.second(ICFG, EntryPoints));
         cout << "DONE" << endl;
         LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmifdstestsolver(
-            *plugin, true);
+            *plugin);
         llvmifdstestsolver.solve();
+        llvmifdstestsolver.dumpResults();
         FinalResultsJson += llvmifdstestsolver.getAsJson();
       }
     }

--- a/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
@@ -49,14 +49,12 @@ IFDSSFB901TaintAnalysis::IFDSSFB901TaintAnalysis(LLVMBasedICFG &I,
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
                                                const llvm::Instruction *succ) {
-  cout << "IFDSSFB901TaintAnalysis::getNormalFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getCallFlowFunction(const llvm::Instruction *callStmt,
                                              const llvm::Function *destMthd) {
-  cout << "IFDSSFB901TaintAnalysis::getCallFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
@@ -65,7 +63,6 @@ IFDSSFB901TaintAnalysis::getRetFlowFunction(const llvm::Instruction *callSite,
                                             const llvm::Function *calleeMthd,
                                             const llvm::Instruction *exitStmt,
                                             const llvm::Instruction *retSite) {
-  cout << "IFDSSFB901TaintAnalysis::getRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
@@ -73,14 +70,12 @@ shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getCallToRetFlowFunction(
     const llvm::Instruction *callSite, const llvm::Instruction *retSite,
     set<const llvm::Function *> callees) {
-  cout << "IFDSSFB901TaintAnalysis::getCallToRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *callStmt, const llvm::Function *destMthd) {
-  cout << "IFDSSFB901TaintAnalysis::getSummaryFlowFunction()\n";
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
@@ -54,7 +54,6 @@ IFDSSimpleTaintAnalysis::IFDSSimpleTaintAnalysis(LLVMBasedICFG &I,
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
                                                const llvm::Instruction *succ) {
-  cout << "IFDSSimpleTaintAnalysis::getNormalFlowFunction()\n";
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
     struct STA : FlowFunction<const llvm::Value *> {
       const llvm::StoreInst *Store;
@@ -75,7 +74,6 @@ IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *callStmt,
                                              const llvm::Function *destMthd) {
-  cout << "IFDSSimpleTaintAnalysis::getCallFlowFunction()\n";
   if (auto Call = llvm::dyn_cast<llvm::CallInst>(callStmt)) {
     if (destMthd->getName().str() == "taint") {
       return make_shared<Gen<const llvm::Value *>>(Call, zeroValue());
@@ -91,7 +89,6 @@ IFDSSimpleTaintAnalysis::getRetFlowFunction(const llvm::Instruction *callSite,
                                             const llvm::Function *calleeMthd,
                                             const llvm::Instruction *exitStmt,
                                             const llvm::Instruction *retSite) {
-  cout << "IFDSSimpleTaintAnalysis::getRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
@@ -99,14 +96,12 @@ shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getCallToRetFlowFunction(
     const llvm::Instruction *callSite, const llvm::Instruction *retSite,
     set<const llvm::Function *> callees) {
-  cout << "IFDSSimpleTaintAnalysis::getCallToRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *callStmt, const llvm::Function *destMthd) {
-  cout << "IFDSSimpleTaintAnalysis::getSummaryFlowFunction()\n";
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
@@ -51,14 +51,12 @@ IFDSTabulationProblemTestPlugin::IFDSTabulationProblemTestPlugin(
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getNormalFlowFunction(
     const llvm::Instruction *curr, const llvm::Instruction *succ) {
-  cout << "IFDSTabulationProblemTestPlugin::getNormalFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getCallFlowFunction(
     const llvm::Instruction *callStmt, const llvm::Function *destMthd) {
-  cout << "IFDSTabulationProblemTestPlugin::getCallFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
@@ -66,7 +64,6 @@ shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getRetFlowFunction(
     const llvm::Instruction *callSite, const llvm::Function *calleeMthd,
     const llvm::Instruction *exitStmt, const llvm::Instruction *retSite) {
-  cout << "IFDSTabulationProblemTestPlugin::getRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
@@ -74,14 +71,12 @@ shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getCallToRetFlowFunction(
     const llvm::Instruction *callSite, const llvm::Instruction *retSite,
     set<const llvm::Function *> callees) {
-  cout << "IFDSTabulationProblemTestPlugin::getCallToRetFlowFunction()\n";
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getSummaryFlowFunction(
     const llvm::Instruction *callStmt, const llvm::Function *destMthd) {
-  cout << "IFDSTabulationProblemTestPlugin::getSummaryFlowFunction()\n";
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -183,17 +183,14 @@ void DOTFunctionSubGraph::createLayoutFactNodes() {
   }
 }
 
-// TODO: this seems to be buggy
 void DOTFunctionSubGraph::createLayoutFactEdges() {
   for (auto &[key, factSG] : facts) {
-    auto last = factSG.nodes.empty() ? factSG.nodes.end()
-                                     : std::prev(factSG.nodes.end());
-    // Check cf edges not only nodes!
-    for (auto firstIt = factSG.nodes.begin(); firstIt != last; ++firstIt) {
-      auto secondIt = std::next(firstIt);
-      DOTNode n1 = firstIt->second;
-      DOTNode n2 = secondIt->second;
-      factSG.edges.emplace(n1, n2, false);
+    for (auto iCFE : intraCFEdges) {
+      DOTNode d1 = {iCFE.source.funcName, factSG.label, iCFE.source.stmtId,
+                    factSG.factId, false};
+      DOTNode d2 = {iCFE.target.funcName, factSG.label, iCFE.target.stmtId,
+                    factSG.factId, false};
+      factSG.edges.emplace(d1, d2, false);
     }
   }
 }
@@ -208,7 +205,7 @@ bool operator<(const DOTNode &lhs, const DOTNode &rhs) {
       return strLess(lhs.stmtId, rhs.stmtId);
     } else {
       return lhs.factId < rhs.factId;
-}
+    }
   }
 }
 

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -1,0 +1,259 @@
+/******************************************************************************
+ * Copyright (c) 2017 Philipp Schubert.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+/*
+ * DOTGraph.cpp
+ *
+ *  Created on: 31.08.2019
+ *      Author: rleer
+ */
+
+#include <algorithm>
+#include <iterator>
+#include <ostream>
+#include <stdlib.h>
+
+#include <phasar/PhasarLLVM/Utils/DOTGraph.h>
+
+namespace psr {
+
+bool cmpStmtIdByValue::operator()(const std::string &lhs,
+                                  const std::string &rhs) const {
+  char *endptr1, *endptr2;
+  long lhs_val = strtol(lhs.c_str(), &endptr1, 10);
+  long rhs_val = strtol(rhs.c_str(), &endptr2, 10);
+  if (lhs.c_str() == endptr1 && lhs.c_str() == endptr2) {
+    return lhs < rhs;
+  } else if (lhs.c_str() == endptr1 && rhs.c_str() != endptr2) {
+    return false;
+  } else if (lhs.c_str() != endptr1 && rhs.c_str() == endptr2) {
+    return true;
+  } else {
+    return lhs_val < rhs_val;
+  }
+}
+
+DOTNode::DOTNode(std::string fName, std::string l, std::string sId,
+                 unsigned fId, bool isStmt, bool isv)
+    : funcName(fName), label(l), stmtId(sId), factId(fId), isVisible(isv) {
+  if (isStmt) {
+    id = funcName + '_' + stmtId;
+  } else {
+    id = funcName + '_' + std::to_string(factId) + '_' + stmtId;
+  }
+}
+
+std::string DOTNode::str(std::string indent) const {
+  std::string str =
+      indent + id + " [label=\"" + label; // + " | SID: " + stmtId + "\"";
+  if (factId) {
+    str += " | SID: " + stmtId;
+  }
+  str += "\"";
+  if (!isVisible) {
+    str += ", style=invis";
+  }
+  return str + ']';
+}
+
+DOTEdge::DOTEdge(DOTNode src, DOTNode tar, bool isv, std::string efl,
+                 std::string vl)
+    : source(src), target(tar), isVisible(isv), edgeFnLabel(efl),
+      valueLabel(vl) {}
+
+std::string DOTEdge::str(std::string indent) const {
+  std::string str = indent + source.id + " -> " + target.id;
+  if (isVisible) {
+    if (!edgeFnLabel.empty() && !valueLabel.empty()) {
+      str += " [headlabel=\"\\r" + edgeFnLabel + "\", taillabel=\"" +
+             valueLabel + "\"]";
+    } else if (!edgeFnLabel.empty()) {
+      str += " [headlabel=\"\\r" + edgeFnLabel + "\"]";
+    } else if (!valueLabel.empty()) {
+      str += " [taillabel=\"" + valueLabel + "\"]";
+    }
+  } else if (!isVisible) {
+    str += " [style=invis]";
+  }
+  return str;
+}
+
+std::string DOTFactSubGraph::str(std::string indent) const {
+  std::string innerIndent = indent + "  ";
+  std::string str = indent + "subgraph cluster_" + id + " {\n" + innerIndent +
+                    "style=invis\n" + innerIndent + "label=\"" + label +
+                    "\"\n\n" + innerIndent + "// Fact nodes in the ESG\n" +
+                    innerIndent + DOTConfig::FactNodeAttr() + '\n';
+  // Print fact nodes
+  for (auto n : nodes) {
+    str += n.second.str(innerIndent) + '\n';
+  }
+  // Print id edges
+  str += '\n' + innerIndent + "// Identity edges for this fact\n" +
+         innerIndent + DOTConfig::FactIdentityEdgeAttr() + '\n';
+  for (DOTEdge e : edges) {
+    str += e.str(innerIndent) + '\n';
+  }
+  return str + indent + '}';
+}
+
+std::string DOTFunctionSubGraph::str(std::string indent) const {
+  std::string innerIndent = indent + "  ";
+  std::string str = indent + "subgraph cluster_" + id + " {\n" + innerIndent +
+                    "label=\"" + id + "\"";
+  // Print control flow nodes
+  str += "\n\n" + innerIndent + "// Control flow nodes\n" + innerIndent +
+         DOTConfig::CFNodeAttr() + '\n';
+  for (DOTNode stmt : stmts) {
+    str += stmt.str(innerIndent) + '\n';
+  }
+
+  // Print fact subgraphs
+  str += '\n' + innerIndent + "// Fact subgraphs\n";
+  for (auto factSG : facts) {
+    str += factSG.second.str(innerIndent) + "\n\n";
+  }
+
+  // Print lambda subgraph
+  str += generateLambdaSG(innerIndent);
+
+  // Print intra control flow edges
+  str += "\n\n" + innerIndent + "// Intra-procedural control flow edges\n" +
+         innerIndent + DOTConfig::CFIntraEdgeAttr() + '\n';
+  for (DOTEdge e : intraCFEdges) {
+    str += e.str(innerIndent) + '\n';
+  }
+
+  // Print intra cross fact edges
+  str += '\n' + innerIndent + "// Intra-procedural cross fact edges\n" +
+         innerIndent + DOTConfig::FactCrossEdgeAttr() + '\n';
+  for (DOTEdge e : crossFactEdges) {
+    str += e.str(innerIndent) + '\n';
+  }
+  return str + indent + '}';
+}
+
+DOTFactSubGraph *DOTFunctionSubGraph::getOrCreateFactSG(unsigned factID,
+                                                        std::string &label) {
+  DOTFactSubGraph *FuncSG = &facts[factID];
+  if (FuncSG->id.empty()) {
+    FuncSG->id = id + '_' + std::to_string(factID);
+    FuncSG->factId = factID;
+    FuncSG->label = label;
+  }
+  return FuncSG;
+}
+
+std::string DOTFunctionSubGraph::generateLambdaSG(std::string indent) const {
+  std::string innerIndent = indent + "  ";
+  std::string str = indent + "// Auto-generated lambda nodes and edges\n" +
+                    indent + "subgraph cluster_" + id + "_lambda {\n" +
+                    innerIndent + "style=invis\n" + innerIndent +
+                    "label=\"Λ\"\n" + innerIndent + DOTConfig::FactNodeAttr() +
+                    '\n';
+  // Print lambda nodes
+  for (DOTNode stmt : stmts) {
+    str += innerIndent + id + "_0_" + stmt.stmtId + " [label=\"Λ\"]\n";
+  }
+  // Print lambda edges
+  str += '\n' + innerIndent + DOTConfig::FactIdentityEdgeAttr() + '\n';
+  for (DOTEdge e : intraCFEdges) {
+    str += innerIndent + id + "_0_" + e.source.stmtId + " -> " + id + "_0_" +
+           e.target.stmtId;
+    if (e.isVisible) {
+      str += " [headlabel=\"\\rAllBottom\", taillabel=\"BOT\"]\n";
+    } else {
+      str += " [style=invis]\n";
+    }
+  }
+  return str + indent + '}';
+}
+
+void DOTFunctionSubGraph::createLayoutCFNodes() {
+  auto last = stmts.empty() ? stmts.end() : std::prev(stmts.end());
+  for (auto firstIt = stmts.begin(); firstIt != last; ++firstIt) {
+    auto secondIt = std::next(firstIt);
+    DOTNode n1 = *firstIt;
+    DOTNode n2 = *secondIt;
+    intraCFEdges.emplace(n1, n2, false);
+  }
+}
+
+void DOTFunctionSubGraph::createLayoutFactNodes() {
+  for (auto &[key, factSG] : facts) {
+    for (auto stmt : stmts) {
+      if (factSG.nodes.find(stmt.stmtId) == factSG.nodes.end()) {
+        DOTNode factNode(stmt.funcName, factSG.label, stmt.stmtId,
+                         factSG.factId, false, false);
+        factSG.nodes[stmt.stmtId] = factNode;
+      }
+    }
+  }
+}
+
+// TODO: this seems to be buggy
+void DOTFunctionSubGraph::createLayoutFactEdges() {
+  for (auto &[key, factSG] : facts) {
+    auto last = factSG.nodes.empty() ? factSG.nodes.end()
+                                     : std::prev(factSG.nodes.end());
+    // Check cf edges not only nodes!
+    for (auto firstIt = factSG.nodes.begin(); firstIt != last; ++firstIt) {
+      auto secondIt = std::next(firstIt);
+      DOTNode n1 = firstIt->second;
+      DOTNode n2 = secondIt->second;
+      factSG.edges.emplace(n1, n2, false);
+    }
+  }
+}
+
+bool operator<(const DOTNode &lhs, const DOTNode &rhs) {
+  char *endptr1, *endptr2;
+  long lhs_sId = strtol(lhs.stmtId.c_str(), &endptr1, 10);
+  long rhs_sId = strtol(rhs.stmtId.c_str(), &endptr2, 10);
+  return lhs_sId < rhs_sId;
+}
+
+bool operator==(const DOTNode &lhs, const DOTNode &rhs) {
+  return !(lhs < rhs) && !(rhs < lhs);
+}
+
+std::ostream &operator<<(std::ostream &os, const DOTNode &node) {
+  return os << node.str();
+}
+
+bool operator<(const DOTEdge &lhs, const DOTEdge &rhs) {
+  if (lhs.source == rhs.source) {
+    return lhs.target < rhs.target;
+  }
+  return lhs.source < rhs.source;
+}
+
+std::ostream &operator<<(std::ostream &os, const DOTEdge &edge) {
+  return os << edge.str();
+}
+
+std::ostream &operator<<(std::ostream &os, const DOTFactSubGraph &factSG) {
+  return os << factSG.str();
+}
+
+std::ostream &operator<<(std::ostream &os,
+                         const DOTFunctionSubGraph &functionSG) {
+  return os << functionSG.str();
+}
+
+// std::ostream &operator<<(std::ostream &os, const DOTGraph &graph) {
+//   return os << graph.str();
+// }
+
+DOTConfig &DOTConfig::getDOTConfig() {
+  static DOTConfig DC;
+  return DC;
+}
+
+} // namespace psr

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -17,27 +17,10 @@
 #include <algorithm>
 #include <iterator>
 #include <ostream>
-#include <stdlib.h>
 
 #include <phasar/PhasarLLVM/Utils/DOTGraph.h>
 
 namespace psr {
-
-bool cmpStmtIdByValue::operator()(const std::string &lhs,
-                                  const std::string &rhs) const {
-  char *endptr1, *endptr2;
-  long lhs_val = strtol(lhs.c_str(), &endptr1, 10);
-  long rhs_val = strtol(rhs.c_str(), &endptr2, 10);
-  if (lhs.c_str() == endptr1 && lhs.c_str() == endptr2) {
-    return lhs < rhs;
-  } else if (lhs.c_str() == endptr1 && rhs.c_str() != endptr2) {
-    return false;
-  } else if (lhs.c_str() != endptr1 && rhs.c_str() == endptr2) {
-    return true;
-  } else {
-    return lhs_val < rhs_val;
-  }
-}
 
 DOTNode::DOTNode(std::string fName, std::string l, std::string sId,
                  unsigned fId, bool isStmt, bool isv)
@@ -213,10 +196,17 @@ void DOTFunctionSubGraph::createLayoutFactEdges() {
 }
 
 bool operator<(const DOTNode &lhs, const DOTNode &rhs) {
-  char *endptr1, *endptr2;
-  long lhs_sId = strtol(lhs.stmtId.c_str(), &endptr1, 10);
-  long rhs_sId = strtol(rhs.stmtId.c_str(), &endptr2, 10);
-  return lhs_sId < rhs_sId;
+  stringIDLess strLess;
+  // comparing control flow nodes
+  if (lhs.factId == 0 && rhs.factId == 0) {
+    return strLess(lhs.stmtId, rhs.stmtId);
+  } else { // comparing fact nodes
+    if (lhs.factId == rhs.factId) {
+      return strLess(lhs.stmtId, rhs.stmtId);
+    } else {
+      return lhs.factId < rhs.factId;
+}
+  }
 }
 
 bool operator==(const DOTNode &lhs, const DOTNode &rhs) {
@@ -246,10 +236,6 @@ std::ostream &operator<<(std::ostream &os,
                          const DOTFunctionSubGraph &functionSG) {
   return os << functionSG.str();
 }
-
-// std::ostream &operator<<(std::ostream &os, const DOTGraph &graph) {
-//   return os << graph.str();
-// }
 
 DOTConfig &DOTConfig::getDOTConfig() {
   static DOTConfig DC;

--- a/lib/PhasarPass/PhasarPass.cpp
+++ b/lib/PhasarPass/PhasarPass.cpp
@@ -76,69 +76,101 @@ bool PhasarPass::runOnModule(llvm::Module &M) {
   if (DataFlowAnalysis == "ifds-solvertest") {
     IFDSSolverTest ifdstest(I, H, DB, EntryPoints);
     LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmifdstestsolver(
-        ifdstest, DumpResults);
+        ifdstest);
     llvmifdstestsolver.solve();
+    if (DumpResults) {
+      llvmifdstestsolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ide-solvertest") {
     IDESolverTest idetest(I, H, DB, EntryPoints);
     LLVMIDESolver<const llvm::Value *, const llvm::Value *, LLVMBasedICFG &>
-        llvmidetestsolver(idetest, DumpResults);
+        llvmidetestsolver(idetest);
     llvmidetestsolver.solve();
+    if (DumpResults) {
+      llvmidetestsolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "intra-mono-solvertest") {
     const llvm::Function *F = DB.getFunction(EntryPoints.front());
     IntraMonoSolverTest intra(CFG, F);
-    LLVMIntraMonoSolver<const llvm::Value *, LLVMBasedCFG &> solver(
-        intra, DumpResults);
+    LLVMIntraMonoSolver<const llvm::Value *, LLVMBasedCFG &> solver(intra);
     solver.solve();
+    if (DumpResults) {
+      solver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "inter-mono-solvertest") {
     const llvm::Function *F = DB.getFunction(EntryPoints.front());
     InterMonoSolverTest inter(I, EntryPoints);
-    LLVMInterMonoSolver<const llvm::Value *, LLVMBasedICFG &, 0> solver(inter,
-                                                                        true);
-
+    LLVMInterMonoSolver<const llvm::Value *, LLVMBasedICFG &, 0> solver(inter);
     solver.solve();
+    if (DumpResults) {
+      solver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ifds-const") {
     IFDSConstAnalysis constproblem(I, H, DB, DB.getAllMemoryLocations(),
                                    EntryPoints);
     LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-        constproblem, DumpResults);
+        constproblem);
     llvmconstsolver.solve();
+    if (DumpResults) {
+      llvmconstsolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ifds-lca") {
     IFDSLinearConstantAnalysis lcaproblem(I, H, DB, EntryPoints);
-    LLVMIFDSSolver<LCAPair, LLVMBasedICFG &> llvmlcasolver(lcaproblem,
-                                                           DumpResults);
+    LLVMIFDSSolver<LCAPair, LLVMBasedICFG &> llvmlcasolver(lcaproblem);
     llvmlcasolver.solve();
+    if (DumpResults) {
+      llvmlcasolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ifds-taint") {
     TaintConfiguration<const llvm::Value *> TSF;
     IFDSTaintAnalysis TaintAnalysisProblem(I, H, DB, TSF, EntryPoints);
     LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> LLVMTaintSolver(
-        TaintAnalysisProblem, DumpResults);
+        TaintAnalysisProblem);
     LLVMTaintSolver.solve();
+    if (DumpResults) {
+      LLVMTaintSolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ifds-type") {
     IFDSTypeAnalysis typeanalysisproblem(I, H, DB, EntryPoints);
     LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmtypesolver(
-        typeanalysisproblem, DumpResults);
+        typeanalysisproblem);
     llvmtypesolver.solve();
+    if (DumpResults) {
+      llvmtypesolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ifds-uninit") {
     IFDSUninitializedVariables uninitializedvarproblem(I, H, DB, EntryPoints);
     LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmunivsolver(
-        uninitializedvarproblem, DumpResults);
+        uninitializedvarproblem);
     llvmunivsolver.solve();
+    if (DumpResults) {
+      llvmunivsolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ide-lca") {
     IDELinearConstantAnalysis lcaproblem(I, H, DB, EntryPoints);
     LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-        lcaproblem, DumpResults);
+        lcaproblem);
     llvmlcasolver.solve();
+    if (DumpResults) {
+      llvmlcasolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ide-taint") {
     IDETaintAnalysis taintanalysisproblem(I, H, DB, EntryPoints);
     LLVMIDESolver<const llvm::Value *, const llvm::Value *, LLVMBasedICFG &>
-        llvmtaintsolver(taintanalysisproblem, DumpResults);
+        llvmtaintsolver(taintanalysisproblem);
     llvmtaintsolver.solve();
+    if (DumpResults) {
+      llvmtaintsolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "ide-typestate") {
     CSTDFILEIOTypeStateDescription fileIODesc;
     IDETypeStateAnalysis typestateproblem(I, H, DB, fileIODesc, EntryPoints);
     LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &>
-        llvmtypestatesolver(typestateproblem, DumpResults);
+        llvmtypestatesolver(typestateproblem);
     llvmtypestatesolver.solve();
+    if (DumpResults) {
+      llvmtypestatesolver.dumpResults();
+    }
   } else if (DataFlowAnalysis == "intra-mono-fullconstantpropagation") {
     // todo
   } else if (DataFlowAnalysis == "inter-mono-taint") {

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -222,8 +222,8 @@ bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2) {
   char *endptr1, *endptr2;
   std::string id1 = getMetaDataID(V1);
   std::string id2 = getMetaDataID(V2);
-  long val1 = strtol(id1.c_str(),&endptr1,10);
-  long val2 = strtol(id2.c_str(),&endptr2,10);
+  long val1 = strtol(id1.c_str(), &endptr1, 10);
+  long val2 = strtol(id2.c_str(), &endptr2, 10);
   // both values have string ID's, i.e. are of Argument type
   if (id1.c_str() == endptr1 && id2.c_str() == endptr2) {
     return id1 < id2;

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -33,6 +33,8 @@
 #include <phasar/Utils/LLVMShorthands.h>
 #include <phasar/Utils/Macros.h>
 
+#include <stdlib.h>
+
 using namespace std;
 using namespace psr;
 
@@ -152,7 +154,7 @@ std::string llvmIRToString(const llvm::Value *V) {
   std::string IRBuffer;
   llvm::raw_string_ostream RSO(IRBuffer);
   V->print(RSO);
-  RSO << ", ID: " << getMetaDataID(V);
+  RSO << " | ID: " << getMetaDataID(V);
   RSO.flush();
   boost::trim_left(IRBuffer);
   return IRBuffer;
@@ -214,6 +216,24 @@ std::string getMetaDataID(const llvm::Value *V) {
     return string(FName + "." + ArgNr);
   }
   return "-1";
+}
+
+bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2) {
+  char *endptr1, *endptr2;
+  std::string id1 = getMetaDataID(V1);
+  std::string id2 = getMetaDataID(V2);
+  long val1 = strtol(id1.c_str(),&endptr1,10);
+  long val2 = strtol(id2.c_str(),&endptr2,10);
+  // both values have string ID's, i.e. are of Argument type
+  if (id1.c_str() == endptr1 && id2.c_str() == endptr2) {
+    return id1 < id2;
+  } else if (id1.c_str() == endptr1 && id2.c_str() != endptr2) {
+    return false;
+  } else if (id1.c_str() != endptr1 && id2.c_str() == endptr2) {
+    return true;
+  } else {
+    return val1 < val2;
+  }
 }
 
 int getFunctionArgumentNr(const llvm::Argument *Arg) {

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -158,6 +158,26 @@ std::string llvmIRToString(const llvm::Value *V) {
   return IRBuffer;
 }
 
+std::string llvmIRToShortString(const llvm::Value *V) {
+  // WARNING: Expensive function, cause is the V->print(RSO)
+  //         (20ms on a medium size code (phasar without debug)
+  //          80ms on a huge size code (clang without debug),
+  //          can be multiplied by times 3 to 5 if passes are enabled)
+  std::string IRBuffer;
+  llvm::raw_string_ostream RSO(IRBuffer);
+  V->print(RSO);
+  boost::trim_left(IRBuffer);
+  RSO.flush();
+  if (IRBuffer.find(", align") != std::string::npos) {
+    IRBuffer.erase(IRBuffer.find(", align"));
+  } else if (IRBuffer.find(", !") != std::string::npos) {
+    IRBuffer.erase(IRBuffer.find(", !"));
+  } else if (IRBuffer.size() > 30) {
+    IRBuffer.erase(30);
+  }
+  return IRBuffer + " | ID: " + getMetaDataID(V);
+}
+
 std::vector<const llvm::Value *>
 globalValuesUsedinFunction(const llvm::Function *F) {
   std::vector<const llvm::Value *> globals_used;

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -218,22 +218,13 @@ std::string getMetaDataID(const llvm::Value *V) {
   return "-1";
 }
 
-bool lessThanOnValueID(const llvm::Value *V1, const llvm::Value *V2) {
-  char *endptr1, *endptr2;
-  std::string id1 = getMetaDataID(V1);
-  std::string id2 = getMetaDataID(V2);
-  long val1 = strtol(id1.c_str(), &endptr1, 10);
-  long val2 = strtol(id2.c_str(), &endptr2, 10);
-  // both values have string ID's, i.e. are of Argument type
-  if (id1.c_str() == endptr1 && id2.c_str() == endptr2) {
-    return id1 < id2;
-  } else if (id1.c_str() == endptr1 && id2.c_str() != endptr2) {
-    return false;
-  } else if (id1.c_str() != endptr1 && id2.c_str() == endptr2) {
-    return true;
-  } else {
-    return val1 < val2;
-  }
+llvmValueIDLess::llvmValueIDLess() : sless(stringIDLess()) {}
+
+bool llvmValueIDLess::operator()(const llvm::Value *lhs,
+                                 const llvm::Value *rhs) const {
+  std::string lhs_id = getMetaDataID(lhs);
+  std::string rhs_id = getMetaDataID(rhs);
+  return sless(lhs_id, rhs_id);
 }
 
 int getFunctionArgumentNr(const llvm::Argument *Arg) {

--- a/lib/Utils/Macros.cpp
+++ b/lib/Utils/Macros.cpp
@@ -94,4 +94,21 @@ ostream &operator<<(ostream &os, const vector<bool> &bits) {
   }
   return os;
 }
+
+bool stringIDLess::operator()(const std::string &lhs,
+                              const std::string &rhs) const {
+  char *endptr1, *endptr2;
+  long lhs_val = strtol(lhs.c_str(), &endptr1, 10);
+  long rhs_val = strtol(rhs.c_str(), &endptr2, 10);
+  if (lhs.c_str() == endptr1 && lhs.c_str() == endptr2) {
+    return lhs < rhs;
+  } else if (lhs.c_str() == endptr1 && rhs.c_str() != endptr2) {
+    return false;
+  } else if (lhs.c_str() != endptr1 && rhs.c_str() == endptr2) {
+    return true;
+  } else {
+    return lhs_val < rhs_val;
+  }
+}
+
 } // namespace psr

--- a/test/llvm_test_code/linear_constant/CMakeLists.txt
+++ b/test/llvm_test_code/linear_constant/CMakeLists.txt
@@ -1,38 +1,21 @@
-set(lca_files
-  basic_01.cpp
-  basic_02.cpp
-  basic_03.cpp
-  basic_04.cpp
-  basic_05.cpp
-  basic_06.cpp
-  basic_07.cpp
-  basic_08.cpp
-  basic_09.cpp
-  branch_01.cpp
-  branch_02.cpp
-  branch_03.cpp
-  branch_04.cpp
-  branch_05.cpp
-  branch_06.cpp
-  branch_07.cpp
-  call_01.cpp
-  call_02.cpp
-  call_03.cpp
-  call_04.cpp
-  call_05.cpp
-  call_06.cpp
-  call_07.cpp
-  call_08.cpp
-)
+file(GLOB lca_files *.c *.cpp)
 
 set(lca_files_mem2reg
   basic_06.cpp
+  call_12.cpp
+  call_13.cpp
 )
 
 foreach(TEST_SRC ${lca_files})
-  generate_ll_file(FILE ${TEST_SRC} DEBUG)
+  get_filename_component(TEST_SRC_FILE ${TEST_SRC} NAME)
+  generate_ll_file(FILE ${TEST_SRC_FILE} DEBUG)
+endforeach(TEST_SRC)
+
+foreach(TEST_SRC ${lca_files})
+  get_filename_component(TEST_SRC_FILE ${TEST_SRC} NAME)
+  generate_ll_file(FILE ${TEST_SRC_FILE})
 endforeach(TEST_SRC)
 
 foreach(TEST_SRC ${lca_files_mem2reg})
-  generate_ll_file(FILE ${TEST_SRC} MEM2REG DEBUG)
+  generate_ll_file(FILE ${TEST_SRC} MEM2REG)
 endforeach(TEST_SRC)

--- a/test/llvm_test_code/linear_constant/CMakeLists.txt
+++ b/test/llvm_test_code/linear_constant/CMakeLists.txt
@@ -1,7 +1,10 @@
 file(GLOB lca_files *.c *.cpp)
 
-set(lca_files_mem2reg
+set(lca_files_mem2reg_dbg
   basic_06.cpp
+)
+
+set(lca_files_mem2reg
   call_12.cpp
   call_13.cpp
 )
@@ -14,6 +17,10 @@ endforeach(TEST_SRC)
 foreach(TEST_SRC ${lca_files})
   get_filename_component(TEST_SRC_FILE ${TEST_SRC} NAME)
   generate_ll_file(FILE ${TEST_SRC_FILE})
+endforeach(TEST_SRC)
+
+foreach(TEST_SRC ${lca_files_mem2reg_dbg})
+  generate_ll_file(FILE ${TEST_SRC} MEM2REG DEBUG)
 endforeach(TEST_SRC)
 
 foreach(TEST_SRC ${lca_files_mem2reg})

--- a/test/llvm_test_code/linear_constant/call_09.cpp
+++ b/test/llvm_test_code/linear_constant/call_09.cpp
@@ -1,0 +1,10 @@
+int foo(int a) {
+  a = 10;
+  return 44;
+}
+
+int main() {
+  int i = 10;
+  int k = foo(i);
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/call_10.cpp
+++ b/test/llvm_test_code/linear_constant/call_10.cpp
@@ -1,0 +1,10 @@
+int foo(int a) {
+  return a;
+}
+
+int main() {
+  int i;
+  i = foo(2);
+  i = foo(i);
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/call_11.cpp
+++ b/test/llvm_test_code/linear_constant/call_11.cpp
@@ -1,0 +1,10 @@
+int foo(int a) {
+  return 42;
+}
+
+int main() {
+  int i;
+  i = foo(2);
+  i = foo(i);
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/call_12.cpp
+++ b/test/llvm_test_code/linear_constant/call_12.cpp
@@ -1,0 +1,13 @@
+void bar(int b) {
+
+}
+
+void foo(int a) {
+  bar(a);
+}
+
+int main() {
+  int i;
+  foo(2);
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/call_13.cpp
+++ b/test/llvm_test_code/linear_constant/call_13.cpp
@@ -1,0 +1,13 @@
+int bar(int b) {
+  return b;
+}
+
+int foo(int a) {
+  return bar(a);
+}
+
+int main() {
+  int i;
+  i = foo(2);
+  return 0;
+}

--- a/test/llvm_test_code/uninitialized_variables/CMakeLists.txt
+++ b/test/llvm_test_code/uninitialized_variables/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NoMem2RegSources
   ctor_default.cpp
   dyn_mem.cpp
   exception.cpp
+  while_uninit_1.cpp
   first_inst_call.cpp
   global_variable.cpp
   growing_example.cpp

--- a/test/llvm_test_code/uninitialized_variables/growing_example.cpp
+++ b/test/llvm_test_code/uninitialized_variables/growing_example.cpp
@@ -1,16 +1,14 @@
-int function(int x, int y)
-{
-	int i;
-	int j = x;
-	int k = y;
-	return i+k;
+int function(int x, int y) {
+  int i;
+  int j = x;
+  int k = y;
+  return i + k;
 }
 
-int main(int argc, char** argv)
-{
-	int i;
-	int j;
-	int k;
-	k = function(j, 12);
-	return 0;
+int main(int argc, char **argv) {
+  int i;
+  int j;
+  int k;
+  k = function(j, 12);
+  return 0;
 }

--- a/test/llvm_test_code/uninitialized_variables/reassing_uninit.cpp
+++ b/test/llvm_test_code/uninitialized_variables/reassing_uninit.cpp
@@ -1,5 +1,6 @@
 int main() {
 	int i;
 	int j = i;
+	j = 10;
 	return 0;
 }

--- a/test/llvm_test_code/uninitialized_variables/while_uninit_1.cpp
+++ b/test/llvm_test_code/uninitialized_variables/while_uninit_1.cpp
@@ -1,0 +1,8 @@
+int main() {
+  int i = 10;
+  int a;
+  while (i-- > 0) {
+    a = 10;
+  }
+  return 0;
+}

--- a/tools/phasar/myphasartool.cpp
+++ b/tools/phasar/myphasartool.cpp
@@ -46,12 +46,14 @@ int main(int argc, const char **argv) {
     I.printAsDot("call_graph.dot");
     // IFDS template parametrization test
 		IFDSLinearConstantAnalysis L(I,H,DB, {"main"});
-    LLVMIFDSSolver<LCAPair, LLVMBasedICFG &> S(L, true);
+    LLVMIFDSSolver<LCAPair, LLVMBasedICFG &> S(L);
     S.solve();
+    S.dumpResults();
 		// IDE template parametrization test
 		IDELinearConstantAnalysis M(I,H,DB, {"main"});
-		LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> T(M, true);
+		LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> T(M);
 		T.solve();
+    T.dumpResults();
   } else {
     std::cerr << "error: file does not contain a 'main' function!\n";
   }

--- a/tools/phasar/phasar.cpp
+++ b/tools/phasar/phasar.cpp
@@ -244,7 +244,9 @@ int main(int argc, const char **argv) {
 			("mem2reg", "Promote memory to register pass")
 			("printedgerec,R", "Print exploded-super-graph edge recorder")
       ("log,L", "Enable logging")
-      ("output-ir", "Output preprocessed and annotated IR")
+      ("emit-ir", "Emit preprocessed and annotated IR of analysis target")
+      ("emit-raw-results", "Emit unprocessed/raw solver results")
+      ("emit-esg-as-dot", "Emit the Exploded super-graph (ESG) as DOT graph")
       #ifdef PHASAR_PLUGINS_ENABLED
 			("analysis-plugin", bpo::value<std::vector<std::string>>()->notifier(validateParamAnalysisPlugin), "Analysis plugin(s) (absolute path to the shared object file(s))")
       ("callgraph-plugin", bpo::value<std::string>()->notifier(validateParamICFGPlugin), "ICFG plugin (absolute path to the shared object file)")

--- a/tools/phasar/phasar.cpp
+++ b/tools/phasar/phasar.cpp
@@ -569,6 +569,6 @@ int main(int argc, const char **argv) {
   bl::core::get()->flush();
   STOP_TIMER("Phasar Runtime", PAMM_SEVERITY_LEVEL::Core);
   // PRINT_MEASURED_DATA(std::cout);
-  EXPORT_MEASURED_DATA(VariablesMap["pamm-out"].as<std::string>());
+  EXPORT_MEASURED_DATA(PhasarConfig::VariablesMap()["pamm-out"].as<std::string>());
   return 0;
 }

--- a/tools/phasar/phasar.cpp
+++ b/tools/phasar/phasar.cpp
@@ -244,7 +244,7 @@ int main(int argc, const char **argv) {
 			("mem2reg", "Promote memory to register pass")
 			("printedgerec,R", "Print exploded-super-graph edge recorder")
       ("log,L", "Enable logging")
-      ("print-ir", "Print preprocessed IR")
+      ("output-ir", "Output preprocessed and annotated IR")
       #ifdef PHASAR_PLUGINS_ENABLED
 			("analysis-plugin", bpo::value<std::vector<std::string>>()->notifier(validateParamAnalysisPlugin), "Analysis plugin(s) (absolute path to the shared object file(s))")
       ("callgraph-plugin", bpo::value<std::string>()->notifier(validateParamICFGPlugin), "ICFG plugin (absolute path to the shared object file)")

--- a/tools/phasar/phasar.cpp
+++ b/tools/phasar/phasar.cpp
@@ -244,6 +244,7 @@ int main(int argc, const char **argv) {
 			("mem2reg", "Promote memory to register pass")
 			("printedgerec,R", "Print exploded-super-graph edge recorder")
       ("log,L", "Enable logging")
+      ("print-ir", "Print preprocessed IR")
       #ifdef PHASAR_PLUGINS_ENABLED
 			("analysis-plugin", bpo::value<std::vector<std::string>>()->notifier(validateParamAnalysisPlugin), "Analysis plugin(s) (absolute path to the shared object file(s))")
       ("callgraph-plugin", bpo::value<std::string>()->notifier(validateParamICFGPlugin), "ICFG plugin (absolute path to the shared object file)")

--- a/unittests/PhasarLLVM/IfdsIde/EdgeFunctionComposerTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/EdgeFunctionComposerTest.cpp
@@ -75,8 +75,8 @@ TEST(EdgeFunctionComposerTest, HandleEFIDs) {
   auto EFC1 = std::make_shared<MyEFC>(EF1, EF2);
   auto EFC2 = std::make_shared<MyEFC>(EF2, EdgeIdentity<int>::getInstance());
   std::cout << "My EFC: " << EFC1->str() << " " << EFC2->str() << '\n';
-  EXPECT_EQ("EFComposer_1[ AddTwoEF_1 , AddTwoEF_2 ]", EFC1->str());
-  EXPECT_EQ("EFComposer_2[ AddTwoEF_2 , EdgeIdentity ]", EFC2->str());
+  EXPECT_EQ("Comp_1[ AddTwoEF_1 , AddTwoEF_2 ]", EFC1->str());
+  EXPECT_EQ("Comp_2[ AddTwoEF_2 , EdgeId ]", EFC2->str());
   // Reset ID's for next test
   CurrAddTwoEF_Id = 0;
 }

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -73,7 +73,7 @@ protected:
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_01) {
   Initialize({pathToLLFiles + "basic_01_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 13}};
   compareResults(gt, llvmlcasolver);
@@ -82,7 +82,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_01) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_02) {
   Initialize({pathToLLFiles + "basic_02_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 17}};
   compareResults(gt, llvmlcasolver);
@@ -91,7 +91,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_02) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_03) {
   Initialize({pathToLLFiles + "basic_03_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"0", 0}, {"1", 14}, {"2", 14}, {"8", 14}};
@@ -101,7 +101,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_03) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_04) {
   Initialize({pathToLLFiles + "basic_04_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"0", 0}, {"1", 14}, {"2", 20}, {"10", 14}, {"11", 20}};
@@ -111,7 +111,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_04) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_05) {
   Initialize({pathToLLFiles + "basic_05_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 3},  {"2", 14},
                                              {"7", 3}, {"8", 12}, {"9", 14}};
@@ -121,7 +121,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_05) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_06) {
   Initialize({pathToLLFiles + "basic_06_cpp_m2r_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 16}};
   compareResults(gt, llvmlcasolver);
@@ -131,7 +131,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_06) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_01) {
   Initialize({pathToLLFiles + "branch_01_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"1", 0}, {"2", LCAProblem->bottomElement()}};
@@ -142,7 +142,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_02) {
   // Probably a bad example/style, since variable i is possibly unitialized
   Initialize({pathToLLFiles + "branch_02_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 10}};
   compareResults(gt, llvmlcasolver);
@@ -151,7 +151,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_02) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_03) {
   Initialize({pathToLLFiles + "branch_03_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 30}};
   compareResults(gt, llvmlcasolver);
@@ -160,7 +160,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_03) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_04) {
   Initialize({pathToLLFiles + "branch_04_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0},
                                              {"2", 10},
@@ -173,7 +173,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_04) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_05) {
   Initialize({pathToLLFiles + "branch_05_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"1", 0},  {"2", 10},  {"3", LCAProblem->bottomElement()},
@@ -184,7 +184,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_05) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_06) {
   Initialize({pathToLLFiles + "branch_06_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0},
                                              {"2", 10},
@@ -197,7 +197,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_06) {
 TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_07) {
   Initialize({pathToLLFiles + "branch_07_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, false, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"1", 0},  {"2", 10}, {"3", LCAProblem->bottomElement()},
@@ -210,7 +210,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_07) {
 TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_01) {
   Initialize({pathToLLFiles + "call_01_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, true, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"0", 42}, {"1", 42},  {"5", 42},        {"8", 0},
@@ -221,7 +221,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_01) {
 TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_02) {
   Initialize({pathToLLFiles + "call_02_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, true, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"0", 2},  {"3", 2},   {"4", 42},       {"6", 0},
@@ -232,7 +232,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_02) {
 TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_03) {
   Initialize({pathToLLFiles + "call_03_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, true, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 42}, {"5", 42}};
   compareResults(gt, llvmlcasolver);
@@ -241,7 +241,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_03) {
 TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_04) {
   Initialize({pathToLLFiles + "call_04_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, true, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 10}, {"6", 42}};
   compareResults(gt, llvmlcasolver);
@@ -250,7 +250,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_04) {
 TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_05) {
   Initialize({pathToLLFiles + "call_05_cpp_dbg.ll"});
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-      *LCAProblem, true, true);
+      *LCAProblem);
   llvmlcasolver.solve();
   const std::map<std::string, int64_t> gt = {
       {"0", 0},

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -144,7 +144,7 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_02) {
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
       *LCAProblem);
   llvmlcasolver.solve();
-  const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 10}};
+  const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", LCAProblem->bottomElement()}};
   compareResults(gt, llvmlcasolver);
 }
 

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -144,7 +144,8 @@ TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_02) {
   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
       *LCAProblem);
   llvmlcasolver.solve();
-  const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", LCAProblem->bottomElement()}};
+  const std::map<std::string, int64_t> gt = {
+      {"1", 0}, {"2", LCAProblem->bottomElement()}};
   compareResults(gt, llvmlcasolver);
 }
 

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IDETypeStateAnalysisTest.cpp
@@ -84,7 +84,7 @@ protected:
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_01) {
   Initialize({pathToLLFiles + "typestate_01_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -97,7 +97,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_01) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_02) {
   Initialize({pathToLLFiles + "typestate_02_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -108,7 +108,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_02) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_03) {
   Initialize({pathToLLFiles + "typestate_03_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -131,7 +131,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_03) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_04) {
   Initialize({pathToLLFiles + "typestate_04_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -145,7 +145,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_04) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_05) {
   Initialize({pathToLLFiles + "typestate_05_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -168,7 +168,7 @@ TEST_F(IDETypeStateAnalysisTest, DISABLED_HandleTypeState_06) {
   // This test fails due to imprecise points-to information
   Initialize({pathToLLFiles + "typestate_06_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -204,7 +204,7 @@ TEST_F(IDETypeStateAnalysisTest, DISABLED_HandleTypeState_06) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_07) {
   Initialize({pathToLLFiles + "typestate_07_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -235,7 +235,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_07) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_08) {
   Initialize({pathToLLFiles + "typestate_08_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -249,7 +249,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_08) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_09) {
   Initialize({pathToLLFiles + "typestate_09_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -263,7 +263,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_09) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_10) {
   Initialize({pathToLLFiles + "typestate_10_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -285,7 +285,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_10) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_11) {
   Initialize({pathToLLFiles + "typestate_11_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -310,7 +310,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_11) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_12) {
   Initialize({pathToLLFiles + "typestate_12_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -326,7 +326,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_12) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_13) {
   Initialize({pathToLLFiles + "typestate_13_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -342,7 +342,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_13) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_14) {
   Initialize({pathToLLFiles + "typestate_14_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -366,7 +366,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_14) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_15) {
   Initialize({pathToLLFiles + "typestate_15_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -411,7 +411,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_15) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_16) {
   Initialize({pathToLLFiles + "typestate_16_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -426,7 +426,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_16) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_17) {
   Initialize({pathToLLFiles + "typestate_17_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -454,7 +454,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_17) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_18) {
   Initialize({pathToLLFiles + "typestate_18_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {
@@ -469,7 +469,7 @@ TEST_F(IDETypeStateAnalysisTest, HandleTypeState_18) {
 TEST_F(IDETypeStateAnalysisTest, HandleTypeState_19) {
   Initialize({pathToLLFiles + "typestate_19_c.ll"});
   LLVMIDESolver<const llvm::Value *, int, LLVMBasedICFG &> llvmtssolver(
-      *TSProblem, false, false);
+      *TSProblem);
 
   llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> gt = {

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
@@ -74,7 +74,7 @@ protected:
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_01) {
   Initialize({pathToLLFiles + "basic/basic_01_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -82,7 +82,7 @@ TEST_F(IFDSConstAnalysisTest, HandleBasicTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_02) {
   Initialize({pathToLLFiles + "basic/basic_02_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -90,7 +90,7 @@ TEST_F(IFDSConstAnalysisTest, HandleBasicTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_03) {
   Initialize({pathToLLFiles + "basic/basic_03_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -98,7 +98,7 @@ TEST_F(IFDSConstAnalysisTest, HandleBasicTest_03) {
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_04) {
   Initialize({pathToLLFiles + "basic/basic_04_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -107,7 +107,7 @@ TEST_F(IFDSConstAnalysisTest, HandleBasicTest_04) {
 TEST_F(IFDSConstAnalysisTest, HandleCFForTest_01) {
   Initialize({pathToLLFiles + "control_flow/cf_for_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -115,7 +115,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCFForTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleCFForTest_02) {
   Initialize({pathToLLFiles + "control_flow/cf_for_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -123,7 +123,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCFForTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_01) {
   Initialize({pathToLLFiles + "control_flow/cf_if_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -131,7 +131,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_02) {
   Initialize({pathToLLFiles + "control_flow/cf_if_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -139,7 +139,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleCFWhileTest_01) {
   Initialize({pathToLLFiles + "control_flow/cf_while_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -148,7 +148,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCFWhileTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_01) {
   Initialize({pathToLLFiles + "pointer/pointer_01_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -156,7 +156,7 @@ TEST_F(IFDSConstAnalysisTest, HandlePointerTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_02) {
   Initialize({pathToLLFiles + "pointer/pointer_02_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -166,7 +166,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandlePointerTest_03) {
   // information
   Initialize({pathToLLFiles + "pointer/pointer_03_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({2, 3}, llvmconstsolver);
 }
@@ -174,7 +174,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandlePointerTest_03) {
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_04) {
   Initialize({pathToLLFiles + "pointer/pointer_04_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({4}, llvmconstsolver);
 }
@@ -183,7 +183,7 @@ TEST_F(IFDSConstAnalysisTest, HandlePointerTest_04) {
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_01) {
   Initialize({pathToLLFiles + "global/global_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -191,7 +191,7 @@ TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_02) {
   Initialize({pathToLLFiles + "global/global_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0, 1}, llvmconstsolver);
 }
@@ -199,7 +199,7 @@ TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_03) {
   Initialize({pathToLLFiles + "global/global_03_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -209,7 +209,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleGlobalTest_04) {
   // information
   Initialize({pathToLLFiles + "global/global_04_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0, 4}, llvmconstsolver);
 }
@@ -218,7 +218,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleGlobalTest_04) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_01) {
   Initialize({pathToLLFiles + "call/param/call_param_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({5}, llvmconstsolver);
 }
@@ -226,7 +226,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_02) {
   Initialize({pathToLLFiles + "call/param/call_param_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({5}, llvmconstsolver);
 }
@@ -234,7 +234,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_03) {
   Initialize({pathToLLFiles + "call/param/call_param_03_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -244,7 +244,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCallParamTest_04) {
   // information
   Initialize({pathToLLFiles + "call/param/call_param_04_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -254,7 +254,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCallParamTest_05) {
   // information
   Initialize({pathToLLFiles + "call/param/call_param_05_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({2}, llvmconstsolver);
 }
@@ -262,7 +262,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCallParamTest_05) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_06) {
   Initialize({pathToLLFiles + "call/param/call_param_06_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -270,7 +270,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_06) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_07) {
   Initialize({pathToLLFiles + "call/param/call_param_07_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({6}, llvmconstsolver);
 }
@@ -278,7 +278,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_07) {
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_08) {
   Initialize({pathToLLFiles + "call/param/call_param_08_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({4}, llvmconstsolver);
 }
@@ -286,7 +286,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_08) {
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_01) {
   Initialize({pathToLLFiles + "call/return/call_ret_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -294,7 +294,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_02) {
   Initialize({pathToLLFiles + "call/return/call_ret_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -302,7 +302,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_03) {
   Initialize({pathToLLFiles + "call/return/call_ret_03_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -311,7 +311,7 @@ TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_03) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_01) {
   Initialize({pathToLLFiles + "array/array_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -319,7 +319,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_02) {
   Initialize({pathToLLFiles + "array/array_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -327,7 +327,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_03) {
   Initialize({pathToLLFiles + "array/array_03_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -337,7 +337,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_04) {
   // information
   Initialize({pathToLLFiles + "array/array_04_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -345,7 +345,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_04) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_05) {
   Initialize({pathToLLFiles + "array/array_05_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -353,7 +353,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_05) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_06) {
   Initialize({pathToLLFiles + "array/array_06_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -363,7 +363,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_07) {
   // information
   Initialize({pathToLLFiles + "array/array_07_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -371,7 +371,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_07) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_08) {
   Initialize({pathToLLFiles + "array/array_08_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -379,7 +379,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_08) {
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_09) {
   Initialize({pathToLLFiles + "array/array_09_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({0}, llvmconstsolver);
 }
@@ -388,7 +388,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_09) {
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_01) {
   Initialize({pathToLLFiles + "array/stl_array/stl_array_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -396,7 +396,7 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_01) {
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_02) {
   Initialize({pathToLLFiles + "array/stl_array/stl_array_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({1}, llvmconstsolver);
 }
@@ -404,7 +404,7 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_02) {
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_03) {
   Initialize({pathToLLFiles + "array/stl_array/stl_array_03_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({2}, llvmconstsolver);
 }
@@ -414,7 +414,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleSTLArrayTest_04) {
   // information
   Initialize({pathToLLFiles + "array/stl_array/stl_array_04_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -422,7 +422,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleSTLArrayTest_04) {
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_05) {
   Initialize({pathToLLFiles + "array/stl_array/stl_array_05_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -430,7 +430,7 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_05) {
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_06) {
   Initialize({pathToLLFiles + "array/stl_array/stl_array_06_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({2}, llvmconstsolver);
 }
@@ -439,7 +439,7 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_06) {
 TEST_F(IFDSConstAnalysisTest, HandleCStringTest_01) {
   Initialize({pathToLLFiles + "array/cstring/cstring_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({}, llvmconstsolver);
 }
@@ -449,7 +449,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
   // information
   Initialize({pathToLLFiles + "array/cstring/cstring_02_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-      *constproblem, false, true);
+      *constproblem);
   llvmconstsolver.solve();
   compareResults({2}, llvmconstsolver);
 }
@@ -458,7 +458,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_01) {
 //  Initialize({pathToLLFiles + "structs/structs_01_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0, 1, 5}, llvmconstsolver);
 //}
@@ -466,7 +466,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_02) {
 //  Initialize({pathToLLFiles + "structs/structs_02_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0, 1, 5}, llvmconstsolver);
 //}
@@ -474,7 +474,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_03) {
 //  Initialize({pathToLLFiles + "structs/structs_03_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0, 1, 9}, llvmconstsolver);
 //}
@@ -482,7 +482,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_04) {
 //  Initialize({pathToLLFiles + "structs/structs_04_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0, 1, 10}, llvmconstsolver);
 //}
@@ -490,7 +490,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_05) {
 //  Initialize({pathToLLFiles + "structs/structs_05_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0, 1}, llvmconstsolver);
 //}
@@ -498,7 +498,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_06) {
 //  Initialize({pathToLLFiles + "structs/structs_06_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -506,7 +506,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_07) {
 //  Initialize({pathToLLFiles + "structs/structs_07_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -514,7 +514,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_08) {
 //  Initialize({pathToLLFiles + "structs/structs_08_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -522,7 +522,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_09) {
 //  Initialize({pathToLLFiles + "structs/structs_09_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -530,7 +530,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_10) {
 //  Initialize({pathToLLFiles + "structs/structs_10_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -538,7 +538,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_11) {
 //  Initialize({pathToLLFiles + "structs/structs_11_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}
@@ -546,7 +546,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
 // TEST_F(IFDSConstAnalysisTest, HandleStructureTest_12) {
 //  Initialize({pathToLLFiles + "structs/structs_12_cpp_dbg.ll"});
 //  LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> llvmconstsolver(
-//      *constproblem, false, true);
+//      *constproblem);
 //  llvmconstsolver.solve();
 //  compareResults({0}, llvmconstsolver);
 //}

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
@@ -72,7 +72,7 @@ protected:
 TEST_F(IFDSTaintAnalysisTest, TaintTest_01) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_01_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[13] = set<string>{"12"};
@@ -82,7 +82,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_01) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_01_m2r) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_01_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[4] = set<string>{"2"};
@@ -92,7 +92,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_01_m2r) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_02) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_02_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[9] = set<string>{"8"};
@@ -102,7 +102,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_02) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_03) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_03_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[18] = set<string>{"17"};
@@ -112,7 +112,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_03) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_04) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_04_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[19] = set<string>{"18"};
@@ -123,7 +123,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_04) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_05) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_05_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[22] = set<string>{"21"};
@@ -133,7 +133,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_05) {
 TEST_F(IFDSTaintAnalysisTest, TaintTest_06) {
   Initialize({pathToLLFiles + "dummy_source_sink/taint_06_cpp_m2r_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> TaintSolver(
-      *TaintProblem, false, true);
+      *TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[5] = set<string>{"main.0"};

--- a/unittests/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
+++ b/unittests/PhasarLLVM/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
@@ -69,7 +69,7 @@ protected:
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_01_SHOULD_NOT_LEAK) {
   Initialize({pathToLLFiles + "all_uninit_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // all_uninit.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -79,7 +79,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_01_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_02_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "binop_uninit_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   // binop_uninit uses uninitialized variable i in 'int j = i + 10;'
@@ -94,7 +94,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_02_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_03_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "callnoret_c_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   // callnoret uses uninitialized variable a in 'return a + 10;' of addTen(int)
@@ -117,7 +117,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_03_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_04_SHOULD_NOT_LEAK) {
   Initialize({pathToLLFiles + "ctor_default_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // ctor.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -127,7 +127,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_04_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_05_SHOULD_NOT_LEAK) {
   Initialize({pathToLLFiles + "struct_member_init_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // struct_member_init.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -136,7 +136,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_05_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_06_SHOULD_NOT_LEAK) {
   Initialize({pathToLLFiles + "struct_member_uninit_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // struct_member_uninit.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -149,7 +149,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_06_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_07_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "struct_member_uninit2_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // struct_member_uninit2.cpp contains a use of the uninitialized field _x.b
   map<int, set<string>> GroundTruth;
@@ -164,7 +164,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_07_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_08_SHOULD_NOT_LEAK) {
   Initialize({pathToLLFiles + "global_variable_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // global_variable.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -178,7 +178,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_08_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_09_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "global_variable_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // global_variable.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -190,7 +190,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_09_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_10_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "return_uninit_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   //%2 = load i32, i32 %1
@@ -205,7 +205,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_11_SHOULD_NOT_LEAK) {
 
   Initialize({pathToLLFiles + "sanitizer_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   // all undef-uses are sanitized;
@@ -223,7 +223,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_11_SHOULD_NOT_LEAK) {
 
   Initialize({pathToLLFiles + "sanitizer_uninit_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              true, true);
+                                                              true);
   Solver.solve();
   // The sanitized value is not used always => the phi-node is "tainted"
   map<int, set<string>> GroundTruth;
@@ -236,7 +236,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_13_SHOULD_NOT_LEAK) {
 
   Initialize({pathToLLFiles + "sanitizer2_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   // The undef-uses do not affect the program behaviour, but are of course still
   // found and reported
@@ -248,7 +248,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_14_SHOULD_LEAK) {
 
   Initialize({pathToLLFiles + "uninit_c_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[14] = {"1"};
@@ -263,7 +263,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_14_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_15_SHOULD_LEAK) {
   Initialize({pathToLLFiles + "dyn_mem_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   // TODO remove GT[14] and GT[13]
@@ -293,7 +293,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_16_SHOULD_LEAK) {
 
   Initialize({pathToLLFiles + "growing_example_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -317,7 +317,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_17_SHOULD_LEAK) {
 
   Initialize({pathToLLFiles + "struct_test_cpp.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -335,7 +335,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_18_SHOULD_NOT_LEAK) {
 
   Initialize({pathToLLFiles + "array_init_cpp.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -353,7 +353,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_19_SHOULD_NOT_LEAK) {
 
   Initialize({pathToLLFiles + "array_init_simple_cpp.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -364,7 +364,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_20_SHOULD_LEAK) {
 
   Initialize({pathToLLFiles + "recursion_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -386,7 +386,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_21_SHOULD_LEAK) {
 
   Initialize({pathToLLFiles + "virtual_call_cpp_dbg.ll"});
   LLVMIFDSSolver<const llvm::Value *, LLVMBasedICFG &> Solver(*UninitProblem,
-                                                              false, false);
+                                                              false);
   Solver.solve();
 
   map<int, set<string>> GroundTruth = {

--- a/unittests/PhasarLLVM/Mono/InterMonoTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/Mono/InterMonoTaintAnalysisTest.cpp
@@ -48,8 +48,11 @@ protected:
     LLVMBasedICFG ICFG(TH, *IRDB, CallGraphAnalysisType::OTF, EntryPoints);
     InterMonoTaintAnalysis TaintProblem(ICFG, EntryPoints);
     LLVMInterMonoSolver<const llvm::Value *, LLVMBasedICFG &, 3> TaintSolver(
-        TaintProblem, printDump);
+        TaintProblem);
     TaintSolver.solve();
+    if (printDump) {
+      TaintSolver.dumpResults();
+    }
     return TaintProblem.getAllLeaks();
   }
   void compareResults(

--- a/unittests/PhasarLLVM/WPDS/Problems/WPDSLinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/WPDS/Problems/WPDSLinearConstantAnalysisTest.cpp
@@ -78,7 +78,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_01) {
 //   Initialize({pathToLLFiles + "basic_01_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 13}};
 //   compareResults(gt, llvmlcasolver);
@@ -87,7 +87,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_02) {
 //   Initialize({pathToLLFiles + "basic_02_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 17}};
 //   compareResults(gt, llvmlcasolver);
@@ -96,7 +96,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_03) {
 //   Initialize({pathToLLFiles + "basic_03_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"0", 0}, {"1", 14}, {"2", 14}, {"8", 14}};
@@ -106,7 +106,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_04) {
 //   Initialize({pathToLLFiles + "basic_04_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"0", 0}, {"1", 14}, {"2", 20}, {"10", 14}, {"11", 20}};
@@ -116,7 +116,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_05) {
 //   Initialize({pathToLLFiles + "basic_05_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"0", 0}, {"1", 3},  {"2", 14},
 //                                              {"7", 3}, {"8", 12}, {"9", 14}};
@@ -126,7 +126,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBasicTest_06) {
 //   Initialize({pathToLLFiles + "basic_06_cpp_m2r_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 16}};
 //   compareResults(gt, llvmlcasolver);
@@ -136,7 +136,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_01) {
 //   Initialize({pathToLLFiles + "branch_01_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"1", 0}, {"2", LCAProblem->bottomElement()}};
@@ -147,7 +147,7 @@ protected:
 //   // Probably a bad example/style, since variable i is possibly unitialized
 //   Initialize({pathToLLFiles + "branch_02_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 10}};
 //   compareResults(gt, llvmlcasolver);
@@ -156,7 +156,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_03) {
 //   Initialize({pathToLLFiles + "branch_03_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 30}};
 //   compareResults(gt, llvmlcasolver);
@@ -165,7 +165,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_04) {
 //   Initialize({pathToLLFiles + "branch_04_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0},
 //                                              {"2", 10},
@@ -179,7 +179,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_05) {
 //   Initialize({pathToLLFiles + "branch_05_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"1", 0},  {"2", 10},  {"3", LCAProblem->bottomElement()},
@@ -190,7 +190,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_06) {
 //   Initialize({pathToLLFiles + "branch_06_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0},
 //                                              {"2", 10},
@@ -204,7 +204,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleBranchTest_07) {
 //   Initialize({pathToLLFiles + "branch_07_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, false, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"1", 0},  {"2", 10}, {"3", LCAProblem->bottomElement()},
@@ -217,7 +217,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleCallTest_01) {
 //   Initialize({pathToLLFiles + "call_01_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, true, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"0", 42}, {"1", 42},  {"5", 42},        {"8", 0},
@@ -228,7 +228,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleCallTest_02) {
 //   Initialize({pathToLLFiles + "call_02_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, true, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"0", 2},  {"3", 2},   {"4", 42},       {"6", 0},
@@ -239,7 +239,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleCallTest_03) {
 //   Initialize({pathToLLFiles + "call_03_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, true, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 42}, {"5", 42}};
 //   compareResults(gt, llvmlcasolver);
@@ -248,7 +248,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleCallTest_04) {
 //   Initialize({pathToLLFiles + "call_04_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, true, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {{"1", 0}, {"2", 10}, {"6", 42}};
 //   compareResults(gt, llvmlcasolver);
@@ -257,7 +257,7 @@ protected:
 // TEST_F(WPDSLinearConstantAnalysisTest, HandleCallTest_05) {
 //   Initialize({pathToLLFiles + "call_05_cpp_dbg.ll"});
 //   LLVMIDESolver<const llvm::Value *, int64_t, LLVMBasedICFG &> llvmlcasolver(
-//       *LCAProblem, true, true);
+//       *LCAProblem);
 //   llvmlcasolver.solve();
 //   const std::map<std::string, int64_t> gt = {
 //       {"0", 0},


### PR DESCRIPTION
As requested by #49 it is now possible to emit the Exploded Super Graph (ESG) as a .dot graph. Use the command-line flag '--emit-esg-as-dot' when running your analysis. This will produce a 'ESG.dot' file inside the build folder. Note that we cannot enforce a strict layout when using .dot graphs, therefore in some cases the produced graphs might look flustered. To mitigate that to some degree, we provide a config file (_config/DOTGraphConfig.json_) where you can change the attributes of the nodes and edges, e.g. change the weight for some edges. Changes inside the config file will be applied during the next analysis run, thus, recompiling PhASAR is not necessary. 