### PR TITLE
Fix build to allow custom boost, llvm and phasar directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,18 @@ include_directories(
 # Threads
 find_package(Threads)
 
+# Fix boost_thread dependency for MacOS
+if(APPLE)
+  set(BOOST_THREAD thread-mt)
+else()
+  set(BOOST_THREAD thread)
+endif()
+
+# Boost
+find_package(Boost 1.66.0 COMPONENTS filesystem graph system program_options log ${BOOST_THREAD} REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+add_definitions(-DBOOST_LOG_DYN_LINK)
+
 # JSON library
 option(JSON_BuildTests OFF)
 add_subdirectory(external/json EXCLUDE_FROM_ALL)
@@ -110,11 +122,6 @@ endif()
 # WALi-OpenNWA
 add_subdirectory(external/WALi-OpenNWA)
 include_directories(external/WALi-OpenNWA/Source/wali/include)
-
-# Boost
-find_package(Boost COMPONENTS filesystem graph system program_options log thread REQUIRED)
-include_directories(${BOOST_INCLUDE_DIR})
-add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # SQL
 find_path(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
@@ -202,13 +209,6 @@ llvm_map_components_to_libnames(llvm_libs
 
 # phasar-based binaries
 add_subdirectory(tools)
-
-# Fix boost_thread dependency for MacOS
-if(APPLE)
-  set(BOOST_THREAD boost_thread-mt)
-else()
-  set(BOOST_THREAD boost_thread)
-endif()
 
 # Workaround: Remove Plugins for MacOS for now
 if(APPLE)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -e
 
+readonly PHASAR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+readonly PHASAR_INSTALL_DIR="/usr/local/phasar"
+readonly LLVM_INSTALL_DIR="/usr/local/llvm-9"
+
 NUM_THREADS=$(nproc)
 LLVM_RELEASE=llvmorg-9.0.0
+DO_UNIT_TEST=false
+
 
 # Parsing command-line-parameters
 # See "https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash" as a reference
@@ -17,6 +23,19 @@ case $key in
     NUM_THREADS="$2"
     shift # past argument
     shift # past value
+    ;;
+    -u|--unittest)
+    DO_UNIT_TEST=true
+    shift # past argument
+    ;;
+    -DBOOST_DIR)
+    DESIRED_BOOST_DIR="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -DBOOST_DIR=*)
+    DESIRED_BOOST_DIR="${key#*=}"
+    shift # past argument=value
     ;;
     -DBOOST_VERSION)
     DESIRED_BOOST_VERSION="$2"
@@ -41,79 +60,87 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 echo "installing phasar dependencies..."
 
 sudo apt-get update
-sudo apt-get install zlib1g-dev sqlite3 libsqlite3-dev libmysqlcppconn-dev bear python3 doxygen graphviz python python-dev python3-pip python-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libz3-dev libedit-dev python-sphinx libomp-dev libcurl4-openssl-dev -y
+sudo apt-get install zlib1g-dev sqlite3 libsqlite3-dev bear python3 doxygen graphviz python python-dev python3-pip python-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libz3-dev libedit-dev python-sphinx libomp-dev libcurl4-openssl-dev -y
 sudo pip install Pygments
 sudo pip install pyyaml
-# installing boost
-#wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
-#tar xvf boost_1_66_0.tar.gz
-#cd boost_1_66_0/
-#./bootstrap.sh
-#sudo ./b2 install
-#cd ..
 
-# New way of installing boost:
-
-# Check whether we have the required boost packages installed
-
-BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"') 
-
-if [ -z $BOOST_VERSION ] ;then
-    if [ -z $DESIRED_BOOST_VERSION ] ;then
-        sudo apt-get install libboost-all-dev -y
-    else
-        # DESIRED_BOOST_VERSION in form d.d, i.e. 1.65 (this is the latest version I found in the apt repo)
-        sudo apt-get install "libboost${DESIRED_BOOST_VERSION}-all-dev" -y
-    fi
-    #verify installation
-    BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"') 
-    if [ -z $BOOST_VERSION ] ;then
-        echo "Failed installing boost $DESIRED_BOOST_VERSION"
-        exit 1
-    else
-        echo "Successfully installed boost v${BOOST_VERSION//_/.}"
-    fi
+if [ ! -z ${DESIRED_BOOST_DIR} ]; then
+    BOOST_PARAMS="-DBOOST_ROOT=${DESIRED_BOOST_DIR}" 
 else
-    echo "Already installed boost version ${BOOST_VERSION//_/.}"
-    DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
-    # install missing packages if necessary
-    boostlibnames=("libboost-system" "libboost-filesystem" 
-               "libboost-graph" "libboost-program-options"
-               "libboost-log" "libboost-thread")
-    additional_boost_libs=()
+# New way of installing boost:
+# Check whether we have the required boost packages installed
+    BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"')
 
-    for boost_lib in ${boostlibnames[@]}; do
-        dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 || additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}")
-    done
-    if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
-        echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[@]}"
-        sudo apt-get install ${additional_boost_libs[@]} -y
-    fi 
+	if [ -z $BOOST_VERSION ] ;then
+	    if [ -z $DESIRED_BOOST_VERSION ] ;then
+	        sudo apt-get install libboost-all-dev -y
+	    else
+	        # DESIRED_BOOST_VERSION in form d.d, i.e. 1.65 (this is the latest version I found in the apt repo)
+	        sudo apt-get install "libboost${DESIRED_BOOST_VERSION}-all-dev" -y
+	    fi
+	    #verify installation
+	    BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"') 
+	    if [ -z $BOOST_VERSION ] ;then
+	        echo "Failed installing boost $DESIRED_BOOST_VERSION"
+	        exit 1
+	    else
+	        echo "Successfully installed boost v${BOOST_VERSION//_/.}"
+	    fi
+	else
+	    echo "Already installed boost version ${BOOST_VERSION//_/.}"
+	    DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
+	    # install missing packages if necessary
+	    boostlibnames=("libboost-system" "libboost-filesystem" 
+	               "libboost-graph" "libboost-program-options"
+	               "libboost-log" "libboost-thread")
+	    additional_boost_libs=()
+	
+	    for boost_lib in ${boostlibnames[@]}; do
+	        dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 || additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}")
+	    done
+	    if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
+	        echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[@]}"
+	        sudo apt-get install ${additional_boost_libs[@]} -y
+	    fi 
+	fi
 fi
 
 
 
 # installing LLVM
-./utils/install-llvm.sh $NUM_THREADS . $LLVM_RELEASE
-# installing wllvm
+tmp_dir=`mktemp -d "llvm-9_build.XXXXXXXX" --tmpdir`
+./utils/install-llvm.sh ${NUM_THREADS} ${tmp_dir} ${LLVM_INSTALL_DIR} ${LLVM_RELEASE}
+rm -rf ${tmp_dir}
 sudo pip3 install wllvm
 
 echo "dependencies successfully installed"
-echo "build phasar..."
+echo "Building PhASAR..."
+${DO_UNIT_TESTS} && echo "with unit tests."
 
-#git submodule init
-#git submodule update
+git submodule init
+git submodule update
 
-export CC=/usr/local/bin/clang
-export CXX=/usr/local/bin/clang++
+export CC=${LLVM_INSTALL}/bin/clang
+export CXX=${LLVM_INSTALL}/bin/clang++
 
-mkdir -p build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+mkdir -p ${PHASAR_DIR}/build
+cd ${PHASAR_DIR}/build
+cmake -DCMAKE_BUILD_TYPE=Release ${BOOST_PARAMS} -DPHASAR_BUILD_UNITTESTS=${DO_UNIT_TEST} ${PHASAR_DIR}
 make -j $NUM_THREADS
+
+if ${DO_UNIT_TEST}; then
+   echo "Running PhASAR unit tests..."
+   pushd unittests
+   for x in `find . -type f -executable -print`; do 
+       pushd ${x%/*} && ./${x##*/} && popd || { echo "Test ${x} failed, aborting."; exit 1; };
+       done
+   popd
+fi
+
 echo "phasar successfully built"
 echo "install phasar..."
-sudo make install
+sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
+
 sudo ldconfig
 cd ..
-echo "phasar successfully installed"
+echo "phasar successfully installed to ${PHASAR_INSTALL_DIR}"

--- a/lib/Controller/CMakeLists.txt
+++ b/lib/Controller/CMakeLists.txt
@@ -30,10 +30,11 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_controller
   LINK_PUBLIC
   curl
-  boost_log
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_controller

--- a/lib/PhasarClang/CMakeLists.txt
+++ b/lib/PhasarClang/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_clang
   LINK_PUBLIC
   clangTooling
@@ -42,8 +43,7 @@ target_link_libraries(phasar_clang
   clangLex
   clangBasic
 
-  boost_log
-  boost_system
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_clang

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/CMakeLists.txt
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/CMakeLists.txt
@@ -22,10 +22,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS filesystem REQUIRED)
 target_link_libraries(phasar_wpds
   LINK_PUBLIC
-  boost_filesystem
-  boost_system
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_wpds

--- a/lib/PhasarLLVM/Passes/CMakeLists.txt
+++ b/lib/PhasarLLVM/Passes/CMakeLists.txt
@@ -22,11 +22,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem REQUIRED)
 target_link_libraries(phasar_passes
   LINK_PUBLIC
-  boost_log
-  boost_filesystem
-  boost_system
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_passes

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -26,12 +26,11 @@ else()
   )
 endif()
 
+
+find_package(Boost COMPONENTS log filesystem program_options REQUIRED)
 target_link_libraries(phasar_plugins
   LINK_PUBLIC
-  boost_filesystem
-  boost_log
-  boost_program_options
-  boost_system
+  ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
 )
 

--- a/lib/PhasarLLVM/Pointer/CMakeLists.txt
+++ b/lib/PhasarLLVM/Pointer/CMakeLists.txt
@@ -36,12 +36,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem graph REQUIRED)
 target_link_libraries(phasar_pointer
-  LINK_PUBLIC
-  boost_log
-  boost_filesystem
-  boost_graph
-  boost_system
+  LINK_PUBLIC  
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_pointer

--- a/lib/PhasarLLVM/TypeHierarchy/CMakeLists.txt
+++ b/lib/PhasarLLVM/TypeHierarchy/CMakeLists.txt
@@ -23,11 +23,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem graph REQUIRED)
 target_link_libraries(phasar_typehierarchy
   LINK_PUBLIC
-  boost_log
-  boost_filesystem
-  boost_graph
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_typehierarchy

--- a/lib/PhasarLLVM/Utils/CMakeLists.txt
+++ b/lib/PhasarLLVM/Utils/CMakeLists.txt
@@ -18,10 +18,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS filesystem REQUIRED)
 target_link_libraries(phasar_phasarllvm_utils
   LINK_PUBLIC
-  boost_filesystem
-  boost_system
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_phasarllvm_utils

--- a/lib/PhasarPass/CMakeLists.txt
+++ b/lib/PhasarPass/CMakeLists.txt
@@ -32,14 +32,12 @@ endif()
 
 # We specifically link internal phasar libs into phasar_pass so on that the
 # llvm user side only has to specify one library.
+
+find_package(Boost COMPONENTS log filesystem graph program_options REQUIRED)
 target_link_libraries(phasar_pass
   LINK_PUBLIC
   ${PHASAR_LINK_LIBS}
-  boost_filesystem
-  boost_graph
-  boost_log
-  boost_program_options
-  boost_system
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_pass

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -29,9 +29,10 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_utils
   LINK_PUBLIC
-  boost_log
+  ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
 )
 

--- a/tools/boomerang/CMakeLists.txt
+++ b/tools/boomerang/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem program_options graph ${BOOST_THREAD} REQUIRED)
 target_link_libraries(boomerang
   LINK_PUBLIC
   phasar_config
@@ -26,12 +27,6 @@ target_link_libraries(boomerang
   phasar_typehierarchy
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/tools/example-tool/CMakeLists.txt
+++ b/tools/example-tool/CMakeLists.txt
@@ -11,6 +11,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem program_options graph ${BOOST_THREAD} REQUIRED)
 target_link_libraries(myphasartool
   LINK_PUBLIC
   phasar_config
@@ -27,12 +28,6 @@ target_link_libraries(myphasartool
   phasar_typehierarchy
   phasar_phasarllvm_utils
   phasar_utils
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/tools/phasar-clang/CMakeLists.txt
+++ b/tools/phasar-clang/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem program_options graph ${BOOST_THREAD} REQUIRED)
 target_link_libraries(phasar-clang
   LINK_PUBLIC
   phasar_config
@@ -28,12 +29,6 @@ target_link_libraries(phasar-clang
   # ${PHASAR_PLUGINS_LIB}
   phasar_pointer
   phasar_typehierarchy
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${SQLITE3_LIBRARY}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}

--- a/tools/phasar-llvm/CMakeLists.txt
+++ b/tools/phasar-llvm/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS log filesystem program_options graph ${BOOST_THREAD} REQUIRED)
 # Warning! There is a another listing of libraries inside cmake/phasar_macros.cmake.
 # If this list is altered the other one should be altered accordingly.
 target_link_libraries(phasar-llvm
@@ -30,12 +31,6 @@ target_link_libraries(phasar-llvm
   # ${PHASAR_PLUGINS_LIB}
   phasar_pointer
   phasar_typehierarchy
-  boost_program_options
-  boost_filesystem
-  boost_graph
-  boost_system
-  boost_log
-  ${BOOST_THREAD}
   ${SQLITE3_LIBRARY}
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}

--- a/utils/install-llvm.sh
+++ b/utils/install-llvm.sh
@@ -7,22 +7,30 @@ target_dir=./
 re_number="^[0-9]+$"
 re_llvm_release="^llvmorg-[0-9]+\.[0-9]+\.[0-9]+$"
 
-if [ "$#" -ne 3 ] || ! [[ "$1" =~ ${re_number} ]] || ! [ -d "$2" ] || ! [[ "$3" =~ ${re_llvm_release} ]]; then
-	echo "usage: <prog> <# cores> <directory> <LLVM release (e.g. 'llvmorg-9.0.0')>" >&2
+num_cores=${1}
+build_dir="${2}"
+dest_dir="${3}"
+llvm_release="${4}"
+
+if [ "$#" -ne 4 ] || ! [[ "$num_cores" =~ ${re_number} ]] || ! [ -d "${build_dir}" ] || ! [[ "${llvm_release}" =~ ${re_llvm_release} ]]; then
+	echo "usage: <prog> <# cores> <build dir> <install dir> <LLVM release (e.g. 'llvmorg-9.0.0')>" >&2
 	exit 1
 fi
 
-num_cores=$1
-target_dir=$2
-llvm_release=$3
+
+if [ -x ${dest_dir}/bin/llvm-config ]; then
+   version=`${dest_dir}/bin/llvm-config --version`
+   echo "Found LLVM ${version} already installed at ${dest_dir}."
+   exit 0;
+fi
 
 echo "Getting the LLVM source code..."
-if [ ! -d "${target_dir}/llvm-project" ]; then
+if [ ! -d "${build_dir}/llvm-project" ]; then
     echo "Getting the complete LLVM source code"
-	git clone https://github.com/llvm/llvm-project.git ${target_dir}/llvm-project
+	git clone https://github.com/llvm/llvm-project.git ${build_dir}/llvm-project
 fi
 echo "Building LLVM..."
-cd ${target_dir}/llvm-project/
+cd ${build_dir}/llvm-project/
 echo "Build the LLVM project"
 git checkout ${llvm_release}
 mkdir -p build
@@ -31,7 +39,7 @@ cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;libcxx
 make -j${num_cores}
 # echo "Run all tests"
 # make -j3 check-all
-echo "Installing LLVM..."
-sudo make install
+echo "Installing LLVM to ${dest_dir}"
+sudo cmake -DCMAKE_INSTALL_PREFIX=${dest_dir} -P cmake_install.cmake 
 sudo ldconfig
 echo "Installed LLVM successfully."


### PR DESCRIPTION
The build was assuming that boost was installed to the default system
location and accessible, however for using this as a library I want to
use a custom installed boost to match the version of boost used by the
application. Most of the changes to CMakeLists are to use find_package
to locate the desired boost libraries. I believe this is the preferred
way to include boost libraries.

Also, this changed to allow llvm to be installed to a specified
directory. This change allows the developer to work with multiple
different versions for different projects.

The bootstrap.sh changes include:
- This also includes a change to specify the exact directory for phasar
to be installed to. This allows the developer to have multiple
installations.
- The git submodule init / update was required for a fresh install.  I'm
guessing this was just accidentally commented out.
- Removed the package libmysqlcppconn-dev which isn't necessary to
copmile.  Perhaps there's another dependency somewhere else, but I
specifically removed this because it also pulls in a bunch of other
dependencies (notably boost, and I specifically do not want the
maintaner's version of boost installed).
- Added ability to specify the boost install dir to use.
- Added ability to run unit tests (I haven't verified this
functionality, but it did work prior to the big merge last week).