### PR TITLE
docker: fixes for LLVM 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install libboost-all-dev -y
 
 # installing LLVM
 COPY utils/install-llvm.sh /usr/src/phasar/utils/install-llvm.sh
-RUN ./utils/install-llvm.sh $(nproc) . "/usr/local/" "llvmorg-9.0.0"
+RUN ./utils/install-llvm.sh $(nproc) . "/usr/local/" "llvmorg-10.0.0"
 
 # installing wllvm
 RUN pip3 install wllvm

--- a/utils/install-llvm.sh
+++ b/utils/install-llvm.sh
@@ -35,11 +35,11 @@ echo "Build the LLVM project"
 git checkout ${llvm_release}
 mkdir -p build
 cd build
-cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;libcxx;libcxxabi;libunwind;lld;lldb;compiler-rt;lld;polly;debuginfo-tests;openmp;parallel-libs' -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CXX1Y=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DBUILD_SHARED_LIBS=ON ../llvm
+cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;libcxx;libcxxabi;libunwind;lld;lldb;compiler-rt;lld;polly;debuginfo-tests;openmp;parallel-libs' -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_CXX1Y=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DBUILD_SHARED_LIBS=ON -DLLVM_BUILD_EXAMPLES=Off -DLLVM_INCLUDE_EXAMPLES=Off -DLLVM_BUILD_TESTS=Off -DLLVM_INCLUDE_TESTS=Off ../llvm
 make -j${num_cores}
 # echo "Run all tests"
 # make -j3 check-all
 echo "Installing LLVM to ${dest_dir}"
-sudo cmake -DCMAKE_INSTALL_PREFIX=${dest_dir} -P cmake_install.cmake 
+sudo cmake -DCMAKE_INSTALL_PREFIX=${dest_dir} -P cmake_install.cmake
 sudo ldconfig
 echo "Installed LLVM successfully."


### PR DESCRIPTION
The Docker build broke with the update to LLVM 10.

I also disabled the inclusion of LLVM tests to keep the image size and build times down.