### PR TITLE
Rewrite phasar cmake to use lib/exec macro linking capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ target_link_libraries(phasar
   LINK_PUBLIC
   phasar_config
   phasar_controller
+  phasar_controlflow
   phasar_mono
   phasar_db
   phasar_experimental

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,10 @@ target_link_libraries(phasar
   phasar_experimental
   phasar_clang
   phasar_passes
+
+  LLVMCore
+  LLVMSupport
+
   ${PHASAR_PLUGINS_LIB}
   phasar_pointer
   boost_program_options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,26 +138,6 @@ if (NOT PHASAR_IN_TREE)
   link_directories(${LLVM_LIB_PATH} ${LLVM_LIBRARY_DIRS})
 endif()
 
-llvm_map_components_to_libnames(llvm_libs
-  coverage
-  coroutines
-  libdriver
-  lto
-  support
-  analysis
-  bitwriter
-  core
-  ipo
-  irreader
-  instcombine
-  instrumentation
-  linker
-  objcarcopts
-  scalaropts
-  transformutils
-  codegen
-  vectorize
-)
 add_definitions(${LLVM_DEFINITIONS})
 
 # Clang
@@ -203,27 +183,75 @@ set(CLANG_LIBRARIES
 add_subdirectory(include)
 add_subdirectory(lib)
 
+set(LLVM_LINK_COMPONENTS
+  coverage
+  coroutines
+  libdriver
+  lto
+  support
+  analysis
+  bitwriter
+  core
+  ipo
+  irreader
+  instcombine
+  instrumentation
+  linker
+  objcarcopts
+  scalaropts
+  transformutils
+  codegen
+  vectorize
+)
+
+llvm_map_components_to_libnames(llvm_libs
+  ${LLVM_LINK_COMPONENTS}
+)
+
 # Build a stand-alone executable
-add_phasar_executable(phasar
-  tools/phasar/phasar.cpp
-)
+if(PHASAR_IN_TREE)
+  add_phasar_executable(phasar
+    tools/phasar/phasar.cpp
+  )
 
-# Build a small test tool to show how phasar may be used
-add_phasar_executable(myphasartool
-  tools/phasar/myphasartool.cpp
-)
+  # Build a small test tool to show how phasar may be used
+  add_phasar_executable(myphasartool
+    tools/phasar/myphasartool.cpp
+  )
 
-add_phasar_executable(syncpdstest
-  tools/phasar/syncpdstest.cpp
-)
+  add_phasar_executable(syncpdstest
+    tools/phasar/syncpdstest.cpp
+  )
 
-add_phasar_executable(boomerangtest
-  tools/phasar/boomerangtest.cpp
-)
+  add_phasar_executable(boomerangtest
+    tools/phasar/boomerangtest.cpp
+  )
 
-add_phasar_executable(wpdstest
-  tools/phasar/wpdstest.cpp
-)
+  add_phasar_executable(wpdstest
+    tools/phasar/wpdstest.cpp
+  )
+else()
+  add_executable(phasar
+    tools/phasar/phasar.cpp
+  )
+
+  # Build a small test tool to show how phasar may be used
+  add_executable(myphasartool
+    tools/phasar/myphasartool.cpp
+  )
+
+  add_executable(syncpdstest
+    tools/phasar/syncpdstest.cpp
+  )
+
+  add_executable(boomerangtest
+    tools/phasar/boomerangtest.cpp
+  )
+
+  add_executable(wpdstest
+    tools/phasar/wpdstest.cpp
+  )
+endif()
 
 # Fix boost_thread dependency for MacOS
 if(APPLE)
@@ -247,14 +275,14 @@ target_link_libraries(phasar
   phasar_config
   phasar_controller
   phasar_controlflow
+  phasar_phasarllvm_utils
+  phasar_ifdside
+  phasar_utils
   phasar_mono
   phasar_db
   phasar_experimental
   phasar_clang
   phasar_passes
-
-  LLVMCore
-  LLVMSupport
 
   ${PHASAR_PLUGINS_LIB}
   phasar_pointer
@@ -270,6 +298,16 @@ target_link_libraries(phasar
   ${CMAKE_THREAD_LIBS_INIT}
   ${CLANG_LIBRARIES}
   curl
+)
+
+if(NOT PHASAR_IN_TREE)
+target_link_libraries(phasar
+  LINK_PUBLIC
+  ${llvm_libs}
+)
+endif()
+
+set(LLVM_LINK_COMPONENTS
 )
 
 target_link_libraries(myphasartool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,24 +204,24 @@ add_subdirectory(include)
 add_subdirectory(lib)
 
 # Build a stand-alone executable
-add_executable(phasar
+add_phasar_executable(phasar
   tools/phasar/phasar.cpp
 )
 
 # Build a small test tool to show how phasar may be used
-add_executable(myphasartool
+add_phasar_executable(myphasartool
   tools/phasar/myphasartool.cpp
 )
 
-add_executable(syncpdstest
+add_phasar_executable(syncpdstest
   tools/phasar/syncpdstest.cpp
 )
 
-add_executable(boomerangtest
+add_phasar_executable(boomerangtest
   tools/phasar/boomerangtest.cpp
 )
 
-add_executable(wpdstest
+add_phasar_executable(wpdstest
   tools/phasar/wpdstest.cpp
 )
 
@@ -243,8 +243,10 @@ endif()
 # Warning! There is a another listing of libraries inside cmake/phasar_macros.cmake.
 # If this list is altered the other one should be altered accordingly.
 target_link_libraries(phasar
+  LINK_PUBLIC
   phasar_config
   phasar_controller
+  phasar_mono
   phasar_db
   phasar_experimental
   phasar_clang
@@ -263,10 +265,10 @@ target_link_libraries(phasar
   ${CMAKE_THREAD_LIBS_INIT}
   ${CLANG_LIBRARIES}
   curl
-  gtest
 )
 
 target_link_libraries(myphasartool
+  LINK_PUBLIC
   phasar_config
   phasar_controller
   phasar_db
@@ -296,6 +298,7 @@ target_link_libraries(myphasartool
 )
 
 target_link_libraries(wpdstest
+  LINK_PUBLIC
   phasar_config
   phasar_controller
   phasar_db
@@ -325,6 +328,7 @@ target_link_libraries(wpdstest
 )
 
 target_link_libraries(syncpdstest
+  LINK_PUBLIC
   phasar_config
   phasar_controller
   phasar_db
@@ -353,6 +357,7 @@ target_link_libraries(syncpdstest
 )
 
 target_link_libraries(boomerangtest
+  LINK_PUBLIC
   phasar_config
   phasar_controller
   phasar_db

--- a/lib/Config/CMakeLists.txt
+++ b/lib/Config/CMakeLists.txt
@@ -1,26 +1,28 @@
 file(GLOB_RECURSE CONFIG_SRC *.h *.cpp)
 
+set(LLVM_LINK_COMPONENTS
+  Support
+)
+
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_config
-		SHARED
-		${CONFIG_SRC}
-	)
+  add_phasar_library(phasar_config
+    SHARED
+    ${CONFIG_SRC}
+  )
 else()
-	add_phasar_library(phasar_config
-		STATIC
-		${CONFIG_SRC}
-	)
+  add_phasar_library(phasar_config
+    STATIC
+    ${CONFIG_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_config
-	LINK_PUBLIC
-	${Boost_LIBRARIES}
-
-  LLVMSupport
+  LINK_PUBLIC
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_config
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -7,6 +7,8 @@ set(PHASAR_LINK_LIBS
   phasar_db
   phasar_pointer
   phasar_controlflow
+  phasar_phasarllvm_utils
+  phasar_utils
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -1,30 +1,35 @@
 file(GLOB_RECURSE CONTROLLER_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_controller
-		SHARED
-		${CONTROLLER_SRC}
-	)
-else()
-	add_phasar_library(phasar_controller
-		STATIC
-		${CONTROLLER_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_controller
+set(PHASAR_LINK_LIBS
   phasar_ifdside
   phasar_mono
   phasar_plugins
+)
 
-  LLVMCore
+set(LLVM_LINK_COMPONENTS
+  Core
+)
 
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_controller
+    SHARED
+    ${CONTROLLER_SRC}
+  )
+else()
+  add_phasar_library(phasar_controller
+    STATIC
+    ${CONTROLLER_SRC}
+  )
+endif()
+
+target_link_libraries(phasar_controller
+  LINK_PUBLIC
   curl
   boost_log
 )
 
 set_target_properties(phasar_controller
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -4,6 +4,9 @@ set(PHASAR_LINK_LIBS
   phasar_ifdside
   phasar_mono
   phasar_plugins
+  phasar_db
+  phasar_pointer
+  phasar_controlflow
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PHASAR_LINK_LIBS
 
 set(LLVM_LINK_COMPONENTS
   Core
+  Support
 )
 
 if(BUILD_SHARED_LIBS)

--- a/lib/DB/CMakeLists.txt
+++ b/lib/DB/CMakeLists.txt
@@ -4,6 +4,28 @@ include_directories(
   ${SQLITE3_INCLUDE_DIR}
 )
 
+set(PHASAR_LINK_LIBS
+  phasar_pointer
+  phasar_passes
+  phasar_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Support
+  Core
+  Vectorize
+  ScalarOpts
+  Instrumentation
+  ObjCARCOpts
+  TransformUtils
+  CodeGen
+  Analysis
+  ipo
+  IRReader
+  InstCombine
+  Linker
+)
+
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_db
     SHARED
@@ -18,23 +40,7 @@ endif()
 
 target_link_libraries(phasar_db
   LINK_PUBLIC
-  phasar_pointer
-  phasar_passes
-  phasar_utils
 
-  LLVMSupport
-  LLVMCore
-  LLVMVectorize
-  LLVMScalarOpts
-  LLVMInstrumentation
-  LLVMObjCARCOpts
-  LLVMTransformUtils
-  LLVMCodeGen
-  LLVMAnalysis
-  LLVMipo
-  LLVMIRReader
-  LLVMInstCombine
-  LLVMLinker
 
   ${Boost_LIBRARIES}
   ${SQLITE3_LIBRARY}

--- a/lib/DB/CMakeLists.txt
+++ b/lib/DB/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   InstCombine
   Linker
+  BitWriter
 )
 
 if(BUILD_SHARED_LIBS)
@@ -40,14 +41,12 @@ endif()
 
 target_link_libraries(phasar_db
   LINK_PUBLIC
-
-
   ${Boost_LIBRARIES}
   ${SQLITE3_LIBRARY}
 )
 
 set_target_properties(phasar_db
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/Experimental/CMakeLists.txt
+++ b/lib/Experimental/CMakeLists.txt
@@ -1,23 +1,25 @@
 file(GLOB_RECURSE EXPERIMENTAL_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_experimental
-		SHARED
-		${EXPERIMENTAL_SRC}
-	)
-else()
-	add_phasar_library(phasar_experimental
-		STATIC
-		${EXPERIMENTAL_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_experimental
-  
+set(PHASAR_LINK_LIBS
 )
 
+set(LLVM_LINK_COMPONENTS
+)
+
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_experimental
+    SHARED
+    ${EXPERIMENTAL_SRC}
+  )
+else()
+  add_phasar_library(phasar_experimental
+    STATIC
+    ${EXPERIMENTAL_SRC}
+  )
+endif()
+
 set_target_properties(phasar_experimental
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarClang/CMakeLists.txt
+++ b/lib/PhasarClang/CMakeLists.txt
@@ -2,10 +2,15 @@ file(GLOB_RECURSE PHASARCLANG_SRC *.h *.cpp)
 
 include_directories(${CLANG_INCLUDE_DIRS})
 
+set(LLVM_LINK_COMPONENTS
+  Support
+  Core
+)
+
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_clang
     SHARED
-	  ${PHASARCLANG_SRC}
+    ${PHASARCLANG_SRC}
   )
 else()
   add_phasar_library(phasar_clang
@@ -15,6 +20,7 @@ else()
 endif()
 
 target_link_libraries(phasar_clang
+  LINK_PUBLIC
   clangTooling
   clangFrontendTool
   clangFrontend
@@ -36,15 +42,12 @@ target_link_libraries(phasar_clang
   clangLex
   clangBasic
 
-  LLVMSupport
-  LLVMCore
-
   boost_log
   boost_system
 )
 
 set_target_properties(phasar_clang
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/ControlFlow/CMakeLists.txt
+++ b/lib/PhasarLLVM/ControlFlow/CMakeLists.txt
@@ -3,6 +3,12 @@ file(GLOB_RECURSE CONTROLFLOW_SRC *.h *.cpp)
 set(PHASAR_LINK_LIBS
   phasar_pointer
   phasar_db
+  phasar_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
 )
 
 if(BUILD_SHARED_LIBS)

--- a/lib/PhasarLLVM/ControlFlow/CMakeLists.txt
+++ b/lib/PhasarLLVM/ControlFlow/CMakeLists.txt
@@ -1,24 +1,24 @@
 file(GLOB_RECURSE CONTROLFLOW_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_controlflow
-		SHARED
-		${CONTROLFLOW_SRC}
-	)
-else()
-	add_phasar_library(phasar_controlflow
-		STATIC
-		${CONTROLFLOW_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_controlflow
+set(PHASAR_LINK_LIBS
   phasar_pointer
   phasar_db
 )
 
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_controlflow
+    SHARED
+    ${CONTROLFLOW_SRC}
+  )
+else()
+  add_phasar_library(phasar_controlflow
+    STATIC
+    ${CONTROLFLOW_SRC}
+  )
+endif()
+
 set_target_properties(phasar_controlflow
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
+++ b/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PHASAR_LINK_LIBS
 
 set(LLVM_LINK_COMPONENTS
   Core
+  Support
 )
 
 if(BUILD_SHARED_LIBS)

--- a/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
+++ b/lib/PhasarLLVM/IfdsIde/CMakeLists.txt
@@ -1,29 +1,32 @@
 file(GLOB_RECURSE IFDSIDE_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_ifdside
-		SHARED
-		${IFDSIDE_SRC}
-	)
-else()
-	add_phasar_library(phasar_ifdside
-		STATIC
-		${IFDSIDE_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_ifdside
+set(PHASAR_LINK_LIBS
   phasar_config
   phasar_utils
   phasar_pointer
   phasar_controlflow
   phasar_phasarllvm_utils
-
-  LLVMCore
+  phasar_db
 )
 
+set(LLVM_LINK_COMPONENTS
+  Core
+)
+
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_ifdside
+    SHARED
+    ${IFDSIDE_SRC}
+  )
+else()
+  add_phasar_library(phasar_ifdside
+    STATIC
+    ${IFDSIDE_SRC}
+  )
+endif()
+
 set_target_properties(phasar_ifdside
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/Mono/CMakeLists.txt
+++ b/lib/PhasarLLVM/Mono/CMakeLists.txt
@@ -1,27 +1,29 @@
 file(GLOB_RECURSE MONO_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_mono
-		SHARED
-		${MONO_SRC}
-	)
-else()
-	add_phasar_library(phasar_mono
-		STATIC
-		${MONO_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_mono
+set(PHASAR_LINK_LIBS
   phasar_config
   phasar_utils
   phasar_phasarllvm_utils
-
-  LLVMCore
 )
 
+set(LLVM_LINK_COMPONENTS
+  Core
+)
+
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_mono
+    SHARED
+    ${MONO_SRC}
+  )
+else()
+  add_phasar_library(phasar_mono
+    STATIC
+    ${MONO_SRC}
+  )
+endif()
+
 set_target_properties(phasar_mono
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/Mono/CMakeLists.txt
+++ b/lib/PhasarLLVM/Mono/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PHASAR_LINK_LIBS
 
 set(LLVM_LINK_COMPONENTS
   Core
+  Support
 )
 
 if(BUILD_SHARED_LIBS)

--- a/lib/PhasarLLVM/Passes/CMakeLists.txt
+++ b/lib/PhasarLLVM/Passes/CMakeLists.txt
@@ -1,29 +1,35 @@
 file(GLOB_RECURSE PASSES_SRC *.h *.cpp)
 
+set(PHASAR_LINK_LIBS
+  phasar_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  Analysis
+)
+
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_passes
-		SHARED
-		${PASSES_SRC}
-	)
+  add_phasar_library(phasar_passes
+    SHARED
+    ${PASSES_SRC}
+  )
 else()
-	add_phasar_library(phasar_passes
-		STATIC
-		${PASSES_SRC}
-	)
+  add_phasar_library(phasar_passes
+    STATIC
+    ${PASSES_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_passes
-  phasar_utils
-
+  LINK_PUBLIC
   boost_log
-
-  LLVMCore
-  LLVMSupport
-  LLVMAnalysis
+  boost_filesystem
 )
 
 set_target_properties(phasar_passes
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -1,6 +1,16 @@
 file(GLOB_RECURSE PLUGINS_SRC *.h *.cpp)
 file(GLOB_RECURSE PLUGINS_SO *.cxx)
 
+set(PHASAR_LINK_LIBS
+  phasar_ifdside
+  phasar_phasarllvm_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+)
+
 # Handle the library files
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_plugins
@@ -15,16 +25,11 @@ else()
 endif()
 
 target_link_libraries(phasar_plugins
-  phasar_ifdside
-  phasar_phasarllvm_utils
-
+  LINK_PUBLIC
   boost_system
   boost_filesystem
   boost_log
   ${CMAKE_DL_LIBS}
-
-  LLVMCore
-  LLVMSupport
 )
 
 # Handle all plugins
@@ -38,6 +43,7 @@ foreach(plugin ${PLUGINS_SO})
     phasar_utils
     phasar_ifdside
     LLVMCore
+    LLVMSupport
     )
 endforeach()
 

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -4,6 +4,7 @@ file(GLOB_RECURSE PLUGINS_SO *.cxx)
 set(PHASAR_LINK_LIBS
   phasar_ifdside
   phasar_phasarllvm_utils
+  phasar_utils
 )
 
 set(LLVM_LINK_COMPONENTS
@@ -26,9 +27,10 @@ endif()
 
 target_link_libraries(phasar_plugins
   LINK_PUBLIC
-  boost_system
   boost_filesystem
   boost_log
+  boost_program_options
+  boost_system
   ${CMAKE_DL_LIBS}
 )
 

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -3,23 +3,28 @@ file(GLOB_RECURSE PLUGINS_SO *.cxx)
 
 # Handle the library files
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_plugins
-		SHARED
-		${PLUGINS_SRC}
-	)
+  add_phasar_library(phasar_plugins
+    SHARED
+    ${PLUGINS_SRC}
+  )
 else()
-	add_phasar_library(phasar_plugins
-		STATIC
-		${PLUGINS_SRC}
-	)
+  add_phasar_library(phasar_plugins
+    STATIC
+    ${PLUGINS_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_plugins
   phasar_ifdside
+  phasar_phasarllvm_utils
+
   boost_system
   boost_filesystem
   boost_log
   ${CMAKE_DL_LIBS}
+
+  LLVMCore
+  LLVMSupport
 )
 
 # Handle all plugins
@@ -37,7 +42,7 @@ foreach(plugin ${PLUGINS_SO})
 endforeach()
 
 set_target_properties(phasar_plugins
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/Pointer/CMakeLists.txt
+++ b/lib/PhasarLLVM/Pointer/CMakeLists.txt
@@ -1,30 +1,37 @@
 file(GLOB_RECURSE POINTER_SRC *.h *.cpp)
 
+set(PHASAR_LINK_LIBS
+  phasar_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  Analysis
+)
+
 # Handle the library files
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_pointer
-		SHARED
-		${POINTER_SRC}
-	)
+  add_phasar_library(phasar_pointer
+    SHARED
+    ${POINTER_SRC}
+  )
 else()
-	add_phasar_library(phasar_pointer
-		STATIC
-		${POINTER_SRC}
-	)
+  add_phasar_library(phasar_pointer
+    STATIC
+    ${POINTER_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_pointer
-  phasar_utils
-
+  LINK_PUBLIC
   boost_log
-
-  LLVMCore
-  LLVMSupport
-  LLVMAnalysis
+  boost_filesystem
+  boost_graph
 )
 
 set_target_properties(phasar_pointer
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/SyncPDS/CMakeLists.txt
+++ b/lib/PhasarLLVM/SyncPDS/CMakeLists.txt
@@ -1,24 +1,24 @@
 file(GLOB_RECURSE SYNCPDS_SRC *.h *.cpp)
 
-if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_syncpds
-		SHARED
-		${SYNCPDS_SRC}
-	)
-else()
-	add_phasar_library(phasar_syncpds
-		STATIC
-		${SYNCPDS_SRC}
-	)
-endif()
-
-target_link_libraries(phasar_syncpds
-	phasar_controlflow
-	phasar_wpds
+set(PHASAR_LINK_LIBS
+  phasar_controlflow
+  phasar_wpds
 )
 
+if(BUILD_SHARED_LIBS)
+  add_phasar_library(phasar_syncpds
+    SHARED
+    ${SYNCPDS_SRC}
+  )
+else()
+  add_phasar_library(phasar_syncpds
+    STATIC
+    ${SYNCPDS_SRC}
+  )
+endif()
+
 set_target_properties(phasar_syncpds
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/Utils/CMakeLists.txt
+++ b/lib/PhasarLLVM/Utils/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
 endif()
 
 target_link_libraries(phasar_phasarllvm_utils
+  LINK_PUBLIC
   boost_filesystem
   boost_system
 )

--- a/lib/PhasarLLVM/Utils/CMakeLists.txt
+++ b/lib/PhasarLLVM/Utils/CMakeLists.txt
@@ -1,5 +1,10 @@
 file(GLOB_RECURSE UTILS_SRC *.h *.cpp)
 
+set(PHASAR_LINK_LIBS
+  phasar_config
+  phasar_utils
+)
+
 # Handle the library files
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_phasarllvm_utils

--- a/lib/PhasarLLVM/Utils/CMakeLists.txt
+++ b/lib/PhasarLLVM/Utils/CMakeLists.txt
@@ -2,15 +2,15 @@ file(GLOB_RECURSE UTILS_SRC *.h *.cpp)
 
 # Handle the library files
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_phasarllvm_utils
-		SHARED
-		${UTILS_SRC}
-	)
+  add_phasar_library(phasar_phasarllvm_utils
+    SHARED
+    ${UTILS_SRC}
+  )
 else()
-	add_phasar_library(phasar_phasarllvm_utils
-		STATIC
-		${UTILS_SRC}
-	)
+  add_phasar_library(phasar_phasarllvm_utils
+    STATIC
+    ${UTILS_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_phasarllvm_utils
@@ -19,7 +19,7 @@ target_link_libraries(phasar_phasarllvm_utils
 )
 
 set_target_properties(phasar_phasarllvm_utils
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarLLVM/WPDS/CMakeLists.txt
+++ b/lib/PhasarLLVM/WPDS/CMakeLists.txt
@@ -1,26 +1,34 @@
 file(GLOB_RECURSE WPDS_SRC *.h *.cpp)
 
+set(PHASAR_LINK_LIBS
+  phasar_utils
+  phasar_ifdside
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+)
+
 if(BUILD_SHARED_LIBS)
-	add_phasar_library(phasar_wpds
-		SHARED
-		${WPDS_SRC}
-	)
+  add_phasar_library(phasar_wpds
+    SHARED
+    ${WPDS_SRC}
+  )
 else()
-	add_phasar_library(phasar_wpds
-		STATIC
-		${WPDS_SRC}
-	)
+  add_phasar_library(phasar_wpds
+    STATIC
+    ${WPDS_SRC}
+  )
 endif()
 
 target_link_libraries(phasar_wpds
-  phasar_utils
-  phasar_ifdside
-
-  LLVMCore
+  LINK_PUBLIC
+  boost_filesystem
 )
 
 set_target_properties(phasar_wpds
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/PhasarPass/CMakeLists.txt
+++ b/lib/PhasarPass/CMakeLists.txt
@@ -1,5 +1,22 @@
 file(GLOB_RECURSE PHASARPASS_SRC *.h *.cpp)
 
+set(PHASAR_LINK_LIBS
+  phasar_config
+  phasar_controlflow
+  phasar_db
+  phasar_ifdside
+  phasar_mono
+  phasar_passes
+  phasar_phasarllvm_utils
+  phasar_pointer
+  phasar_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+)
+
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_pass
     SHARED
@@ -12,26 +29,20 @@ else()
   )
 endif()
 
+# We specifically link internal phasar libs into phasar_pass so on that the
+# llvm user side only has to specify one library.
 target_link_libraries(phasar_pass
+  LINK_PUBLIC
+  ${PHASAR_LINK_LIBS}
   boost_filesystem
   boost_graph
   boost_log
   boost_program_options
   boost_system
-
-  phasar_config
-  phasar_controlflow
-  phasar_db
-  phasar_ifdside
-  phasar_mono
-  phasar_passes
-  phasar_phasarllvm_utils
-  phasar_pointer
-  phasar_utils
 )
 
 set_target_properties(phasar_pass
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -1,10 +1,21 @@
 file(GLOB_RECURSE UTILS_SRC *.h *.cpp)
 
 if(PHASAR_ENABLE_PAMM STREQUAL "Off" AND NOT PHASAR_BUILD_UNITTESTS)
-	message("Not compiling PAMM.cpp since PAMM and Unittests are disabled.")
-	get_filename_component(pamm_src PAMM.cpp ABSOLUTE)
-	list(REMOVE_ITEM UTILS_SRC ${pamm_src})
+  message("Not compiling PAMM.cpp since PAMM and Unittests are disabled.")
+  get_filename_component(pamm_src PAMM.cpp ABSOLUTE)
+  list(REMOVE_ITEM UTILS_SRC ${pamm_src})
 endif()
+
+set(PHASAR_LINK_LIBS
+  phasar_config
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  BitWriter
+)
+
 
 if(BUILD_SHARED_LIBS)
   add_phasar_library(phasar_utils
@@ -19,19 +30,13 @@ else()
 endif()
 
 target_link_libraries(phasar_utils
-  phasar_config
-
-  LLVMCore
-  LLVMSupport
-  LLVMBitWriter
-
+  LINK_PUBLIC
   boost_log
-
   ${CMAKE_DL_LIBS}
 )
 
 set_target_properties(phasar_utils
-	PROPERTIES
-	LINKER_LANGUAGE CXX
-	PREFIX "lib"
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
 )


### PR DESCRIPTION
The cmake macros add_phasar_library and  add_phasar_executable have specific variables on how to pass options for linking phasar_libs and llvm_components, this commit update phasars to use these.
This fixes RPATH issues when installing phasar with an in tree build.