### PR TITLE
Removes cyclic linking dependency for VaRA-LTO

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/Mono/CMakeLists.txt
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PHASAR_LINK_LIBS
   phasar_config
   phasar_utils
   phasar_phasarllvm_utils
+  phasar_db
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -32,7 +32,6 @@ set(LLVM_LINK_COMPONENTS
   coverage
   coroutines
   libdriver
-  lto
   support
   analysis
   bitwriter


### PR DESCRIPTION
Removes unused dependency to link lto against phasar_utils.
Furthermore, adds needed dependency to phasar_mono.