### PR TITLE
Refactor Points-To graph merge logic.

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
@@ -116,9 +116,12 @@ private:
 
   /// The points to graph.
   graph_t PAG;
-  std::unordered_map<const llvm::Value *, vertex_t> ValueVertexMap;
+  typedef std::unordered_map<const llvm::Value *, vertex_t> ValueVertexMapT;
+  ValueVertexMapT ValueVertexMap;
   /// Keep track of what has already been merged into this points-to graph.
-  std::unordered_set<std::string> ContainedFunctions;
+  std::unordered_set<const llvm::Function* > ContainedFunctions;
+
+  void mergeGraph(const PointsToGraph &Other);
 
 public:
   /**
@@ -213,11 +216,13 @@ public:
   // TODO add more detailed description
   inline bool representsSingleFunction();
   void mergeWith(const PointsToGraph *Other, const llvm::Function *F);
+
+  void mergeCallSite(const llvm::ImmutableCallSite &CS,
+                     const llvm::Function *F);
+
   void mergeWith(const PointsToGraph &Other,
                  const std::vector<std::pair<llvm::ImmutableCallSite,
                                              const llvm::Function *>> &Calls);
-  void mergeWith(PointsToGraph *Other, llvm::ImmutableCallSite CS,
-                 const llvm::Function *F);
 
   /**
    * The value-vertex-map maps each Value of the points-to graph to

--- a/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
@@ -23,6 +23,7 @@
 
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/ControlFlow/Resolver/OTFResolver.h>
+#include <phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h>
 #include <phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h>
 #include <phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h>
 #include <phasar/Utils/LLVMShorthands.h>
@@ -52,7 +53,8 @@ void OTFResolver::handlePossibleTargets(
     // only if they are available
     if (!CalleeTarget->isDeclaration()) {
       auto CalleePTG = PT.getPointsToGraph(CalleeTarget);
-      WholeModulePTG.mergeWith(CalleePTG, CS, CalleeTarget);
+      WholeModulePTG.mergeWith(CalleePTG, CalleeTarget);
+      WholeModulePTG.mergeCallSite(CS, CalleeTarget);
     }
   }
 }


### PR DESCRIPTION
Changes the merge logic for points-to graph to avoid re-creating the
ValueVertexMap from scratch each time.  When merging we can ask boost to
provide a mapping so we can simply append to the existing ValueVertexMap
instead.  For large applications this makes a measurable runtime
improvement since the number of merge calls is large.

I verified with a small application which does some virtual function calls that the resulting callgraph before/after this change were identical.