### PR TITLE
Removes const version of bits setter function in BitVectorSet

### DIFF
--- a/include/phasar/Utils/BitVectorSet.h
+++ b/include/phasar/Utils/BitVectorSet.h
@@ -68,8 +68,6 @@ private:
 
     void setBits(std::vector<bool> B) { Bits = B; }
 
-    void setBits(std::vector<bool> B) const { Bits = B; }
-
     bool operator==(const BitVectorSetIterator<D> &rawIterator) const {
       return (pos_ptr == rawIterator.getPtr());
     }


### PR DESCRIPTION
Const qualifying a setter functions does not work and leads to compile
errors, therefore, we remove the const version of the setBits function.