### PR TITLE
Refactor build for boost, and llvm target dir and running tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ target_link_libraries(phasar
   ${CLANG_LIBRARIES}
   ${llvm_libs}
   curl
-  gtest
+#  gtest
 )
 
 target_link_libraries(myphasartool
@@ -285,7 +285,7 @@ target_link_libraries(myphasartool
   ${CLANG_LIBRARIES}
   ${llvm_libs}
   curl
-  gtest
+#  gtest
 )
 
 target_link_libraries(wpdstest
@@ -385,6 +385,9 @@ install(DIRECTORY external/json/single_include/nlohmann/
 install(DIRECTORY external/googletest/googletest/include/gtest/
   DESTINATION include/gtest
 )
+# If we link against gtest we need to install the dynamic library: libgtest.so
+#install(TARGETS gtest
+#        LIBRARY DESTINATION lib)
 # Install Phasar utils helper scripts
 install(DIRECTORY utils/
   DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,18 @@ include_directories(
 # Threads
 find_package(Threads)
 
+# Boost
+# Fix boost_thread dependency for MacOS
+if(APPLE)
+  set(BOOST_THREAD thread-mt)
+else()
+  set(BOOST_THREAD thread)
+endif()
+# Require boost 1.66.0 or newer.
+find_package(Boost 1.66.0 COMPONENTS graph program_options ${BOOST_THREAD} REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+add_definitions(-DBOOST_LOG_DYN_LINK)
+
 # JSON library
 option(JSON_BuildTests OFF)
 add_subdirectory(external/json EXCLUDE_FROM_ALL)
@@ -112,11 +124,6 @@ include_directories(external/WALi-OpenNWA/Source/wali/include)
 # wise enum
 add_subdirectory(external/wise_enum)
 include_directories(external/wise_enum)
-
-# Boost
-find_package(Boost COMPONENTS filesystem graph system program_options log thread REQUIRED)
-include_directories(${BOOST_INCLUDE_DIR})
-add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # Curl
 find_package(CURL REQUIRED)
@@ -223,12 +230,6 @@ add_executable(wpdstest
   tools/phasar/wpdstest.cpp
 )
 
-# Fix boost_thread dependency for MacOS
-if(APPLE)
-  set(BOOST_THREAD boost_thread-mt)
-else()
-  set(BOOST_THREAD boost_thread)
-endif()
 
 # Workaround: Remove Plugins for MacOS for now
 if(APPLE)
@@ -254,12 +255,6 @@ target_link_libraries(phasar
   phasar_pointer
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${SQLITE3_LIBRARY}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
@@ -284,12 +279,6 @@ target_link_libraries(myphasartool
   phasar_pointer
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
@@ -316,12 +305,6 @@ target_link_libraries(wpdstest
   phasar_phasarllvm_utils
   phasar_utils
   curl
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${SQLITE3_LIBRARY}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
@@ -346,12 +329,6 @@ target_link_libraries(syncpdstest
   phasar_pointer
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
@@ -374,12 +351,6 @@ target_link_libraries(boomerangtest
   phasar_pointer
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,5 +107,9 @@ echo "Installing PhASAR..."
 PHASAR_INSTALL_DIR="/usr/local/phasar"
 sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
 cd ..
+
+echo "${PHASAR_INSTALL_DIR}/lib" | sudo tee /etc/ld.so.conf.d/phasar.conf > /dev/null
+sudo ldconfig
+
 echo "PhASAR installed successfully to ${PHASAR_INSTALL_DIR}"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,28 +1,78 @@
 #!/bin/bash
+# Run with "-b <boost directory>" to use a pre-existing boost install.
+# Run with "-u" to build & run unit tests
 set -e
+
+# Get the directory where this script lives.
+readonly PHASAR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+readonly LLVM_INSTALL="/usr/local/llvm-8"
+
+
+BOOST_INSTALL=""
+DO_UNIT_TEST=false
+
+function install_boost()
+{
+   BOOST_INSTALL="/usr/local/boost_1_66_0"
+   if [ -d ${BOOST_INSTALL} ]; then
+       echo "Found boost already installed at: ${BOOST_INSTALL}"
+       return 0;
+   fi
+   
+   echo "Installing Boost..."
+   if [ ! -f boost_1_66_0.tar.gz ]
+   then
+	  wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+   fi
+   if [ ! -d boost_1_66_0/ ]
+   then
+	  tar xvf boost_1_66_0.tar.gz
+   fi
+   pushd boost_1_66_0/
+      ./bootstrap.sh
+      sudo ./b2 -j $(nproc) install --prefix=${BOOST_INSTALL}
+   popd
+}
+
+
+while getopts “b:u” opt; do
+  case $opt in
+    b) BOOST_INSTALL=$OPTARG ;;
+    u) DO_UNIT_TEST=true
+  esac
+done
+
+echo "We need sudo to do various install activities.  We only ask for it once!"
+sudo -v || exit 1
+while true; do
+  sudo -nv; sleep 30  # keep sudo from expiring
+  kill -0 "$$" 2>/dev/null || exit  # this process should quit once the parent quits
+done &  # run subscript in background
+
 echo "Installing PhASAR dependencies..."
 echo "Installing dependencies from sources..."
-sudo apt-get update
-sudo apt-get install -y zlib1g zlib1g-dev sqlite3 libsqlite3-dev python3 doxygen graphviz python python-dev python3-pip python-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libedit-dev python-sphinx libcurl4-openssl-dev
-sudo pip install Pygments
-sudo pip install pyyaml
+PACKAGES="zlib1g zlib1g-dev sqlite3 libsqlite3-dev python3 doxygen graphviz python python-dev python3-pip python-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libedit-dev python-sphinx libcurl4-openssl-dev"
+dpkg-query -l ${PACKAGES} > /dev/null || {
+   sudo apt-get update;
+   sudo apt-get install -y zlib1g zlib1g-dev sqlite3 libsqlite3-dev python3 doxygen graphviz python python-dev python3-pip python-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libedit-dev python-sphinx libcurl4-openssl-dev;
+};
 
-echo "Installing Boost..."
-if [ ! -f boost_1_66_0.tar.gz ]
-then
-	wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+#What are the python packages used for?  Can we install the ubuntu package version?
+#sudo pip install Pygments
+#sudo pip install pyyaml
+
+if [[ -z ${BOOST_INSTALL} ]]; then
+    echo "Installing Boost..."
+    install_boost
+else
+    echo "Using user supplied boost at: ${BOOST_INSTALL}"
 fi
-if [ ! -d boost_1_66_0/ ]
-then
-	tar xvf boost_1_66_0.tar.gz
-fi
-cd boost_1_66_0/
-./bootstrap.sh
-sudo ./b2 -j $(nproc) install
-cd ..
+echo "Using boost from: ${BOOST_INSTALL}"
 
 echo "Installing LLVM..."
-./utils/install-llvm-8.0.0.sh $(nproc) ./
+tmp_dir=`mktemp -d "llvm-8_build.XXXXXXXX" --tmpdir`
+./utils/install-llvm-8.0.0.sh $(nproc) "${tmp_dir}" "${LLVM_INSTALL}"
+rm -rf ${tmp_dir}
 
 echo "Installing WLLVM..."
 sudo pip3 install wllvm
@@ -30,18 +80,32 @@ sudo pip3 install wllvm
 echo "Dependencies installed successfully."
 
 echo "Building PhASAR..."
+${DO_UNIT_TESTS} && echo "with unit tests."
 git submodule init
 git submodule update
 
-export CC=/usr/local/bin/clang
-export CXX=/usr/local/bin/clang++
+export CC=${LLVM_INSTALL}/bin/clang
+export CXX=${LLVM_INSTALL}/bin/clang++
 
-mkdir -p build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+mkdir -p ${PHASAR_DIR}/build
+cd ${PHASAR_DIR}/build
+cmake -DCMAKE_BUILD_TYPE=Release -DBOOST_ROOT=${BOOST_INSTALL} -DPHASAR_BUILD_UNITTESTS=${DO_UNIT_TEST} ${PHASAR_DIR}
+
 make -j $(nproc)
 echo "PhASAR built successfully."
+
+if ${DO_UNIT_TEST}; then
+   echo "Running PhASAR unit tests..."
+   pushd unittests
+   for x in `find . -type f -executable -print`; do 
+       pushd ${x%/*} && ./${x##*/} && popd || { echo "Test ${x} failed, aborting."; exit 1; };
+       done
+   popd
+fi
+
 echo "Installing PhASAR..."
-sudo make install
+PHASAR_INSTALL_DIR="/usr/local/phasar"
+sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
 cd ..
-echo "PhASAR installed successfully."
+echo "PhASAR installed successfully to ${PHASAR_INSTALL_DIR}"
+

--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -4,12 +4,6 @@ function(add_phasar_unittest test_name)
   add_executable(${test}
     ${test_name}
   )
-  # Fix boost_thread dependency for MacOS
-  if(APPLE)
-    set(BOOST_THREAD boost_thread-mt)
-  else()
-    set(BOOST_THREAD boost_thread)
-  endif()
   # Workaround: Remove Plugins for MacOS for now
   if(APPLE)
     set(PHASAR_PLUGINS_LIB )
@@ -31,14 +25,7 @@ function(add_phasar_unittest test_name)
     phasar_pointer
     phasar_phasarllvm_utils
     phasar_utils
-    boost_program_options
-    boost_filesystem
-    boost_graph
-    boost_system
-    boost_log
-    ${BOOST_THREAD}
     ${SQLITE3_LIBRARY}
-    ${Boost_LIBRARIES}
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${CLANG_LIBRARIES}
@@ -46,7 +33,7 @@ function(add_phasar_unittest test_name)
     curl
     gtest
   )
-
+  
   add_test(NAME "${test}"
     COMMAND ${test} ${CATCH_TEST_FILTER}
   )

--- a/docker/18.04_base/Dockerfile
+++ b/docker/18.04_base/Dockerfile
@@ -1,0 +1,39 @@
+# Note: This creates an image with a user "phasar" with password also "phasar"
+#
+# Generally the first thing you'll want to do after is run the bootstrap.sh
+# script to compile phasar from the src directory to compile phasar.
+#
+# This dockerfile is intended to setup a minimal environment for successfully 
+# compiling on a Ubuntu 18.04 system.  It does not initiate a compile 
+# (which is a long process, mostly due to the need to compile LLVM), because
+# we want that to run as a normal user, however the bootstrap script also
+# requires sudo access.
+
+
+FROM ubuntu:18.04
+
+
+RUN apt-get update
+
+# We need an updated version of cmake, other than git & sudo these dependencies are for installing that repository
+# We also need wget for other things, that one overlaps.
+RUN apt-get install git sudo apt-utils wget apt-transport-https ca-certificates gnupg software-properties-common -y
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+RUN apt-get update
+RUN apt-get upgrade -y
+
+RUN useradd -ms /bin/bash phasar -p "$(openssl passwd -1 phasar)" -G sudo
+
+USER phasar
+WORKDIR /home/phasar
+
+RUN mkdir -p src
+# ******* NOTE *******  This should switch back to the regular repo and master
+RUN git clone --branch buildCleanup https://github.com/ddiepo-pjr/phasar.git /home/phasar/src
+
+
+
+USER phasar
+WORKDIR /home/phasar
+CMD ["/bin/bash"]

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -12,6 +12,7 @@ else()
 	)
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_controller
   phasar_ifdside
   phasar_mono
@@ -20,7 +21,7 @@ target_link_libraries(phasar_controller
   LLVMCore
 
   curl
-  boost_log
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_controller

--- a/lib/PhasarClang/CMakeLists.txt
+++ b/lib/PhasarClang/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_clang
   clangTooling
   clangFrontendTool
@@ -38,9 +39,8 @@ target_link_libraries(phasar_clang
 
   LLVMSupport
   LLVMCore
-
-  boost_log
-  boost_system
+  
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_clang

--- a/lib/PhasarLLVM/Passes/CMakeLists.txt
+++ b/lib/PhasarLLVM/Passes/CMakeLists.txt
@@ -12,11 +12,13 @@ else()
 	)
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
+
 target_link_libraries(phasar_passes
   phasar_utils
-
-  boost_log
-
+  
+  ${Boost_LIBRARIES}
+  
   LLVMCore
   LLVMSupport
   LLVMAnalysis

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -14,11 +14,11 @@ else()
 	)
 endif()
 
+find_package(Boost COMPONENTS filesystem log REQUIRED)
+
 target_link_libraries(phasar_plugins
   phasar_ifdside
-  boost_system
-  boost_filesystem
-  boost_log
+  ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
 )
 

--- a/lib/PhasarLLVM/Pointer/CMakeLists.txt
+++ b/lib/PhasarLLVM/Pointer/CMakeLists.txt
@@ -13,11 +13,13 @@ else()
 	)
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
+
 target_link_libraries(phasar_pointer
   phasar_utils
-
-  boost_log
-
+  
+  ${Boost_LIBRARIES}
+  
   LLVMCore
   LLVMSupport
   LLVMAnalysis

--- a/lib/PhasarLLVM/Utils/CMakeLists.txt
+++ b/lib/PhasarLLVM/Utils/CMakeLists.txt
@@ -13,10 +13,8 @@ else()
 	)
 endif()
 
-target_link_libraries(phasar_phasarllvm_utils
-  boost_filesystem
-  boost_system
-)
+find_package(Boost COMPONENTS filesystem REQUIRED)
+target_link_libraries(phasar_phasarllvm_utils ${Boost_LIBRARIES})
 
 set_target_properties(phasar_phasarllvm_utils
 	PROPERTIES

--- a/lib/PhasarPass/CMakeLists.txt
+++ b/lib/PhasarPass/CMakeLists.txt
@@ -5,12 +5,15 @@ add_phasar_library(phasar_pass
   ${PHASARPASS_SRC}
 )
 
+find_package(Boost COMPONENTS 
+  filesystem
+  graph
+  log
+  program_options
+  REQUIRED)
+  
 target_link_libraries(phasar_pass
-  boost_filesystem
-  boost_graph
-  boost_log
-  boost_program_options
-  boost_system
+ ${Boost_LIBRARIES}
 
   phasar_config
   phasar_controlflow

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_utils
   phasar_config
 
@@ -25,7 +26,7 @@ target_link_libraries(phasar_utils
   LLVMSupport
   LLVMBitWriter
 
-  boost_log
+  ${Boost_LIBRARIES}
 
   ${CMAKE_DL_LIBS}
 )

--- a/utils/install-llvm-8.0.0.sh
+++ b/utils/install-llvm-8.0.0.sh
@@ -3,31 +3,38 @@
 set -e
 
 num_cores=1
-target_dir=./
+build_dir=./
 re_number="^[0-9]+$"
 
-if [ "$#" -ne 2 ] || ! [[ "$1" =~ ${re_number} ]] || ! [ -d "$2" ]; then
-	echo "usage: <prog> <# cores> <directory>" >&2
+if [ "$#" -ne 3 ] || ! [[ "${1}" =~ ${re_number} ]] || ! [ -d "${2}" ]; then
+	echo "usage: ${0} <# cores> <build directory> <install directory>" >&2
 	exit 1
 fi
 
-num_cores=$1
-target_dir=$2
+num_cores=${1}
+build_dir="${2}"
+dest_dir="${3}"
+
+if [ -x ${dest_dir}/bin/llvm-config ]; then
+   version=`${dest_dir}/bin/llvm-config --version`
+   echo "Found LLVM ${version} already installed at ${dest_dir}."
+   exit 0;
+fi
 
 echo "Getting the LLVM source code..."
-if [ ! -d "${target_dir}/llvm-project" ]; then
-	git clone https://github.com/llvm/llvm-project.git ${target_dir}/llvm-project
+if [ ! -d "${build_dir}/llvm-project" ]; then
+	git clone --branch llvmorg-8.0.0 https://github.com/llvm/llvm-project.git ${build_dir}/llvm-project
 fi
 echo "Building LLVM..."
-cd ${target_dir}/llvm-project/
-git checkout llvmorg-8.0.0
-mkdir -p build
-cd build
+mkdir -p ${build_dir}/llvm-project/build
+cd ${build_dir}/llvm-project/build
 cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;libcxx;libcxxabi;libunwind;lld;lldb;compiler-rt;lld;polly;debuginfo-tests;openmp;parallel-libs' -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CXX1Y=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DBUILD_SHARED_LIBS=ON -DLLVM_BUILD_LLVM_DYLIB=ON ../llvm
+
 make -j${num_cores}
 # echo "Run all tests"
 # make -j3 check-all
 echo "Installing LLVM..."
-sudo make install
+sudo cmake -DCMAKE_INSTALL_PREFIX=${dest_dir} -P cmake_install.cmake 
+echo "${dest_dir}/lib" | sudo tee /etc/ld.so.conf.d/llvm-8.conf > /dev/null
 sudo ldconfig
 echo "Installed LLVM successfully."


### PR DESCRIPTION
These changes allow the user to specify an existing boost install, and
if not specified now boost installs to a version-specific directory,
keeping it separate from potential conflicts with other versions of
boost installed.  Also, the cmake boost dependencies are always
initiated from a find_package call to ensure we get the desired
boost version.

Similarly, llvm now installs to a version-specific directory as well.

Both these change allow a developer to work on projects which may
require different versions of these dependencies.

Lastly, unit tests can be run as part of the bootstrap, albeit somewhat
crudely. The test PhasarLLVM/Mono/InterMonoTaintAnalysisTest is failing
within TaintTest_03.