### PR TITLE
Optimize calls to get the Users for a a points-to vertex.

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
@@ -77,6 +77,10 @@ public:
     VertexProperties() = default;
     VertexProperties(const llvm::Value *v);
     std::string getValueAsString() const;
+
+    // Fetching the users for V is expensive, so we cache the result.
+    mutable std::vector<const llvm::User*> users;
+    std::vector<const llvm::User*> getUsers() const;
   };
 
   /**
@@ -91,7 +95,7 @@ public:
   };
 
   /// Data structure for holding the points-to graph.
-  typedef boost::adjacency_list<boost::setS, boost::vecS, boost::undirectedS,
+  typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
                                 VertexProperties, EdgeProperties>
       graph_t;
 


### PR DESCRIPTION
The call to Value->users() is quite expensive.  Because the result
should not change between executions, we can cache the results for each
Vertex of the points-to graph.  This has a significant performance
improvement.

Changing the graph's backing data structure edge type to use a vector
instead of a set also improves performance.

This change also modifies the n^2 loop to be n^2/2 as described in the
comments -- the inner loop was previously starting at the beginning of
the map instead of at the next item in the map, and we can avoid looking
up in the map by using the appropriate iterators.  These changes did not
significantly impact performance, however the resulting code is more
concise.