### PR TITLE
ICFG Optimizations -- graph merging and others.

### DIFF
--- a/include/phasar/DB/ProjectIRDB.h
+++ b/include/phasar/DB/ProjectIRDB.h
@@ -20,7 +20,6 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 
-#include <phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h>
 #include <phasar/Utils/EnumFlags.h>
 
 namespace llvm {

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -88,7 +88,7 @@ private:
   };
 
   /// Specify the type of graph to be used.
-  typedef boost::adjacency_list<boost::multisetS, boost::vecS,
+  typedef boost::adjacency_list<boost::vecS, boost::vecS,
                                 boost::bidirectionalS, VertexProperties,
                                 EdgeProperties>
       bidigraph_t;
@@ -106,7 +106,7 @@ private:
   /// Maps function names to the corresponding vertex id.
   std::unordered_map<const llvm::Function *, vertex_t> FunctionVertexMap;
 
-  void constructionWalker(const llvm::Function *F, Resolver *Res);
+  void constructionWalker(const llvm::Function *F, Resolver &Resolver);
 
   struct dependency_visitor;
 
@@ -162,44 +162,7 @@ public:
   using LLVMBasedCFG::print; // tell the compiler we wish to have both prints
   void print(std::ostream &OS = std::cout) const override;
 
-  // provide a VertexPropertyWrite to tell boost how to write a vertex
-  class CallGraphVertexWriter {
-  public:
-    CallGraphVertexWriter(const bidigraph_t &CGraph) : CGraph(CGraph) {}
-    template <class VertexOrEdge>
-    void operator()(std::ostream &out, const VertexOrEdge &v) const {
-      out << "[label=\"" << CGraph[v].getFunctionName() << "\"]";
-    }
-
-  private:
-    const bidigraph_t &CGraph;
-  };
-
-  // a function to conveniently create the vertex writer
-  CallGraphVertexWriter
-  makeCallGraphVertexWriter(const bidigraph_t &CGraph) const {
-    return CallGraphVertexWriter(CGraph);
-  }
-
-  // provide a EdgePropertyWrite to tell boost how to write an edge
-  class CallGraphEdgeWriter {
-  public:
-    CallGraphEdgeWriter(const bidigraph_t &CGraph) : CGraph(CGraph) {}
-    template <class VertexOrEdge>
-    void operator()(std::ostream &out, const VertexOrEdge &v) const {
-      out << "[label=\"" << CGraph[v].getCallSiteAsString() << "\"]";
-    }
-
-  private:
-    const bidigraph_t &CGraph;
-  };
-
-  // a function to conveniently create the edge writer
-  CallGraphEdgeWriter makeCallGraphEdgeWriter(const bidigraph_t &CGraph) const {
-    return CallGraphEdgeWriter(CGraph);
-  }
-
-  void printAsDot(std::ostream &OS = std::cout) const;
+  void printAsDot(std::ostream &OS = std::cout, bool printEdgeLabels = true) const;
 
   void printInternalPTGAsDot(std::ostream &OS = std::cout) const;
 

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMZeroValue.h>
 #include <phasar/PhasarLLVM/Passes/GeneralStatisticsAnalysis.h>

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -35,6 +35,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h>
 #include <phasar/Utils/GraphExtensions.h>

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFGTest.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 #include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.h>
 #include <phasar/Utils/LLVMShorthands.h>

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 #include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h>
 #include <phasar/Utils/LLVMShorthands.h>

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h>
 #include <phasar/Utils/LLVMShorthands.h>

--- a/unittests/PhasarLLVM/TypeHierarchy/TypeGraphTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/TypeGraphTest.cpp
@@ -4,6 +4,7 @@
 #include <phasar/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.h>
 
 #include <boost/graph/isomorphism.hpp>
+#include <phasar/Config/Configuration.h>
 #include <phasar/Utils/LLVMShorthands.h>
 #include <phasar/Utils/Utilities.h>
 

--- a/unittests/Utils/LLVMShorthandsTest.cpp
+++ b/unittests/Utils/LLVMShorthandsTest.cpp
@@ -1,4 +1,7 @@
 #include <gtest/gtest.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <phasar/Config/Configuration.h>
 #include <phasar/DB/ProjectIRDB.h>
 #include <phasar/Utils/LLVMShorthands.h>
 #include <phasar/Utils/Utilities.h>


### PR DESCRIPTION
The largest change performance wise is the change to the graph type to
use a vector for edge storage.

The merge function now mirrors the changes to the Points-To class to
avoid re-building the FunctionVertexMap from scratch.

Changes in constructionWalker avoid fetching the same data multiple
times back-to-back.

printAsDot was modified to allow the user to skip the edge labels,
because those are quite expensive.  Moved code out of the header that is
only used internally to this function body.


ProjectIRDB.h does not use the LLVMPointsToGraph.h, so it was removed
which necessitated several other header changes.