### PR TITLE
Fix get calls for the case the function is not a vertex.

### DIFF
--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -281,10 +281,13 @@ set<const llvm::Function *>
 LLVMBasedICFG::getCalleesOfCallAt(const llvm::Instruction *n) const {
   if (llvm::isa<llvm::CallInst>(n) || llvm::isa<llvm::InvokeInst>(n)) {
     set<const llvm::Function *> Callees;
-    auto Caller = n->getFunction();
+    auto mapEntry = FunctionVertexMap.find(n->getFunction());
+    if (mapEntry == FunctionVertexMap.end()) {
+      return Callees;
+    }
     out_edge_iterator ei, ei_end;
     for (boost::tie(ei, ei_end) =
-             boost::out_edges(FunctionVertexMap.at(Caller), CallGraph);
+             boost::out_edges(mapEntry->second, CallGraph);
          ei != ei_end; ++ei) {
       auto source = boost::source(*ei, CallGraph);
       auto edge = CallGraph[*ei];
@@ -305,9 +308,13 @@ LLVMBasedICFG::getCalleesOfCallAt(const llvm::Instruction *n) const {
 set<const llvm::Instruction *>
 LLVMBasedICFG::getCallersOf(const llvm::Function *F) const {
   set<const llvm::Instruction *> CallersOf;
+  auto mapEntry = FunctionVertexMap.find(F);
+  if (mapEntry == FunctionVertexMap.end()) {
+    return CallersOf;
+  }
   in_edge_iterator ei, ei_end;
   for (boost::tie(ei, ei_end) =
-           boost::in_edges(FunctionVertexMap.at(F), CallGraph);
+           boost::in_edges(mapEntry->second, CallGraph);
        ei != ei_end; ++ei) {
     auto source = boost::source(*ei, CallGraph);
     auto edge = CallGraph[*ei];


### PR DESCRIPTION
For these two functions, the function (or the function of the
corresponding instruction) may not be part of the callgraph. In the
original code this resulted in an exception being thrown. With the
modification an empty set is returned instead.