### PR TITLE
docker: image build fix

### DIFF
--- a/bootstrap_docker.sh
+++ b/bootstrap_docker.sh
@@ -14,7 +14,7 @@ sudo pip install pyyaml
 sudo apt-get install libboost-all-dev -y
 
 # installing LLVM
-./utils/install-llvm.sh $NUM_THREADS . $LLVM_RELEASE
+./utils/install-llvm.sh $NUM_THREADS . "/usr/local" $LLVM_RELEASE
 # installing wllvm
 sudo pip3 install wllvm
 


### PR DESCRIPTION
Docker image does not build because utils/install-llvm.sh expects 4 arguemnts. The install directory was missing, so I added a sensible default.