### PR TITLE
Improve Clang Tidy Support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
-Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
+#Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
 # Careful with the readability-identifier-nameing - we have to fix some errors caused by clang-tidy first.
-Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+#Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+Checks: '-*, readability-identifier-naming'
+
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
@@ -10,8 +12,8 @@ CheckOptions:
 #    value:           camelBack
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
-#  - key:             readability-identifier-naming.ParameterCase
-#    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
 #  - key:             readability-identifier-naming.VariableCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,14 @@
 #Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
 # Careful with the readability-identifier-nameing - we have to fix some errors caused by clang-tidy first.
-#Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
-Checks: '-*, readability-identifier-naming'
+Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
-#  - key:             readability-identifier-naming.FunctionCase
-#    value:           camelBack
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,5 +16,5 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
-#  - key:             readability-identifier-naming.VariableCase
-#    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,16 +1,15 @@
 #Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
 # Careful with the readability-identifier-nameing - we have to fix some errors caused by clang-tidy first.
-Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
-
-WarningsAsErrors: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+#Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+Checks: '-*, readability-identifier-naming'
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
-  - key:             readability-identifier-naming.FunctionCase
-    value:           camelBack
+#  - key:             readability-identifier-naming.FunctionCase
+#    value:           camelBack
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,16 @@
 #Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
 # Careful with the readability-identifier-nameing - we have to fix some errors caused by clang-tidy first.
-#Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
-Checks: '-*, readability-identifier-naming'
+Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+
+WarningsAsErrors: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
-#  - key:             readability-identifier-naming.FunctionCase
-#    value:           camelBack
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,18 +1,18 @@
 Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters'
 # Careful with the readability-identifier-nameing - we have to fix some errors caused by clang-tidy first.
-# Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
-# CheckOptions:
-#  - key:             readability-identifier-naming.ClassCase
-#    value:           CamelCase
-#  - key:             readability-identifier-naming.EnumCase
-#    value:           CamelCase
+Checks: '-*,modernize-use-override,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming'
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
 #  - key:             readability-identifier-naming.FunctionCase
 #    value:           camelBack
-#  - key:             readability-identifier-naming.MemberCase
-#    value:           CamelCase
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
 #  - key:             readability-identifier-naming.ParameterCase
 #    value:           CamelCase
-#  - key:             readability-identifier-naming.UnionCase
-#    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
 #  - key:             readability-identifier-naming.VariableCase
 #    value:           CamelCase

--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,0 +1,2 @@
+Checks: '-*'
+WarningsAsErrors: ''

--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,2 +1,1 @@
 Checks: '-*'
-WarningsAsErrors: ''

--- a/include/phasar/Config/Configuration.h
+++ b/include/phasar/Config/Configuration.h
@@ -45,7 +45,7 @@ public:
   }
 
   /// Specifies the directory in which Phasar is located.
-  static const std::string PhasarDirectory() { return phasar_directory; }
+  static const std::string PhasarDirectory() { return PhasarDir; }
 
   /// Name of the file storing all standard header search paths used for
   /// compilation.
@@ -129,7 +129,7 @@ private:
   }();
 
   /// Specifies the directory in which Phasar is located.
-  static const std::string phasar_directory;
+  static const std::string PhasarDir;
 
   /// Name of the file storing all glibc function names.
   const std::string GLIBCFunctionListFileName =

--- a/include/phasar/DB/Queries.h
+++ b/include/phasar/DB/Queries.h
@@ -14,33 +14,33 @@
 
 namespace psr {
 
-extern const std::string SPO_INSERT;
+extern const std::string SPOInsert;
 
-extern const std::string SOP_INSERT;
+extern const std::string SOPInsert;
 
-extern const std::string PSO_INSERT;
+extern const std::string PSOInsert;
 
-extern const std::string POS_INSERT;
+extern const std::string POSInsert;
 
-extern const std::string OSP_INSERT;
+extern const std::string OSPInsert;
 
-extern const std::string OPS_INSERT;
+extern const std::string OPSInsert;
 
-extern const std::string SEARCH_SPO;
+extern const std::string SearchSPO;
 
-extern const std::string SEARCH_SPX;
+extern const std::string SearchSPX;
 
-extern const std::string SEARCH_SXO;
+extern const std::string SearchSXO;
 
-extern const std::string SEARCH_XPO;
+extern const std::string SearchXPO;
 
-extern const std::string SEARCH_SXX;
+extern const std::string SearchSXX;
 
-extern const std::string SEARCH_XPX;
+extern const std::string SearchXPX;
 
-extern const std::string SEARCH_XXO;
+extern const std::string SearchXXO;
 
-extern const std::string SEARCH_XXX;
+extern const std::string SearchXXX;
 
 extern const std::string INIT;
 

--- a/include/phasar/PhasarClang/RandomChangeVisitor.h
+++ b/include/phasar/PhasarClang/RandomChangeVisitor.h
@@ -48,10 +48,10 @@ private:
 public:
   RandomChangeVisitor(clang::Rewriter &R);
   virtual ~RandomChangeVisitor() = default;
-  virtual bool VisitVarDecl(clang::VarDecl *V);
-  virtual bool VisitTypeDecl(clang::TypeDecl *T);
-  virtual bool VisitStmt(clang::Stmt *S);
-  virtual bool VisitFunctionDecl(clang::FunctionDecl *F);
+  virtual bool visitVarDecl(clang::VarDecl *V);
+  virtual bool visitTypeDecl(clang::TypeDecl *T);
+  virtual bool visitStmt(clang::Stmt *S);
+  virtual bool visitFunctionDecl(clang::FunctionDecl *F);
 };
 
 } // namespace psr

--- a/include/phasar/PhasarClang/RandomChangeVisitor.h
+++ b/include/phasar/PhasarClang/RandomChangeVisitor.h
@@ -48,10 +48,10 @@ private:
 public:
   RandomChangeVisitor(clang::Rewriter &R);
   virtual ~RandomChangeVisitor() = default;
-  virtual bool visitVarDecl(clang::VarDecl *V);
-  virtual bool visitTypeDecl(clang::TypeDecl *T);
-  virtual bool visitStmt(clang::Stmt *S);
-  virtual bool visitFunctionDecl(clang::FunctionDecl *F);
+  virtual bool VisitVarDecl(clang::VarDecl *V);
+  virtual bool VisitTypeDecl(clang::TypeDecl *T);
+  virtual bool VisitStmt(clang::Stmt *S);
+  virtual bool VisitFunctionDecl(clang::FunctionDecl *F);
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
+++ b/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
@@ -20,9 +20,9 @@ enum class AnalysisStrategy {
 #include "phasar/PhasarLLVM/AnalysisStrategy/Strategies.def"
 };
 
-std::string to_string(const AnalysisStrategy &S);
+std::string toString(const AnalysisStrategy &S);
 
-AnalysisStrategy to_AnalysisStrategy(const std::string &S);
+AnalysisStrategy toAnalysisStrategy(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const AnalysisStrategy &S);
 

--- a/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
+++ b/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
@@ -20,7 +20,7 @@ enum class AnalysisStrategy {
 #include "phasar/PhasarLLVM/AnalysisStrategy/Strategies.def"
 };
 
-std::string to_string(const AnalysisStrategy &S);
+std::string toString(const AnalysisStrategy &S);
 
 AnalysisStrategy to_AnalysisStrategy(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
+++ b/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
@@ -20,9 +20,9 @@ enum class AnalysisStrategy {
 #include "phasar/PhasarLLVM/AnalysisStrategy/Strategies.def"
 };
 
-std::string toString(const AnalysisStrategy &S);
+std::string to_string(const AnalysisStrategy &S);
 
-AnalysisStrategy toAnalysisStrategy(const std::string &S);
+AnalysisStrategy to_AnalysisStrategy(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const AnalysisStrategy &S);
 

--- a/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
+++ b/include/phasar/PhasarLLVM/AnalysisStrategy/Strategies.h
@@ -22,7 +22,7 @@ enum class AnalysisStrategy {
 
 std::string toString(const AnalysisStrategy &S);
 
-AnalysisStrategy to_AnalysisStrategy(const std::string &S);
+AnalysisStrategy toAnalysisStrategy(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const AnalysisStrategy &S);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -36,7 +36,7 @@ enum class CallGraphAnalysisType {
 
 std::string toString(const CallGraphAnalysisType &CGA);
 
-CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S);
+CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const CallGraphAnalysisType &CGA);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -46,27 +46,27 @@ public:
 
   virtual std::set<F> getAllFunctions() const = 0;
 
-  virtual F getFunction(const std::string &fun) const = 0;
+  virtual F getFunction(const std::string &Fun) const = 0;
 
-  virtual bool isCallStmt(N stmt) const = 0;
+  virtual bool isCallStmt(N Stmt) const = 0;
 
-  virtual bool isIndirectFunctionCall(N stmt) const = 0;
+  virtual bool isIndirectFunctionCall(N Stmt) const = 0;
 
-  virtual bool isVirtualFunctionCall(N stmt) const = 0;
+  virtual bool isVirtualFunctionCall(N Stmt) const = 0;
 
   virtual std::set<N> allNonCallStartNodes() const = 0;
 
-  virtual std::set<F> getCalleesOfCallAt(N stmt) const = 0;
+  virtual std::set<F> getCalleesOfCallAt(N Stmt) const = 0;
 
-  virtual std::set<N> getCallersOf(F fun) const = 0;
+  virtual std::set<N> getCallersOf(F Fun) const = 0;
 
-  virtual std::set<N> getCallsFromWithin(F fun) const = 0;
+  virtual std::set<N> getCallsFromWithin(F Fun) const = 0;
 
-  virtual std::set<N> getStartPointsOf(F fun) const = 0;
+  virtual std::set<N> getStartPointsOf(F Fun) const = 0;
 
-  virtual std::set<N> getExitPointsOf(F fun) const = 0;
+  virtual std::set<N> getExitPointsOf(F Fun) const = 0;
 
-  virtual std::set<N> getReturnSitesOfCallAt(N stmt) const = 0;
+  virtual std::set<N> getReturnSitesOfCallAt(N Stmt) const = 0;
 
   using CFG<N, F>::print; // tell the compiler we wish to have both prints
   virtual void print(std::ostream &OS = std::cout) const = 0;

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -34,9 +34,9 @@ enum class CallGraphAnalysisType {
   Invalid
 };
 
-std::string toString(const CallGraphAnalysisType &CGA);
+std::string to_string(const CallGraphAnalysisType &CGA);
 
-CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S);
+CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const CallGraphAnalysisType &CGA);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -34,7 +34,7 @@ enum class CallGraphAnalysisType {
   Invalid
 };
 
-std::string to_string(const CallGraphAnalysisType &CGA);
+std::string toString(const CallGraphAnalysisType &CGA);
 
 CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/ICFG.h
@@ -34,9 +34,9 @@ enum class CallGraphAnalysisType {
   Invalid
 };
 
-std::string to_string(const CallGraphAnalysisType &CGA);
+std::string toString(const CallGraphAnalysisType &CGA);
 
-CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S);
+CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const CallGraphAnalysisType &CGA);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -131,9 +131,9 @@ public:
 
   std::set<const llvm::Function *> getAllFunctions() const override;
 
-  bool isIndirectFunctionCall(const llvm::Instruction *N) const override;
+  bool isIndirectFunctionCall(const llvm::Instruction *Inst) const override;
 
-  bool isVirtualFunctionCall(const llvm::Instruction *N) const override;
+  bool isVirtualFunctionCall(const llvm::Instruction *Inst) const override;
 
   const llvm::Function *getFunction(const std::string &Fun) const override;
 
@@ -143,7 +143,7 @@ public:
    * \return all call sites within a given method.
    */
   std::vector<const llvm::Instruction *>
-  getOutEdges(const llvm::Function *F) const;
+  getOutEdges(const llvm::Function *Fun) const;
 
   /**
    * For the supplied function, get all the output edge Instructions and
@@ -151,14 +151,14 @@ public:
    *
    * \return the edges and the target function for each edge.
    */
-  OutEdgesAndTargets getOutEdgeAndTarget(const llvm::Function *F) const;
+  OutEdgesAndTargets getOutEdgeAndTarget(const llvm::Function *Fun) const;
 
   /**
    * Removes all edges found for the given instruction within the
    * sourceFunction. \return number of edges removed
    */
-  size_t removeEdges(const llvm::Function *sourceFunction,
-                     const llvm::Instruction *instruction);
+  size_t removeEdges(const llvm::Function *SourceFunction,
+                     const llvm::Instruction *Inst);
 
   /**
    * Removes the vertex for the given function.
@@ -166,42 +166,42 @@ public:
    * IN or OUT edges is a bad idea.
    * \return true iff the vertex was found and removed.
    */
-  bool removeVertex(const llvm::Function *F);
+  bool removeVertex(const llvm::Function *Fun);
 
   /**
    * \return the total number of in edges to the vertex representing this
    * Function.
    */
-  size_t getCallerCount(const llvm::Function *F) const;
+  size_t getCallerCount(const llvm::Function *Fun) const;
 
   /**
    * \return all callee methods for a given call that might be called.
    */
   std::set<const llvm::Function *>
-  getCalleesOfCallAt(const llvm::Instruction *N) const override;
+  getCalleesOfCallAt(const llvm::Instruction *Inst) const override;
 
   /**
    * \return all caller statements/nodes of a given method.
    */
   std::set<const llvm::Instruction *>
-  getCallersOf(const llvm::Function *M) const override;
+  getCallersOf(const llvm::Function *Fun) const override;
 
   /**
    * \return all call sites within a given method.
    */
   std::set<const llvm::Instruction *>
-  getCallsFromWithin(const llvm::Function *M) const override;
+  getCallsFromWithin(const llvm::Function *Fun) const override;
 
   std::set<const llvm::Instruction *>
-  getStartPointsOf(const llvm::Function *M) const override;
+  getStartPointsOf(const llvm::Function *Fun) const override;
 
   std::set<const llvm::Instruction *>
   getExitPointsOf(const llvm::Function *Fun) const override;
 
   std::set<const llvm::Instruction *>
-  getReturnSitesOfCallAt(const llvm::Instruction *N) const override;
+  getReturnSitesOfCallAt(const llvm::Instruction *Inst) const override;
 
-  bool isCallStmt(const llvm::Instruction *Stmt) const override;
+  bool isCallStmt(const llvm::Instruction *Inst) const override;
 
   std::set<const llvm::Instruction *> allNonCallStartNodes() const override;
 

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -131,11 +131,11 @@ public:
 
   std::set<const llvm::Function *> getAllFunctions() const override;
 
-  bool isIndirectFunctionCall(const llvm::Instruction *n) const override;
+  bool isIndirectFunctionCall(const llvm::Instruction *N) const override;
 
-  bool isVirtualFunctionCall(const llvm::Instruction *n) const override;
+  bool isVirtualFunctionCall(const llvm::Instruction *N) const override;
 
-  const llvm::Function *getFunction(const std::string &fun) const override;
+  const llvm::Function *getFunction(const std::string &Fun) const override;
 
   /**
    * Essentially the same as `getCallsFromWithin`, but uses the callgraph
@@ -178,41 +178,41 @@ public:
    * \return all callee methods for a given call that might be called.
    */
   std::set<const llvm::Function *>
-  getCalleesOfCallAt(const llvm::Instruction *n) const override;
+  getCalleesOfCallAt(const llvm::Instruction *N) const override;
 
   /**
    * \return all caller statements/nodes of a given method.
    */
   std::set<const llvm::Instruction *>
-  getCallersOf(const llvm::Function *m) const override;
+  getCallersOf(const llvm::Function *M) const override;
 
   /**
    * \return all call sites within a given method.
    */
   std::set<const llvm::Instruction *>
-  getCallsFromWithin(const llvm::Function *m) const override;
+  getCallsFromWithin(const llvm::Function *M) const override;
 
   std::set<const llvm::Instruction *>
-  getStartPointsOf(const llvm::Function *m) const override;
+  getStartPointsOf(const llvm::Function *M) const override;
 
   std::set<const llvm::Instruction *>
-  getExitPointsOf(const llvm::Function *fun) const override;
+  getExitPointsOf(const llvm::Function *Fun) const override;
 
   std::set<const llvm::Instruction *>
-  getReturnSitesOfCallAt(const llvm::Instruction *n) const override;
+  getReturnSitesOfCallAt(const llvm::Instruction *N) const override;
 
-  bool isCallStmt(const llvm::Instruction *stmt) const override;
+  bool isCallStmt(const llvm::Instruction *Stmt) const override;
 
   std::set<const llvm::Instruction *> allNonCallStartNodes() const override;
 
-  const llvm::Instruction *getLastInstructionOf(const std::string &name);
+  const llvm::Instruction *getLastInstructionOf(const std::string &Name);
 
   std::vector<const llvm::Instruction *>
-  getAllInstructionsOfFunction(const std::string &name);
+  getAllInstructionsOfFunction(const std::string &Name);
 
-  void mergeWith(const LLVMBasedICFG &other);
+  void mergeWith(const LLVMBasedICFG &Other);
 
-  bool isPrimitiveFunction(const std::string &name);
+  bool isPrimitiveFunction(const std::string &Name);
 
   using LLVMBasedCFG::print; // tell the compiler we wish to have both prints
   void print(std::ostream &OS = std::cout) const override;

--- a/include/phasar/PhasarLLVM/ControlFlow/Resolver/DTAResolver.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/Resolver/DTAResolver.h
@@ -44,14 +44,14 @@ protected:
    * An heuristic that return true if the bitcast instruction is interesting to
    * take into the DTA relational graph
    */
-  bool heuristic_anti_contructor_this_type(const llvm::BitCastInst *bitcast);
+  bool heuristicAntiConstructorThisType(const llvm::BitCastInst *bitcast);
 
   /**
    * Another heuristic that return true if the bitcast instruction is
    * interesting to take into the DTA relational graph (use the presence or not
    * of vtable)
    */
-  bool heuristic_anti_contructor_vtable_pos(const llvm::BitCastInst *bitcast);
+  bool heuristicAntiConstructorVtablePos(const llvm::BitCastInst *bitcast);
 
 public:
   DTAResolver(ProjectIRDB &IRDB, LLVMTypeHierarchy &TH);

--- a/include/phasar/PhasarLLVM/ControlFlow/Resolver/DTAResolver.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/Resolver/DTAResolver.h
@@ -44,14 +44,14 @@ protected:
    * An heuristic that return true if the bitcast instruction is interesting to
    * take into the DTA relational graph
    */
-  bool heuristicAntiConstructorThisType(const llvm::BitCastInst *bitcast);
+  bool heuristic_anti_contructor_this_type(const llvm::BitCastInst *bitcast);
 
   /**
    * Another heuristic that return true if the bitcast instruction is
    * interesting to take into the DTA relational graph (use the presence or not
    * of vtable)
    */
-  bool heuristicAntiConstructorVtablePos(const llvm::BitCastInst *bitcast);
+  bool heuristic_anti_contructor_vtable_pos(const llvm::BitCastInst *bitcast);
 
 public:
   DTAResolver(ProjectIRDB &IRDB, LLVMTypeHierarchy &TH);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
@@ -75,7 +75,7 @@ public:
 
   typedef std::map<std::string, std::map<unsigned, LCAResult>> lca_results_t;
 
-  void stripBottomResults(std::unordered_map<d_t, l_t> &res);
+  void stripBottomResults(std::unordered_map<d_t, l_t> &Res);
 
   // start formulating our analysis by specifying the parts required for IFDS
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
@@ -39,9 +39,9 @@ class IDELinearConstantAnalysis
                                   int64_t, LLVMBasedICFG> {
 private:
   // For debug purpose only
-  static unsigned CurrGenConstant_Id;
-  static unsigned CurrLCAID_Id;
-  static unsigned CurrBinary_Id;
+  static unsigned CurrGenConstantId;
+  static unsigned CurrLCAIDId;
+  static unsigned CurrBinaryId;
 
 public:
   typedef const llvm::Value *d_t;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
@@ -48,7 +48,7 @@ public:
   // keep in mind that 'char** argv' of main is a source for tainted values as
   // well
   std::set<std::string> sink_functions = {"fwrite", "write", "printf"};
-  bool setContainsStr(std::set<std::string> s, std::string str);
+  bool set_contains_str(std::set<std::string> s, std::string str);
 
   IDETaintAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                    const LLVMBasedICFG *ICF, const LLVMPointsToInfo *PT,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
@@ -48,7 +48,7 @@ public:
   // keep in mind that 'char** argv' of main is a source for tainted values as
   // well
   std::set<std::string> sink_functions = {"fwrite", "write", "printf"};
-  bool set_contains_str(std::set<std::string> s, std::string str);
+  bool setContainsStr(std::set<std::string> s, std::string str);
 
   IDETaintAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                    const LLVMBasedICFG *ICF, const LLVMPointsToInfo *PT,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
@@ -51,7 +51,7 @@ private:
 
   static const std::map<std::string, std::set<int>> StdFileIOFuncs;
   // delta matrix to implement the state machine's delta function
-  static const CSTDFILEIOState delta[3][5];
+  static const CSTDFILEIOState Delta[3][5];
   CSTDFILEIOToken funcNameToToken(const std::string &F) const;
 
 public:

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKeyDerivationTypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKeyDerivationTypeStateDescription.h
@@ -63,7 +63,7 @@ private:
       OpenSSLEVPKeyDerivationFuncs;
 
   // delta matrix to implement the state machine's delta function
-  static const OpenSSLEVPKeyDerivationState delta[6][7];
+  static const OpenSSLEVPKeyDerivationState Delta[6][7];
 
   OpenSSLEVPKeyDerivationToken funcNameToToken(const std::string &F) const;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
@@ -25,7 +25,7 @@
 
 namespace psr {
 
-extern const std::shared_ptr<AllBottom<BinaryDomain>> ALL_BOTTOM;
+extern const std::shared_ptr<AllBottom<BinaryDomain>> ALLBOTTOM;
 
 /**
  * This class promotes a given IFDSTabulationProblem to an IDETabulationProblem
@@ -101,7 +101,7 @@ public:
   std::shared_ptr<EdgeFunction<BinaryDomain>>
   getNormalEdgeFunction(N src, D srcNode, N tgt, D tgtNode) override {
     if (Problem.isZeroValue(srcNode))
-      return ALL_BOTTOM;
+      return ALLBOTTOM;
     else
       return EdgeIdentity<BinaryDomain>::getInstance();
   }
@@ -110,7 +110,7 @@ public:
   getCallEdgeFunction(N callStmt, D srcNode, F destinationFunction,
                       D destNode) override {
     if (Problem.isZeroValue(srcNode))
-      return ALL_BOTTOM;
+      return ALLBOTTOM;
     else
       return EdgeIdentity<BinaryDomain>::getInstance();
   }
@@ -119,7 +119,7 @@ public:
   getReturnEdgeFunction(N callSite, F calleeFunction, N exitStmt, D exitNode,
                         N returnSite, D retNode) override {
     if (Problem.isZeroValue(exitNode))
-      return ALL_BOTTOM;
+      return ALLBOTTOM;
     else
       return EdgeIdentity<BinaryDomain>::getInstance();
   }
@@ -128,7 +128,7 @@ public:
   getCallToRetEdgeFunction(N callStmt, D callNode, N returnSite,
                            D returnSideNode, std::set<F> callees) override {
     if (Problem.isZeroValue(callNode))
-      return ALL_BOTTOM;
+      return ALLBOTTOM;
     else
       return EdgeIdentity<BinaryDomain>::getInstance();
   }

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
@@ -20,17 +20,17 @@ enum class WPDSType {
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
 };
 
-WPDSType to_WPDSType(const std::string &S);
+WPDSType toWPDSType(const std::string &S);
 
-std::string to_string(const WPDSType &T);
+std::string toString(const WPDSType &T);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T);
 
 enum class WPDSSearchDirection { FORWARD, BACKWARD };
 
-WPDSSearchDirection to_WPDSSearchDirection(const std::string &S);
+WPDSSearchDirection toWPDSSearchDirection(const std::string &S);
 
-std::string to_string(const WPDSSearchDirection &S);
+std::string toString(const WPDSSearchDirection &S);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S);
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
@@ -22,7 +22,7 @@ enum class WPDSType {
 
 WPDSType to_WPDSType(const std::string &S);
 
-std::string to_string(const WPDSType &T);
+std::string toString(const WPDSType &T);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T);
 
@@ -30,7 +30,7 @@ enum class WPDSSearchDirection { FORWARD, BACKWARD };
 
 WPDSSearchDirection to_WPDSSearchDirection(const std::string &S);
 
-std::string to_string(const WPDSSearchDirection &S);
+std::string toString(const WPDSSearchDirection &S);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S);
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
@@ -20,17 +20,17 @@ enum class WPDSType {
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
 };
 
-WPDSType toWPDSType(const std::string &S);
+WPDSType to_WPDSType(const std::string &S);
 
-std::string toString(const WPDSType &T);
+std::string to_string(const WPDSType &T);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T);
 
 enum class WPDSSearchDirection { FORWARD, BACKWARD };
 
-WPDSSearchDirection toWPDSSearchDirection(const std::string &S);
+WPDSSearchDirection to_WPDSSearchDirection(const std::string &S);
 
-std::string toString(const WPDSSearchDirection &S);
+std::string to_string(const WPDSSearchDirection &S);
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S);
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.h
@@ -20,7 +20,7 @@ enum class WPDSType {
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
 };
 
-WPDSType to_WPDSType(const std::string &S);
+WPDSType toWPDSType(const std::string &S);
 
 std::string toString(const WPDSType &T);
 
@@ -28,7 +28,7 @@ std::ostream &operator<<(std::ostream &OS, const WPDSType &T);
 
 enum class WPDSSearchDirection { FORWARD, BACKWARD };
 
-WPDSSearchDirection to_WPDSSearchDirection(const std::string &S);
+WPDSSearchDirection toWPDSSearchDirection(const std::string &S);
 
 std::string toString(const WPDSSearchDirection &S);
 

--- a/include/phasar/PhasarLLVM/Passes/ValueAnnotationPass.h
+++ b/include/phasar/PhasarLLVM/Passes/ValueAnnotationPass.h
@@ -41,7 +41,7 @@ class ValueAnnotationPass
 private:
   friend llvm::AnalysisInfoMixin<ValueAnnotationPass>;
   static llvm::AnalysisKey Key;
-  static size_t unique_value_id;
+  static size_t UniqueValueId;
 
 public:
   explicit ValueAnnotationPass();

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
@@ -41,7 +41,7 @@ enum class PointerAnalysisType {
 
 std::string toString(const PointerAnalysisType &PA);
 
-PointerAnalysisType to_PointerAnalysisType(const std::string &S);
+PointerAnalysisType toPointerAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const PointerAnalysisType &PA);
 

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
@@ -39,9 +39,9 @@ enum class PointerAnalysisType {
   Invalid
 };
 
-std::string toString(const PointerAnalysisType &PA);
+std::string to_string(const PointerAnalysisType &PA);
 
-PointerAnalysisType toPointerAnalysisType(const std::string &S);
+PointerAnalysisType to_PointerAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const PointerAnalysisType &PA);
 

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
@@ -39,9 +39,9 @@ enum class PointerAnalysisType {
   Invalid
 };
 
-std::string to_string(const PointerAnalysisType &PA);
+std::string toString(const PointerAnalysisType &PA);
 
-PointerAnalysisType to_PointerAnalysisType(const std::string &S);
+PointerAnalysisType toPointerAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const PointerAnalysisType &PA);
 

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
@@ -39,7 +39,7 @@ enum class PointerAnalysisType {
   Invalid
 };
 
-std::string to_string(const PointerAnalysisType &PA);
+std::string toString(const PointerAnalysisType &PA);
 
 PointerAnalysisType to_PointerAnalysisType(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
@@ -19,9 +19,9 @@ namespace psr {
 
 enum class AliasResult { NoAlias, MayAlias, PartialAlias, MustAlias };
 
-std::string toString(AliasResult AR);
+std::string to_string(AliasResult AR);
 
-AliasResult toAliasResult(const std::string &S);
+AliasResult to_AliasResult(const std::string &S);
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR);
 

--- a/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
@@ -19,9 +19,9 @@ namespace psr {
 
 enum class AliasResult { NoAlias, MayAlias, PartialAlias, MustAlias };
 
-std::string to_string(AliasResult AR);
+std::string toString(AliasResult AR);
 
-AliasResult to_AliasResult(const std::string &S);
+AliasResult toAliasResult(const std::string &S);
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR);
 

--- a/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
@@ -19,7 +19,7 @@ namespace psr {
 
 enum class AliasResult { NoAlias, MayAlias, PartialAlias, MustAlias };
 
-std::string to_string(AliasResult AR);
+std::string toString(AliasResult AR);
 
 AliasResult to_AliasResult(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
@@ -21,7 +21,7 @@ enum class AliasResult { NoAlias, MayAlias, PartialAlias, MustAlias };
 
 std::string toString(AliasResult AR);
 
-AliasResult to_AliasResult(const std::string &S);
+AliasResult toAliasResult(const std::string &S);
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR);
 

--- a/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
+++ b/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
@@ -20,9 +20,9 @@ enum class DataFlowAnalysisType {
 #include "phasar/PhasarLLVM/Utils/DataFlowAnalysisType.def"
 };
 
-std::string toString(const DataFlowAnalysisType &D);
+std::string to_string(const DataFlowAnalysisType &D);
 
-DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S);
+DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const DataFlowAnalysisType &D);
 

--- a/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
+++ b/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
@@ -20,7 +20,7 @@ enum class DataFlowAnalysisType {
 #include "phasar/PhasarLLVM/Utils/DataFlowAnalysisType.def"
 };
 
-std::string to_string(const DataFlowAnalysisType &D);
+std::string toString(const DataFlowAnalysisType &D);
 
 DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
+++ b/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
@@ -20,9 +20,9 @@ enum class DataFlowAnalysisType {
 #include "phasar/PhasarLLVM/Utils/DataFlowAnalysisType.def"
 };
 
-std::string to_string(const DataFlowAnalysisType &D);
+std::string toString(const DataFlowAnalysisType &D);
 
-DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S);
+DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const DataFlowAnalysisType &D);
 

--- a/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
+++ b/include/phasar/PhasarLLVM/Utils/DataFlowAnalysisType.h
@@ -22,7 +22,7 @@ enum class DataFlowAnalysisType {
 
 std::string toString(const DataFlowAnalysisType &D);
 
-DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S);
+DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const DataFlowAnalysisType &D);
 

--- a/include/phasar/PhasarLLVM/Utils/IOFormat.h
+++ b/include/phasar/PhasarLLVM/Utils/IOFormat.h
@@ -20,9 +20,9 @@ enum class IOFormat {
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"
 };
 
-std::string to_string(const IOFormat &D);
+std::string toString(const IOFormat &D);
 
-IOFormat to_IOFormat(const std::string &S);
+IOFormat toIOFormat(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const IOFormat &D);
 

--- a/include/phasar/PhasarLLVM/Utils/IOFormat.h
+++ b/include/phasar/PhasarLLVM/Utils/IOFormat.h
@@ -20,7 +20,7 @@ enum class IOFormat {
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"
 };
 
-std::string to_string(const IOFormat &D);
+std::string toString(const IOFormat &D);
 
 IOFormat to_IOFormat(const std::string &S);
 

--- a/include/phasar/PhasarLLVM/Utils/IOFormat.h
+++ b/include/phasar/PhasarLLVM/Utils/IOFormat.h
@@ -20,9 +20,9 @@ enum class IOFormat {
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"
 };
 
-std::string toString(const IOFormat &D);
+std::string to_string(const IOFormat &D);
 
-IOFormat toIOFormat(const std::string &S);
+IOFormat to_IOFormat(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const IOFormat &D);
 

--- a/include/phasar/PhasarLLVM/Utils/IOFormat.h
+++ b/include/phasar/PhasarLLVM/Utils/IOFormat.h
@@ -22,7 +22,7 @@ enum class IOFormat {
 
 std::string toString(const IOFormat &D);
 
-IOFormat to_IOFormat(const std::string &S);
+IOFormat toIOFormat(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const IOFormat &D);
 

--- a/include/phasar/Utils/Logger.h
+++ b/include/phasar/Utils/Logger.h
@@ -39,7 +39,7 @@ extern const std::map<std::string, severity_level> StringToSeverityLevel;
 
 extern const std::map<severity_level, std::string> SeverityLevelToString;
 
-extern severity_level logFilterLevel;
+extern severity_level LogFilterLevel;
 
 std::ostream &operator<<(std::ostream &os, enum severity_level l);
 

--- a/include/phasar/Utils/SoundnessFlag.h
+++ b/include/phasar/Utils/SoundnessFlag.h
@@ -21,9 +21,9 @@ enum class SoundnessFlag {
   Invalid
 };
 
-std::string to_string(const SoundnessFlag &SF);
+std::string toString(const SoundnessFlag &SF);
 
-SoundnessFlag to_SoundnessFlag(const std::string &S);
+SoundnessFlag toSoundnessFlag(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const SoundnessFlag &SF);
 

--- a/include/phasar/Utils/SoundnessFlag.h
+++ b/include/phasar/Utils/SoundnessFlag.h
@@ -21,9 +21,9 @@ enum class SoundnessFlag {
   Invalid
 };
 
-std::string toString(const SoundnessFlag &SF);
+std::string to_string(const SoundnessFlag &SF);
 
-SoundnessFlag toSoundnessFlag(const std::string &S);
+SoundnessFlag to_SoundnessFlag(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const SoundnessFlag &SF);
 

--- a/include/phasar/Utils/SoundnessFlag.h
+++ b/include/phasar/Utils/SoundnessFlag.h
@@ -23,7 +23,7 @@ enum class SoundnessFlag {
 
 std::string toString(const SoundnessFlag &SF);
 
-SoundnessFlag to_SoundnessFlag(const std::string &S);
+SoundnessFlag toSoundnessFlag(const std::string &S);
 
 std::ostream &operator<<(std::ostream &os, const SoundnessFlag &SF);
 

--- a/include/phasar/Utils/SoundnessFlag.h
+++ b/include/phasar/Utils/SoundnessFlag.h
@@ -21,7 +21,7 @@ enum class SoundnessFlag {
   Invalid
 };
 
-std::string to_string(const SoundnessFlag &SF);
+std::string toString(const SoundnessFlag &SF);
 
 SoundnessFlag to_SoundnessFlag(const std::string &S);
 

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -23,7 +23,7 @@ namespace psr {
 
 std::string createTimeStamp();
 
-std::string cxxDemangle(const std::string &mangled_name);
+std::string cxx_demangle(const std::string &mangled_name);
 
 bool isConstructor(const std::string &mangled_name);
 

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -23,7 +23,7 @@ namespace psr {
 
 std::string createTimeStamp();
 
-std::string cxx_demangle(const std::string &mangled_name);
+std::string cxxDemangle(const std::string &mangled_name);
 
 bool isConstructor(const std::string &mangled_name);
 

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -40,14 +40,14 @@ std::string PhasarConfig::readConfigFile(const std::string &Path) {
   // other phasar libraries.
   if (boost::filesystem::exists(Path) &&
       !boost::filesystem::is_directory(Path)) {
-    std::ifstream ifs(Path, std::ios::binary);
-    if (ifs.is_open()) {
-      ifs.seekg(0, ifs.end);
-      size_t file_size = ifs.tellg();
-      ifs.seekg(0, ifs.beg);
-      std::string content(file_size + 1, '\0');
-      ifs.read(const_cast<char *>(content.data()), file_size);
-      return content;
+    std::ifstream Ifs(Path, std::ios::binary);
+    if (Ifs.is_open()) {
+      Ifs.seekg(0, Ifs.end);
+      size_t FileSize = Ifs.tellg();
+      Ifs.seekg(0, Ifs.beg);
+      std::string Content(FileSize + 1, '\0');
+      Ifs.read(const_cast<char *>(Content.data()), FileSize);
+      return Content;
     }
   }
   throw std::ios_base::failure("could not read file: " + Path);
@@ -59,13 +59,13 @@ void PhasarConfig::loadGlibcSpecialFunctionNames() {
 
   if (boost::filesystem::exists(GLIBCFunctionListFilePath)) {
     // Load glibc function names specified in the config file
-    std::vector<std::string> glibcfunctions;
-    std::string glibc = readConfigFile(GLIBCFunctionListFilePath);
+    std::vector<std::string> GlibcFunctions;
+    std::string Glibc = readConfigFile(GLIBCFunctionListFilePath);
     // Insert glibc function names
-    boost::split(glibcfunctions, glibc, boost::is_any_of("\n"),
+    boost::split(GlibcFunctions, Glibc, boost::is_any_of("\n"),
                  boost::token_compress_on);
 
-    special_function_names.insert(glibcfunctions.begin(), glibcfunctions.end());
+    special_function_names.insert(GlibcFunctions.begin(), GlibcFunctions.end());
   } else {
     // Add default glibc function names
     special_function_names.insert({"_exit"});
@@ -77,25 +77,25 @@ void PhasarConfig::loadLLVMSpecialFunctionNames() {
       ConfigurationDirectory() + LLVMIntrinsicFunctionListFileName;
   if (boost::filesystem::exists(LLVMFunctionListFilePath)) {
     // Load LLVM function names specified in the config file
-    std::string llvmintrinsics = readConfigFile(LLVMFunctionListFilePath);
+    std::string LLVMIntrinsics = readConfigFile(LLVMFunctionListFilePath);
 
-    std::vector<std::string> llvmintrinsicfunctions;
-    boost::split(llvmintrinsicfunctions, llvmintrinsics, boost::is_any_of("\n"),
+    std::vector<std::string> LLVMIntrinsicFunctions;
+    boost::split(LLVMIntrinsicFunctions, LLVMIntrinsics, boost::is_any_of("\n"),
                  boost::token_compress_on);
 
     // Insert llvm intrinsic function names
-    special_function_names.insert(llvmintrinsicfunctions.begin(),
-                                  llvmintrinsicfunctions.end());
+    special_function_names.insert(LLVMIntrinsicFunctions.begin(),
+                                  LLVMIntrinsicFunctions.end());
   } else {
     // Add default LLVM function names
     special_function_names.insert({"llvm.va_start"});
   }
 }
 
-const std::string PhasarConfig::phasar_directory = std::string([]() {
-  std::string curr_path = boost::filesystem::current_path().string();
-  size_t i = curr_path.rfind("build", curr_path.length());
-  return curr_path.substr(0, i);
+const std::string PhasarConfig::PhasarDir = std::string([]() {
+  std::string CurrPath = boost::filesystem::current_path().string();
+  size_t I = CurrPath.rfind("build", CurrPath.length());
+  return CurrPath.substr(0, I);
 }());
 
 PhasarConfig &PhasarConfig::getPhasarConfig() {

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -35,12 +35,12 @@ PhasarConfig::PhasarConfig() {
   special_function_names.insert({"_Znwm", "_Znam", "_ZdlPv", "_ZdaPv"});
 }
 
-std::string PhasarConfig::readConfigFile(const std::string &path) {
+std::string PhasarConfig::readConfigFile(const std::string &Path) {
   // We use a local file reading function to make phasar_config independent of
   // other phasar libraries.
-  if (boost::filesystem::exists(path) &&
-      !boost::filesystem::is_directory(path)) {
-    std::ifstream ifs(path, std::ios::binary);
+  if (boost::filesystem::exists(Path) &&
+      !boost::filesystem::is_directory(Path)) {
+    std::ifstream ifs(Path, std::ios::binary);
     if (ifs.is_open()) {
       ifs.seekg(0, ifs.end);
       size_t file_size = ifs.tellg();
@@ -50,7 +50,7 @@ std::string PhasarConfig::readConfigFile(const std::string &path) {
       return content;
     }
   }
-  throw std::ios_base::failure("could not read file: " + path);
+  throw std::ios_base::failure("could not read file: " + Path);
 }
 
 void PhasarConfig::loadGlibcSpecialFunctionNames() {

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -53,11 +53,11 @@ namespace std {
 
 template <> struct hash<pair<const llvm::Value *, unsigned>> {
   size_t operator()(const pair<const llvm::Value *, unsigned> &P) const {
-    std::hash<const llvm::Value *> hash_ptr;
-    std::hash<unsigned> hash_unsigned;
-    size_t hp = hash_ptr(P.first);
-    size_t hu = hash_unsigned(P.second);
-    return hp ^ (hu << 1);
+    std::hash<const llvm::Value *> HashPtr;
+    std::hash<unsigned> HashUnsigned;
+    size_t Hp = HashPtr(P.first);
+    size_t Hu = HashUnsigned(P.second);
+    return Hp ^ (Hu << 1);
   }
 };
 

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -52,11 +52,11 @@ using namespace psr;
 namespace std {
 
 template <> struct hash<pair<const llvm::Value *, unsigned>> {
-  size_t operator()(const pair<const llvm::Value *, unsigned> &p) const {
+  size_t operator()(const pair<const llvm::Value *, unsigned> &P) const {
     std::hash<const llvm::Value *> hash_ptr;
     std::hash<unsigned> hash_unsigned;
-    size_t hp = hash_ptr(p.first);
-    size_t hu = hash_unsigned(p.second);
+    size_t hp = hash_ptr(P.first);
+    size_t hu = hash_unsigned(P.second);
     return hp ^ (hu << 1);
   }
 };

--- a/lib/DB/Hexastore.cpp
+++ b/lib/DB/Hexastore.cpp
@@ -19,91 +19,91 @@ namespace psr {
 
 Hexastore::Hexastore(string Filename) {
   sqlite3_open(Filename.c_str(), &hs_internal_db);
-  const string query = INIT;
-  char *err;
-  sqlite3_exec(hs_internal_db, query.c_str(), callback, 0, &err);
-  if (err != NULL)
-    cout << err << "\n\n";
+  const string Query = INIT;
+  char *Err;
+  sqlite3_exec(hs_internal_db, Query.c_str(), callback, 0, &Err);
+  if (Err != NULL)
+    cout << Err << "\n\n";
 }
 
 Hexastore::~Hexastore() { sqlite3_close(hs_internal_db); }
 
 int Hexastore::callback(void *NotUsed, int Argc, char **Argv,
                         char **AzColName) {
-  for (int i = 0; i < Argc; ++i) {
-    cout << AzColName[i] << " " << (Argv[i] ? Argv[i] : "NULL") << endl;
+  for (int Idx = 0; Idx < Argc; ++Idx) {
+    cout << AzColName[Idx] << " " << (Argv[Idx] ? Argv[Idx] : "NULL") << endl;
   }
   return 0;
 }
 
 void Hexastore::put(array<string, 3> Edge) {
-  doPut(SPO_INSERT, Edge);
-  doPut(SOP_INSERT, Edge);
-  doPut(PSO_INSERT, Edge);
-  doPut(POS_INSERT, Edge);
-  doPut(OSP_INSERT, Edge);
-  doPut(OPS_INSERT, Edge);
+  doPut(SPOInsert, Edge);
+  doPut(SOPInsert, Edge);
+  doPut(PSOInsert, Edge);
+  doPut(POSInsert, Edge);
+  doPut(OSPInsert, Edge);
+  doPut(OPSInsert, Edge);
 }
 
 void Hexastore::doPut(string Query, array<string, 3> Edge) {
-  string compiled_query = str(format(Query) % Edge[0] % Edge[1] % Edge[2]);
-  char *err;
-  sqlite3_exec(hs_internal_db, compiled_query.c_str(), callback, 0, &err);
-  if (err != NULL)
-    cout << err;
+  string CompiledQuery = str(format(Query) % Edge[0] % Edge[1] % Edge[2]);
+  char *Err;
+  sqlite3_exec(hs_internal_db, CompiledQuery.c_str(), callback, 0, &Err);
+  if (Err != NULL)
+    cout << Err;
 }
 
 vector<hs_result> Hexastore::get(array<string, 3> EdgeQuery,
                                  size_t ResultSizeHint) {
-  vector<hs_result> result;
-  result.reserve(ResultSizeHint);
-  string querystring;
+  vector<hs_result> Result;
+  Result.reserve(ResultSizeHint);
+  string QueryString;
   if (EdgeQuery[0] == "?") {
     if (EdgeQuery[1] == "?") {
       if (EdgeQuery[2] == "?") {
-        querystring = SEARCH_XXX;
+        QueryString = SearchXXX;
       } else {
-        querystring = SEARCH_XXO;
+        QueryString = SearchXXO;
       }
     } else {
       if (EdgeQuery[2] == "?") {
-        querystring = SEARCH_XPX;
+        QueryString = SearchXPX;
       } else {
-        querystring = SEARCH_XPO;
+        QueryString = SearchXPO;
       }
     }
   } else {
     if (EdgeQuery[1] == "?") {
       if (EdgeQuery[2] == "?") {
-        querystring = SEARCH_SXX;
+        QueryString = SearchSXX;
       } else {
-        querystring = SEARCH_SXO;
+        QueryString = SearchSXO;
       }
     } else {
       if (EdgeQuery[2] == "?") {
-        querystring = SEARCH_SPX;
+        QueryString = SearchSPX;
       } else {
-        querystring = SEARCH_SPO;
+        QueryString = SearchSPO;
       }
     }
   }
-  string compiled_query =
-      str(format(querystring) % EdgeQuery[0] % EdgeQuery[1] % EdgeQuery[2]);
+  string CompiledQuery =
+      str(format(QueryString) % EdgeQuery[0] % EdgeQuery[1] % EdgeQuery[2]);
   // this lambda will collect all of our results, since it is called on every
   // row of the result set
-  auto sqlite_cb_result_collector = [](void *CB, int Argc, char **Argv,
-                                       char **AzColName) {
-    vector<hs_result> *res = static_cast<vector<hs_result> *>(CB);
-    res->emplace_back(Argv[0], Argv[1], Argv[2]);
+  auto SqliteCBResultCollector = [](void *CB, int Argc, char **Argv,
+                                    char **AzColName) {
+    vector<hs_result> *Res = static_cast<vector<hs_result> *>(CB);
+    Res->emplace_back(Argv[0], Argv[1], Argv[2]);
     return 0;
   };
-  char *err;
-  sqlite3_exec(hs_internal_db, compiled_query.c_str(),
-               sqlite_cb_result_collector, &result, &err);
-  if (err != NULL) {
-    cout << err;
+  char *Err;
+  sqlite3_exec(hs_internal_db, CompiledQuery.c_str(), SqliteCBResultCollector,
+               &Result, &Err);
+  if (Err != NULL) {
+    cout << Err;
   }
-  return result;
+  return Result;
 }
 
 } // namespace psr

--- a/lib/DB/Hexastore.cpp
+++ b/lib/DB/Hexastore.cpp
@@ -17,8 +17,8 @@ using namespace boost;
 
 namespace psr {
 
-Hexastore::Hexastore(string filename) {
-  sqlite3_open(filename.c_str(), &hs_internal_db);
+Hexastore::Hexastore(string Filename) {
+  sqlite3_open(Filename.c_str(), &hs_internal_db);
   const string query = INIT;
   char *err;
   sqlite3_exec(hs_internal_db, query.c_str(), callback, 0, &err);
@@ -28,59 +28,59 @@ Hexastore::Hexastore(string filename) {
 
 Hexastore::~Hexastore() { sqlite3_close(hs_internal_db); }
 
-int Hexastore::callback(void *NotUsed, int argc, char **argv,
-                        char **azColName) {
-  for (int i = 0; i < argc; ++i) {
-    cout << azColName[i] << " " << (argv[i] ? argv[i] : "NULL") << endl;
+int Hexastore::callback(void *NotUsed, int Argc, char **Argv,
+                        char **AzColName) {
+  for (int i = 0; i < Argc; ++i) {
+    cout << AzColName[i] << " " << (Argv[i] ? Argv[i] : "NULL") << endl;
   }
   return 0;
 }
 
-void Hexastore::put(array<string, 3> edge) {
-  doPut(SPO_INSERT, edge);
-  doPut(SOP_INSERT, edge);
-  doPut(PSO_INSERT, edge);
-  doPut(POS_INSERT, edge);
-  doPut(OSP_INSERT, edge);
-  doPut(OPS_INSERT, edge);
+void Hexastore::put(array<string, 3> Edge) {
+  doPut(SPO_INSERT, Edge);
+  doPut(SOP_INSERT, Edge);
+  doPut(PSO_INSERT, Edge);
+  doPut(POS_INSERT, Edge);
+  doPut(OSP_INSERT, Edge);
+  doPut(OPS_INSERT, Edge);
 }
 
-void Hexastore::doPut(string query, array<string, 3> edge) {
-  string compiled_query = str(format(query) % edge[0] % edge[1] % edge[2]);
+void Hexastore::doPut(string Query, array<string, 3> Edge) {
+  string compiled_query = str(format(Query) % Edge[0] % Edge[1] % Edge[2]);
   char *err;
   sqlite3_exec(hs_internal_db, compiled_query.c_str(), callback, 0, &err);
   if (err != NULL)
     cout << err;
 }
 
-vector<hs_result> Hexastore::get(array<string, 3> edge_query,
-                                 size_t result_size_hint) {
+vector<hs_result> Hexastore::get(array<string, 3> EdgeQuery,
+                                 size_t ResultSizeHint) {
   vector<hs_result> result;
-  result.reserve(result_size_hint);
+  result.reserve(ResultSizeHint);
   string querystring;
-  if (edge_query[0] == "?") {
-    if (edge_query[1] == "?") {
-      if (edge_query[2] == "?") {
+  if (EdgeQuery[0] == "?") {
+    if (EdgeQuery[1] == "?") {
+      if (EdgeQuery[2] == "?") {
         querystring = SEARCH_XXX;
       } else {
         querystring = SEARCH_XXO;
       }
     } else {
-      if (edge_query[2] == "?") {
+      if (EdgeQuery[2] == "?") {
         querystring = SEARCH_XPX;
       } else {
         querystring = SEARCH_XPO;
       }
     }
   } else {
-    if (edge_query[1] == "?") {
-      if (edge_query[2] == "?") {
+    if (EdgeQuery[1] == "?") {
+      if (EdgeQuery[2] == "?") {
         querystring = SEARCH_SXX;
       } else {
         querystring = SEARCH_SXO;
       }
     } else {
-      if (edge_query[2] == "?") {
+      if (EdgeQuery[2] == "?") {
         querystring = SEARCH_SPX;
       } else {
         querystring = SEARCH_SPO;
@@ -88,13 +88,13 @@ vector<hs_result> Hexastore::get(array<string, 3> edge_query,
     }
   }
   string compiled_query =
-      str(format(querystring) % edge_query[0] % edge_query[1] % edge_query[2]);
+      str(format(querystring) % EdgeQuery[0] % EdgeQuery[1] % EdgeQuery[2]);
   // this lambda will collect all of our results, since it is called on every
   // row of the result set
-  auto sqlite_cb_result_collector = [](void *cb, int argc, char **argv,
-                                       char **azColName) {
-    vector<hs_result> *res = static_cast<vector<hs_result> *>(cb);
-    res->emplace_back(argv[0], argv[1], argv[2]);
+  auto sqlite_cb_result_collector = [](void *CB, int Argc, char **Argv,
+                                       char **AzColName) {
+    vector<hs_result> *res = static_cast<vector<hs_result> *>(CB);
+    res->emplace_back(Argv[0], Argv[1], Argv[2]);
     return 0;
   };
   char *err;

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -502,7 +502,7 @@ set<const llvm::Value *> ProjectIRDB::getAllMemoryLocations() const {
   for (auto &[File, Module] : Modules) {
     for (auto &GV : Module->globals()) {
       if (GV.hasName()) {
-        string GVName = cxx_demangle(GV.getName().str());
+        string GVName = cxxDemangle(GV.getName().str());
         if (!IgnoredGlobalNames.count(GVName.substr(0, GVName.find(' ')))) {
           AllMemoryLoc.insert(&GV);
         }

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -57,15 +57,15 @@ ProjectIRDB::ProjectIRDB(const std::vector<std::string> &IRFiles,
       llvm::SMDiagnostic Diag;
       std::unique_ptr<llvm::LLVMContext> C(new llvm::LLVMContext);
       std::unique_ptr<llvm::Module> M = llvm::parseIRFile(File, Diag, *C);
-      bool broken_debug_info = false;
+      bool BrokenDebugInfo = false;
       if (M.get() == nullptr)
         Diag.print(File.c_str(), llvm::errs());
       /* Crash in presence of llvm-3.9.1 module (segfault) */
       if (M.get() == nullptr ||
-          llvm::verifyModule(*M, &llvm::errs(), &broken_debug_info)) {
+          llvm::verifyModule(*M, &llvm::errs(), &BrokenDebugInfo)) {
         throw std::runtime_error(File + " could not be parsed correctly");
       }
-      if (broken_debug_info) {
+      if (BrokenDebugInfo) {
         std::cout << "caution: debug info is broken\n";
       }
       Modules.insert(std::make_pair(File, std::move(M)));
@@ -105,10 +105,10 @@ ProjectIRDB::~ProjectIRDB() {
 
 void ProjectIRDB::preprocessModule(llvm::Module *M) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
+  auto &LG = lg::get();
   // add moduleID to timer name if performing MWA!
   START_TIMER("LLVM Passes", PAMM_SEVERITY_LEVEL::Full);
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO)
                 << "Preprocess module: " << M->getModuleIdentifier());
   llvm::PassBuilder PB;
   llvm::ModuleAnalysisManager MAM;
@@ -159,12 +159,12 @@ void ProjectIRDB::linkForWPA() {
             llvm::MemoryBuffer::getMemBuffer(IRBuffer);
         std::unique_ptr<llvm::Module> TmpMod =
             llvm::parseIR(*MemBuffer, ErrorDiagnostics, MainMod->getContext());
-        bool broken_debug_info = false;
+        bool BrokenDebugInfo = false;
         if (TmpMod.get() == nullptr ||
-            llvm::verifyModule(*TmpMod, &llvm::errs(), &broken_debug_info)) {
+            llvm::verifyModule(*TmpMod, &llvm::errs(), &BrokenDebugInfo)) {
           llvm::report_fatal_error("Error: module is broken!");
         }
-        if (broken_debug_info) {
+        if (BrokenDebugInfo) {
           // FIXME at least log this incident
         }
         // now we can safely perform the linking
@@ -178,19 +178,19 @@ void ProjectIRDB::linkForWPA() {
     // Update the IRDB reflecting that we now only need 'MainMod' and its
     // corresponding context!
     // delete every other module
-    for (auto it = Modules.begin(); it != Modules.end();) {
-      if (it->second.get() != MainMod) {
-        it = Modules.erase(it);
+    for (auto It = Modules.begin(); It != Modules.end();) {
+      if (It->second.get() != MainMod) {
+        It = Modules.erase(It);
       } else {
-        ++it;
+        ++It;
       }
     }
     // delete every other context
-    for (auto it = Contexts.begin(); it != Contexts.end();) {
-      if (it->get() != &MainMod->getContext()) {
-        it = Contexts.erase(it);
+    for (auto It = Contexts.begin(); It != Contexts.end();) {
+      if (It->get() != &MainMod->getContext()) {
+        It = Contexts.erase(It);
       } else {
-        ++it;
+        ++It;
       }
     }
     WPAModule = MainMod;
@@ -243,12 +243,12 @@ llvm::Instruction *ProjectIRDB::getInstruction(std::size_t Id) {
 }
 
 std::size_t ProjectIRDB::getInstructionID(const llvm::Instruction *I) const {
-  std::size_t id = 0;
+  std::size_t Id = 0;
   if (auto MD = llvm::cast<llvm::MDString>(
           I->getMetadata(PhasarConfig::MetaDataKind())->getOperand(0))) {
-    id = stol(MD->getString().str());
+    Id = stol(MD->getString().str());
   }
-  return id;
+  return Id;
 }
 
 void ProjectIRDB::print() const {
@@ -262,11 +262,11 @@ void ProjectIRDB::emitPreprocessedIR(std::ostream &OS, bool ShortenIR) const {
   for (auto &[File, Module] : Modules) {
     OS << "IR module: " << File << '\n';
     // print globals
-    for (auto &glob : Module->globals()) {
+    for (auto &Glob : Module->globals()) {
       if (ShortenIR) {
-        OS << llvmIRToShortString(&glob);
+        OS << llvmIRToShortString(&Glob);
       } else {
-        OS << llvmIRToString(&glob);
+        OS << llvmIRToString(&Glob);
       }
       OS << '\n';
     }
@@ -389,10 +389,10 @@ std::string ProjectIRDB::valueToPersistedString(const llvm::Value *V) {
     for (auto User : V->users()) {
       if (const llvm::Instruction *I =
               llvm::dyn_cast<llvm::Instruction>(User)) {
-        for (unsigned idx = 0; idx < I->getNumOperands(); ++idx) {
-          if (I->getOperand(idx) == V) {
+        for (unsigned Idx = 0; Idx < I->getNumOperands(); ++Idx) {
+          if (I->getOperand(Idx) == V) {
             return I->getFunction()->getName().str() + "." + getMetaDataID(I) +
-                   ".o." + std::to_string(idx);
+                   ".o." + std::to_string(Idx);
           }
         }
       }
@@ -411,21 +411,21 @@ const llvm::Value *ProjectIRDB::persistedStringToValue(const std::string &S) {
   } else if (S.find(".") == std::string::npos) {
     return getGlobalVariableDefinition(S);
   } else if (S.find(".f") != std::string::npos) {
-    unsigned argno = stoi(S.substr(S.find(".f") + 2, S.size()));
+    unsigned Argno = stoi(S.substr(S.find(".f") + 2, S.size()));
     return getNthFunctionArgument(
-        getFunctionDefinition(S.substr(0, S.find(".f"))), argno);
+        getFunctionDefinition(S.substr(0, S.find(".f"))), Argno);
   } else if (S.find(".o.") != std::string::npos) {
-    unsigned i = S.find(".");
-    unsigned j = S.find(".o.");
-    unsigned instID = stoi(S.substr(i + 1, j));
+    unsigned I = S.find(".");
+    unsigned J = S.find(".o.");
+    unsigned InstID = stoi(S.substr(I + 1, J));
     // std::cout << "FOUND instID: " << instID << "\n";
-    unsigned opIdx = stoi(S.substr(j + 3, S.size()));
+    unsigned OpIdx = stoi(S.substr(J + 3, S.size()));
     // std::cout << "FOUND opIdx: " << to_string(opIdx) << "\n";
     const llvm::Function *F = getFunctionDefinition(S.substr(0, S.find(".")));
     for (auto &BB : *F) {
-      for (auto &I : BB) {
-        if (getMetaDataID(&I) == std::to_string(instID)) {
-          return I.getOperand(opIdx);
+      for (auto &Inst : BB) {
+        if (getMetaDataID(&Inst) == std::to_string(InstID)) {
+          return Inst.getOperand(OpIdx);
         }
       }
     }
@@ -433,9 +433,9 @@ const llvm::Value *ProjectIRDB::persistedStringToValue(const std::string &S) {
   } else if (S.find(".") != std::string::npos) {
     const llvm::Function *F = getFunctionDefinition(S.substr(0, S.find(".")));
     for (auto &BB : *F) {
-      for (auto &I : BB) {
-        if (getMetaDataID(&I) == S.substr(S.find(".") + 1, S.size())) {
-          return &I;
+      for (auto &Inst : BB) {
+        if (getMetaDataID(&Inst) == S.substr(S.find(".") + 1, S.size())) {
+          return &Inst;
         }
       }
     }
@@ -487,9 +487,9 @@ ProjectIRDB::getAllocatedStructTypes() const {
 set<const llvm::Value *> ProjectIRDB::getAllMemoryLocations() const {
   // get all stack and heap alloca instructions
   auto AllocaInsts = getAllocaInstructions();
-  set<const llvm::Value *> allMemoryLoc;
+  set<const llvm::Value *> AllMemoryLoc;
   for (auto AllocaInst : AllocaInsts) {
-    allMemoryLoc.insert(static_cast<const llvm::Value *>(AllocaInst));
+    AllMemoryLoc.insert(static_cast<const llvm::Value *>(AllocaInst));
   }
   set<string> IgnoredGlobalNames = {"llvm.used",
                                     "llvm.compiler.used",
@@ -504,12 +504,12 @@ set<const llvm::Value *> ProjectIRDB::getAllMemoryLocations() const {
       if (GV.hasName()) {
         string GVName = cxx_demangle(GV.getName().str());
         if (!IgnoredGlobalNames.count(GVName.substr(0, GVName.find(' ')))) {
-          allMemoryLoc.insert(&GV);
+          AllMemoryLoc.insert(&GV);
         }
       }
     }
   }
-  return allMemoryLoc;
+  return AllMemoryLoc;
 }
 
 bool ProjectIRDB::wasCompiledWithDebugInfo(llvm::Module *M) const {

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -236,9 +236,9 @@ llvm::Module *ProjectIRDB::getModule(const std::string &ModuleName) {
 
 std::size_t ProjectIRDB::getNumberOfModules() const { return Modules.size(); }
 
-llvm::Instruction *ProjectIRDB::getInstruction(std::size_t id) {
-  if (IDInstructionMapping.count(id))
-    return IDInstructionMapping[id];
+llvm::Instruction *ProjectIRDB::getInstruction(std::size_t Id) {
+  if (IDInstructionMapping.count(Id))
+    return IDInstructionMapping[Id];
   return nullptr;
 }
 
@@ -258,22 +258,22 @@ void ProjectIRDB::print() const {
   }
 }
 
-void ProjectIRDB::emitPreprocessedIR(std::ostream &os, bool shortenIR) const {
+void ProjectIRDB::emitPreprocessedIR(std::ostream &OS, bool ShortenIR) const {
   for (auto &[File, Module] : Modules) {
-    os << "IR module: " << File << '\n';
+    OS << "IR module: " << File << '\n';
     // print globals
     for (auto &glob : Module->globals()) {
-      if (shortenIR) {
-        os << llvmIRToShortString(&glob);
+      if (ShortenIR) {
+        OS << llvmIRToShortString(&glob);
       } else {
-        os << llvmIRToString(&glob);
+        OS << llvmIRToString(&glob);
       }
-      os << '\n';
+      OS << '\n';
     }
-    os << '\n';
+    OS << '\n';
     for (auto F : getAllFunctions()) {
       if (!F->isDeclaration() && Module->getFunction(F->getName())) {
-        os << F->getName().str() << " {\n";
+        OS << F->getName().str() << " {\n";
         for (auto &BB : *F) {
           // do not print the label of the first BB
           if (BB.getPrevNode()) {
@@ -281,23 +281,23 @@ void ProjectIRDB::emitPreprocessedIR(std::ostream &os, bool shortenIR) const {
             llvm::raw_string_ostream RSO(BBLabel);
             BB.printAsOperand(RSO, false);
             RSO.flush();
-            os << "\n<label " << BBLabel << ">\n";
+            OS << "\n<label " << BBLabel << ">\n";
           }
           // print all instructions
           for (auto &I : BB) {
-            os << "  ";
-            if (shortenIR) {
-              os << llvmIRToShortString(&I);
+            OS << "  ";
+            if (ShortenIR) {
+              OS << llvmIRToShortString(&I);
             } else {
-              os << llvmIRToString(&I);
+              OS << llvmIRToString(&I);
             }
-            os << '\n';
+            OS << '\n';
           }
         }
-        os << "}\n\n";
+        OS << "}\n\n";
       }
     }
-    os << '\n';
+    OS << '\n';
   }
 }
 

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -502,7 +502,7 @@ set<const llvm::Value *> ProjectIRDB::getAllMemoryLocations() const {
   for (auto &[File, Module] : Modules) {
     for (auto &GV : Module->globals()) {
       if (GV.hasName()) {
-        string GVName = cxxDemangle(GV.getName().str());
+        string GVName = cxx_demangle(GV.getName().str());
         if (!IgnoredGlobalNames.count(GVName.substr(0, GVName.find(' ')))) {
           AllMemoryLoc.insert(&GV);
         }

--- a/lib/DB/Queries.cpp
+++ b/lib/DB/Queries.cpp
@@ -14,7 +14,7 @@ using namespace psr;
 
 namespace psr {
 
-const string SPO_INSERT =
+const string SPOInsert =
     "insert or ignore into spo_subject (name) "
     "values (\"%1%\");"
 
@@ -26,7 +26,7 @@ const string SPO_INSERT =
     "(select id from spo_predicate where name=\"%2%\" and sid=(select id from "
     "spo_subject where name=\"%1%\")));";
 
-const string SOP_INSERT =
+const string SOPInsert =
     "insert or ignore into sop_subject (name) "
     "values (\"%1%\");"
 
@@ -38,7 +38,7 @@ const string SOP_INSERT =
     "(select id from sop_object where name=\"%3%\" and sid=(select id from "
     "sop_subject where name=\"%1%\")));";
 
-const string PSO_INSERT =
+const string PSOInsert =
     "insert or ignore into pso_predicate (name) "
     "values (\"%2%\");"
 
@@ -50,7 +50,7 @@ const string PSO_INSERT =
     "(select id from pso_subject where name=\"%1%\" and pid=(select id from "
     "pso_predicate where name=\"%2%\")));";
 
-const string POS_INSERT =
+const string POSInsert =
     "insert or ignore into pos_predicate (name) "
     "values (\"%2%\");"
 
@@ -64,7 +64,7 @@ const string POS_INSERT =
     "(select pid from pos_object where name=\"%3%\" and pid=(select id from "
     "pos_predicate where name=\"%2%\")));";
 
-const string OSP_INSERT =
+const string OSPInsert =
     "insert or ignore into osp_object (name) "
     "values (\"%3%\");"
 
@@ -77,7 +77,7 @@ const string OSP_INSERT =
     "(select id from osp_object where name=\"%3%\" and oid=(select id from "
     "osp_object where name=\"%3%\")));";
 
-const string OPS_INSERT =
+const string OPSInsert =
     "insert or ignore into ops_object (name) "
     "values (\"%3%\");"
 
@@ -89,7 +89,7 @@ const string OPS_INSERT =
     "(select id from pos_object where name=\"%3%\" and oid=(select id from "
     "osp_object where name=\"%3%\")));";
 
-const string SEARCH_SPO =
+const string SearchSPO =
     "select spo_subject.name, spo_predicate.name, spo_object.name from "
     "spo_subject inner join spo_predicate on spo_subject.id=spo_predicate.sid "
     "inner join spo_object on spo_predicate.id=spo_object.pid and "
@@ -97,7 +97,7 @@ const string SEARCH_SPO =
     "where spo_subject.name=\"%1%\" and spo_predicate.name=\"%2%\" and "
     "spo_object.name=\"%3%\";";
 
-const string SEARCH_SPX =
+const string SearchSPX =
     "-- %3%\n"
     "select spo_subject.name, spo_predicate.name, spo_object.name from "
     "spo_subject inner join spo_predicate on spo_subject.id=spo_predicate.sid "
@@ -105,7 +105,7 @@ const string SEARCH_SPX =
     "spo_subject.id=spo_object.sid "
     "where spo_subject.name=\"%1%\" and spo_predicate.name=\"%2%\";";
 
-const string SEARCH_SXO =
+const string SearchSXO =
     "-- %2%\n"
     "select sop_subject.name, sop_predicate.name, sop_object.name from "
     "sop_subject "
@@ -114,7 +114,7 @@ const string SEARCH_SXO =
     "sop_subject.id=sop_predicate.sid "
     "where sop_subject.name=\"%1%\" and sop_object.name=\"%3%\";";
 
-const string SEARCH_XPO =
+const string SearchXPO =
     "-- %1%\n"
     "select pos_subject.name, pos_predicate.name, pos_object.name from "
     "pos_predicate "
@@ -123,7 +123,7 @@ const string SEARCH_XPO =
     "pos_subject.oid=pos_object.id "
     "where pos_predicate.name=\"%2%\" and pos_object.name=\"%3%\";";
 
-const string SEARCH_SXX =
+const string SearchSXX =
     "-- %2%%3%\n"
     "select spo_subject.name, spo_predicate.name, spo_object.name from "
     "spo_subject inner join spo_predicate on spo_subject.id=spo_predicate.sid "
@@ -131,7 +131,7 @@ const string SEARCH_SXX =
     "spo_subject.id=spo_object.sid "
     "where spo_subject.name=\"%1%\";";
 
-const string SEARCH_XPX =
+const string SearchXPX =
     "-- %1%%3%\n"
     "select pso_subject.name, pso_predicate.name, pso_object.name from "
     "pso_predicate inner join pso_subject on pso_predicate.id=pso_subject.pid "
@@ -139,7 +139,7 @@ const string SEARCH_XPX =
     "pso_subject.id=pso_object.sid "
     "where pso_predicate.name=\"%2%\";";
 
-const string SEARCH_XXO =
+const string SearchXXO =
     "-- %1%%2%\n"
     "select osp_subject.name, osp_predicate.name, osp_object.name from "
     "osp_object inner join osp_subject on osp_object.id=osp_subject.oid "
@@ -147,7 +147,7 @@ const string SEARCH_XXO =
     "osp_object.id=osp_predicate.oid "
     "where osp_object.name=\"%3%\";";
 
-const string SEARCH_XXX =
+const string SearchXXX =
     "-- %1%%2%%3%\n"
     "select spo_subject.name, spo_predicate.name, spo_object.name from "
     "spo_subject inner join spo_predicate on spo_subject.id=spo_predicate.sid "

--- a/lib/PhasarClang/ClangController.cpp
+++ b/lib/PhasarClang/ClangController.cpp
@@ -22,19 +22,19 @@ namespace psr {
 
 ClangController::ClangController(
     clang::tooling::CommonOptionsParser &OptionsParser) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "ClangController::ClangController()");
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Source file(s):");
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "Source file(s):");
   // for (auto &src : OptionsParser.getSourcePathList()) {
-  for (auto src : OptionsParser.getCompilations().getAllFiles()) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << src);
+  for (auto Src : OptionsParser.getCompilations().getAllFiles()) {
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << Src);
   }
   clang::tooling::ClangTool Tool(OptionsParser.getCompilations(),
                                  OptionsParser.getCompilations().getAllFiles());
-  int result = Tool.run(
+  int Result = Tool.run(
       clang::tooling::newFrontendActionFactory<RandomChangeFrontendAction>()
           .get());
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "finished clang ast analysis.");
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "finished clang ast analysis.");
 }
 } // namespace psr

--- a/lib/PhasarClang/MyMatcher.cpp
+++ b/lib/PhasarClang/MyMatcher.cpp
@@ -40,12 +40,12 @@ namespace psr {
 void MyMatcher::run(const MatchFinder::MatchResult &Result) {
   if (const ForStmt *FS = Result.Nodes.getNodeAs<ForStmt>("forLoop"))
     FS->dump();
-  if (const CallExpr *callee = Result.Nodes.getNodeAs<CallExpr>("callee"))
+  if (const CallExpr *CALLEE = Result.Nodes.getNodeAs<CallExpr>("callee"))
     errs() << "CALLEE: "
-           << callee->getDirectCallee()->getNameInfo().getAsString() << "\n";
-  if (const CXXRecordDecl *caller =
+           << CALLEE->getDirectCallee()->getNameInfo().getAsString() << "\n";
+  if (const CXXRecordDecl *CALLER =
           Result.Nodes.getNodeAs<CXXRecordDecl>("caller"))
-    errs() << "CALLER: " << caller->getNameAsString() << "\n";
+    errs() << "CALLER: " << CALLER->getNameAsString() << "\n";
   if (auto Caller = Result.Nodes.getNodeAs<clang::FunctionDecl>("caller"))
     errs() << "### Caller:" << Caller->getNameInfo().getAsString() << "\n";
   if (auto Callee = Result.Nodes.getNodeAs<clang::FunctionDecl>("callee"))

--- a/lib/PhasarClang/RandomChangeFrontendAction.cpp
+++ b/lib/PhasarClang/RandomChangeFrontendAction.cpp
@@ -45,8 +45,8 @@ void RandomChangeFrontendAction::EndSourceFileAction() {
 
 std::unique_ptr<clang::ASTConsumer>
 RandomChangeFrontendAction::CreateASTConsumer(clang::CompilerInstance &CI,
-                                              llvm::StringRef file) {
-  llvm::errs() << "** Creating AST consumer for: " << file << "\n";
+                                              llvm::StringRef File) {
+  llvm::errs() << "** Creating AST consumer for: " << File << "\n";
   RW.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
   return llvm::make_unique<RandomChangeASTConsumer>(RW);
 }

--- a/lib/PhasarClang/RandomChangeVisitor.cpp
+++ b/lib/PhasarClang/RandomChangeVisitor.cpp
@@ -36,7 +36,7 @@ namespace psr {
 
 RandomChangeVisitor::RandomChangeVisitor(clang::Rewriter &R) : RW(R) {}
 
-bool RandomChangeVisitor::visitStmt(clang::Stmt *S) {
+bool RandomChangeVisitor::VisitStmt(clang::Stmt *S) {
   // Only care about If statements.
   if (clang::isa<clang::IfStmt>(S)) {
     clang::IfStmt *IfStatement = clang::cast<clang::IfStmt>(S);
@@ -49,7 +49,7 @@ bool RandomChangeVisitor::visitStmt(clang::Stmt *S) {
   return true;
 }
 
-bool RandomChangeVisitor::visitFunctionDecl(clang::FunctionDecl *F) {
+bool RandomChangeVisitor::VisitFunctionDecl(clang::FunctionDecl *F) {
   // Only function definitions (with bodies), not declarations.
   if (F->hasBody()) {
     clang::Stmt *FuncBody = F->getBody();
@@ -75,13 +75,13 @@ bool RandomChangeVisitor::visitFunctionDecl(clang::FunctionDecl *F) {
   return true;
 }
 
-bool RandomChangeVisitor::visitTypeDecl(clang::TypeDecl *T) {
+bool RandomChangeVisitor::VisitTypeDecl(clang::TypeDecl *T) {
   llvm::outs() << "Found TypeDecl:\n";
   T->dump();
   return true;
 }
 
-bool RandomChangeVisitor::visitVarDecl(clang::VarDecl *V) {
+bool RandomChangeVisitor::VisitVarDecl(clang::VarDecl *V) {
   if (V->isLocalVarDecl()) {
     llvm::outs() << "Found local VarDecl: " << V->getName() << '\n';
     if (V->getName() == "x") {

--- a/lib/PhasarClang/RandomChangeVisitor.cpp
+++ b/lib/PhasarClang/RandomChangeVisitor.cpp
@@ -36,7 +36,7 @@ namespace psr {
 
 RandomChangeVisitor::RandomChangeVisitor(clang::Rewriter &R) : RW(R) {}
 
-bool RandomChangeVisitor::VisitStmt(clang::Stmt *S) {
+bool RandomChangeVisitor::visitStmt(clang::Stmt *S) {
   // Only care about If statements.
   if (clang::isa<clang::IfStmt>(S)) {
     clang::IfStmt *IfStatement = clang::cast<clang::IfStmt>(S);
@@ -49,7 +49,7 @@ bool RandomChangeVisitor::VisitStmt(clang::Stmt *S) {
   return true;
 }
 
-bool RandomChangeVisitor::VisitFunctionDecl(clang::FunctionDecl *F) {
+bool RandomChangeVisitor::visitFunctionDecl(clang::FunctionDecl *F) {
   // Only function definitions (with bodies), not declarations.
   if (F->hasBody()) {
     clang::Stmt *FuncBody = F->getBody();
@@ -75,13 +75,13 @@ bool RandomChangeVisitor::VisitFunctionDecl(clang::FunctionDecl *F) {
   return true;
 }
 
-bool RandomChangeVisitor::VisitTypeDecl(clang::TypeDecl *T) {
+bool RandomChangeVisitor::visitTypeDecl(clang::TypeDecl *T) {
   llvm::outs() << "Found TypeDecl:\n";
   T->dump();
   return true;
 }
 
-bool RandomChangeVisitor::VisitVarDecl(clang::VarDecl *V) {
+bool RandomChangeVisitor::visitVarDecl(clang::VarDecl *V) {
   if (V->isLocalVarDecl()) {
     llvm::outs() << "Found local VarDecl: " << V->getName() << '\n';
     if (V->getName() == "x") {

--- a/lib/PhasarClang/RandomChangeVisitor.cpp
+++ b/lib/PhasarClang/RandomChangeVisitor.cpp
@@ -96,15 +96,15 @@ bool RandomChangeVisitor::VisitVarDecl(clang::VarDecl *V) {
       auto End = Start;
       End = Start.getLocWithOffset(V->getDeclName().getAsString().size());
       // gets the range of the total parameter - including type and argument
-      auto range = clang::CharSourceRange::getTokenRange(Start, End);
+      auto Range = clang::CharSourceRange::getTokenRange(Start, End);
       // get the stringPtr from the range and convert to std::string
-      std::string s = std::string(clang::Lexer::getSourceText(
-          range, RW.getSourceMgr(), RW.getLangOpts()));
+      std::string S = std::string(clang::Lexer::getSourceText(
+          Range, RW.getSourceMgr(), RW.getLangOpts()));
       // offset gives us the length
-      int offset = clang::Lexer::MeasureTokenLength(End, RW.getSourceMgr(),
+      int Offset = clang::Lexer::MeasureTokenLength(End, RW.getSourceMgr(),
                                                     RW.getLangOpts());
       // replace the text with the text sent
-      RW.ReplaceText(Start, s.length() - offset, "newX");
+      RW.ReplaceText(Start, S.length() - Offset, "newX");
     }
   }
   return true;

--- a/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
+++ b/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string to_string(const AnalysisStrategy &S) {
+std::string toString(const AnalysisStrategy &S) {
   switch (S) {
   default:
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
@@ -29,7 +29,7 @@ std::string to_string(const AnalysisStrategy &S) {
   }
 }
 
-AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
+AnalysisStrategy toAnalysisStrategy(const std::string &S) {
   AnalysisStrategy Type = llvm::StringSwitch<AnalysisStrategy>(S)
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
   .Case(NAME, AnalysisStrategy::TYPE)
@@ -46,7 +46,7 @@ AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AnalysisStrategy &S) {
-  return OS << to_string(S);
+  return OS << toString(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
+++ b/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
@@ -29,7 +29,7 @@ std::string toString(const AnalysisStrategy &S) {
   }
 }
 
-AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
+AnalysisStrategy toAnalysisStrategy(const std::string &S) {
   AnalysisStrategy Type = llvm::StringSwitch<AnalysisStrategy>(S)
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
   .Case(NAME, AnalysisStrategy::TYPE)

--- a/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
+++ b/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string toString(const AnalysisStrategy &S) {
+std::string to_string(const AnalysisStrategy &S) {
   switch (S) {
   default:
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
@@ -29,7 +29,7 @@ std::string toString(const AnalysisStrategy &S) {
   }
 }
 
-AnalysisStrategy toAnalysisStrategy(const std::string &S) {
+AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
   AnalysisStrategy Type = llvm::StringSwitch<AnalysisStrategy>(S)
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
   .Case(NAME, AnalysisStrategy::TYPE)
@@ -46,7 +46,7 @@ AnalysisStrategy toAnalysisStrategy(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AnalysisStrategy &S) {
-  return OS << toString(S);
+  return OS << to_string(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
+++ b/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string to_string(const AnalysisStrategy &S) {
+std::string toString(const AnalysisStrategy &S) {
   switch (S) {
   default:
 #define ANALYSIS_STRATEGY_TYPES(NAME, CMDFLAG, TYPE)                           \
@@ -46,7 +46,7 @@ AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AnalysisStrategy &S) {
-  return OS << to_string(S);
+  return OS << toString(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
+++ b/lib/PhasarLLVM/AnalysisStrategy/Strategies.cpp
@@ -45,8 +45,8 @@ AnalysisStrategy to_AnalysisStrategy(const std::string &S) {
   return Type;
 }
 
-std::ostream &operator<<(std::ostream &os, const AnalysisStrategy &S) {
-  return os << to_string(S);
+std::ostream &operator<<(std::ostream &OS, const AnalysisStrategy &S) {
+  return OS << to_string(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/ICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/ICFG.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const CallGraphAnalysisType &CGA) {
+std::string toString(const CallGraphAnalysisType &CGA) {
   switch (CGA) {
   default:
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
@@ -54,7 +54,7 @@ CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const CallGraphAnalysisType &CGA) {
-  return OS << to_string(CGA);
+  return OS << toString(CGA);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/ICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/ICFG.cpp
@@ -37,7 +37,7 @@ std::string toString(const CallGraphAnalysisType &CGA) {
   }
 }
 
-CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
+CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S) {
   CallGraphAnalysisType Type = llvm::StringSwitch<CallGraphAnalysisType>(S)
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
   .Case(NAME, CallGraphAnalysisType::TYPE)

--- a/lib/PhasarLLVM/ControlFlow/ICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/ICFG.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const CallGraphAnalysisType &CGA) {
+std::string toString(const CallGraphAnalysisType &CGA) {
   switch (CGA) {
   default:
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
@@ -37,7 +37,7 @@ std::string to_string(const CallGraphAnalysisType &CGA) {
   }
 }
 
-CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
+CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S) {
   CallGraphAnalysisType Type = llvm::StringSwitch<CallGraphAnalysisType>(S)
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
   .Case(NAME, CallGraphAnalysisType::TYPE)
@@ -54,7 +54,7 @@ CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const CallGraphAnalysisType &CGA) {
-  return OS << to_string(CGA);
+  return OS << toString(CGA);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/ICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/ICFG.cpp
@@ -53,8 +53,8 @@ CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
   return Type;
 }
 
-ostream &operator<<(ostream &os, const CallGraphAnalysisType &CGA) {
-  return os << to_string(CGA);
+ostream &operator<<(ostream &OS, const CallGraphAnalysisType &CGA) {
+  return OS << to_string(CGA);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/ICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/ICFG.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace psr {
 
-std::string toString(const CallGraphAnalysisType &CGA) {
+std::string to_string(const CallGraphAnalysisType &CGA) {
   switch (CGA) {
   default:
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
@@ -37,7 +37,7 @@ std::string toString(const CallGraphAnalysisType &CGA) {
   }
 }
 
-CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S) {
+CallGraphAnalysisType to_CallGraphAnalysisType(const std::string &S) {
   CallGraphAnalysisType Type = llvm::StringSwitch<CallGraphAnalysisType>(S)
 #define ANALYSIS_SETUP_CALLGRAPH_TYPE(NAME, CMDFLAG, TYPE)                     \
   .Case(NAME, CallGraphAnalysisType::TYPE)
@@ -54,7 +54,7 @@ CallGraphAnalysisType toCallGraphAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const CallGraphAnalysisType &CGA) {
-  return OS << toString(CGA);
+  return OS << to_string(CGA);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.cpp
@@ -38,15 +38,15 @@ LLVMBasedBackwardCFG::getFunctionOf(const llvm::Instruction *Stmt) const {
 
 std::vector<const llvm::Instruction *>
 LLVMBasedBackwardCFG::getPredsOf(const llvm::Instruction *Stmt) const {
-  vector<const llvm::Instruction *> preds;
+  vector<const llvm::Instruction *> Preds;
   if (Stmt->getNextNode())
-    preds.push_back(Stmt->getNextNode());
+    Preds.push_back(Stmt->getNextNode());
   if (Stmt->isTerminator()) {
-    for (unsigned i = 0; i < Stmt->getNumSuccessors(); ++i) {
-      preds.push_back(&*Stmt->getSuccessor(i)->begin());
+    for (unsigned I = 0; I < Stmt->getNumSuccessors(); ++I) {
+      Preds.push_back(&*Stmt->getSuccessor(I)->begin());
     }
   }
-  return preds;
+  return Preds;
 }
 
 std::vector<const llvm::Instruction *>

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.cpp
@@ -32,39 +32,39 @@ namespace psr {
 
 // same as LLVMBasedCFG
 const llvm::Function *
-LLVMBasedBackwardCFG::getFunctionOf(const llvm::Instruction *stmt) const {
-  return stmt->getParent()->getParent();
+LLVMBasedBackwardCFG::getFunctionOf(const llvm::Instruction *Stmt) const {
+  return Stmt->getParent()->getParent();
 }
 
 std::vector<const llvm::Instruction *>
-LLVMBasedBackwardCFG::getPredsOf(const llvm::Instruction *stmt) const {
+LLVMBasedBackwardCFG::getPredsOf(const llvm::Instruction *Stmt) const {
   vector<const llvm::Instruction *> preds;
-  if (stmt->getNextNode())
-    preds.push_back(stmt->getNextNode());
-  if (stmt->isTerminator()) {
-    for (unsigned i = 0; i < stmt->getNumSuccessors(); ++i) {
-      preds.push_back(&*stmt->getSuccessor(i)->begin());
+  if (Stmt->getNextNode())
+    preds.push_back(Stmt->getNextNode());
+  if (Stmt->isTerminator()) {
+    for (unsigned i = 0; i < Stmt->getNumSuccessors(); ++i) {
+      preds.push_back(&*Stmt->getSuccessor(i)->begin());
     }
   }
   return preds;
 }
 
 std::vector<const llvm::Instruction *>
-LLVMBasedBackwardCFG::getSuccsOf(const llvm::Instruction *stmt) const {
+LLVMBasedBackwardCFG::getSuccsOf(const llvm::Instruction *Stmt) const {
   vector<const llvm::Instruction *> Preds;
-  if (stmt->getPrevNode()) {
-    Preds.push_back(stmt->getPrevNode());
+  if (Stmt->getPrevNode()) {
+    Preds.push_back(Stmt->getPrevNode());
   }
-  for (auto PredBlock : llvm::predecessors(stmt->getParent())) {
+  for (auto PredBlock : llvm::predecessors(Stmt->getParent())) {
     Preds.push_back(&PredBlock->back());
   }
   return Preds;
 }
 
 std::vector<std::pair<const llvm::Instruction *, const llvm::Instruction *>>
-LLVMBasedBackwardCFG::getAllControlFlowEdges(const llvm::Function *fun) const {
+LLVMBasedBackwardCFG::getAllControlFlowEdges(const llvm::Function *Fun) const {
   vector<pair<const llvm::Instruction *, const llvm::Instruction *>> Edges;
-  for (auto &BB : *fun) {
+  for (auto &BB : *Fun) {
     for (auto &I : BB) {
       auto Successors = getSuccsOf(&I);
       for (auto Successor : Successors) {
@@ -76,9 +76,9 @@ LLVMBasedBackwardCFG::getAllControlFlowEdges(const llvm::Function *fun) const {
 }
 
 std::vector<const llvm::Instruction *>
-LLVMBasedBackwardCFG::getAllInstructionsOf(const llvm::Function *fun) const {
+LLVMBasedBackwardCFG::getAllInstructionsOf(const llvm::Function *Fun) const {
   vector<const llvm::Instruction *> Instructions;
-  for (auto &BB : *fun) {
+  for (auto &BB : *Fun) {
     for (auto &I : BB) {
       Instructions.insert(Instructions.begin(), &I);
     }
@@ -87,34 +87,34 @@ LLVMBasedBackwardCFG::getAllInstructionsOf(const llvm::Function *fun) const {
 }
 
 // LLVMBasedCFG::isStartPoint
-bool LLVMBasedBackwardCFG::isExitStmt(const llvm::Instruction *stmt) const {
-  return (stmt == &stmt->getFunction()->front().front());
+bool LLVMBasedBackwardCFG::isExitStmt(const llvm::Instruction *Stmt) const {
+  return (Stmt == &Stmt->getFunction()->front().front());
 }
 
 // LLVMBasedCFG::isExitStmt
-bool LLVMBasedBackwardCFG::isStartPoint(const llvm::Instruction *stmt) const {
-  return llvm::isa<llvm::ReturnInst>(stmt);
+bool LLVMBasedBackwardCFG::isStartPoint(const llvm::Instruction *Stmt) const {
+  return llvm::isa<llvm::ReturnInst>(Stmt);
 }
 
-bool LLVMBasedBackwardCFG::isFieldLoad(const llvm::Instruction *stmt) const {
-  return ForwardCFG.isFieldLoad(stmt);
+bool LLVMBasedBackwardCFG::isFieldLoad(const llvm::Instruction *Stmt) const {
+  return ForwardCFG.isFieldLoad(Stmt);
 }
 
-bool LLVMBasedBackwardCFG::isFieldStore(const llvm::Instruction *stmt) const {
-  return ForwardCFG.isFieldStore(stmt);
+bool LLVMBasedBackwardCFG::isFieldStore(const llvm::Instruction *Stmt) const {
+  return ForwardCFG.isFieldStore(Stmt);
 }
 
 bool LLVMBasedBackwardCFG::isFallThroughSuccessor(
-    const llvm::Instruction *stmt, const llvm::Instruction *succ) const {
+    const llvm::Instruction *Stmt, const llvm::Instruction *Succ) const {
   assert(false && "FallThrough not valid in LLVM IR");
   return false;
 }
 
-bool LLVMBasedBackwardCFG::isBranchTarget(const llvm::Instruction *stmt,
-                                          const llvm::Instruction *succ) const {
-  if (const llvm::BranchInst *B = llvm::dyn_cast<llvm::BranchInst>(succ)) {
+bool LLVMBasedBackwardCFG::isBranchTarget(const llvm::Instruction *Stmt,
+                                          const llvm::Instruction *Succ) const {
+  if (const llvm::BranchInst *B = llvm::dyn_cast<llvm::BranchInst>(Succ)) {
     for (auto BB : B->successors()) {
-      if (stmt == &(BB->front())) {
+      if (Stmt == &(BB->front())) {
         return true;
       }
     }
@@ -124,14 +124,14 @@ bool LLVMBasedBackwardCFG::isBranchTarget(const llvm::Instruction *stmt,
 
 // same as LLVMBasedCFG
 std::string
-LLVMBasedBackwardCFG::getFunctionName(const llvm::Function *fun) const {
-  return fun->getName().str();
+LLVMBasedBackwardCFG::getFunctionName(const llvm::Function *Fun) const {
+  return Fun->getName().str();
 }
 
 std::string
-LLVMBasedBackwardCFG::getStatementId(const llvm::Instruction *stmt) const {
+LLVMBasedBackwardCFG::getStatementId(const llvm::Instruction *Stmt) const {
   return llvm::cast<llvm::MDString>(
-             stmt->getMetadata(PhasarConfig::MetaDataKind())->getOperand(0))
+             Stmt->getMetadata(PhasarConfig::MetaDataKind())->getOperand(0))
       ->getString()
       .str();
 }

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
@@ -58,18 +58,18 @@ LLVMBasedBackwardsICFG::LLVMBasedBackwardsICFG(
   boost::copy_graph(boost::make_reverse_graph(cgCopy), ForwardICFG.CallGraph);
 }
 
-bool LLVMBasedBackwardsICFG::isCallStmt(const llvm::Instruction *stmt) const {
-  return ForwardICFG.isCallStmt(stmt);
+bool LLVMBasedBackwardsICFG::isCallStmt(const llvm::Instruction *Stmt) const {
+  return ForwardICFG.isCallStmt(Stmt);
 }
 
 bool LLVMBasedBackwardsICFG::isIndirectFunctionCall(
-    const llvm::Instruction *stmt) const {
-  return ForwardICFG.isIndirectFunctionCall(stmt);
+    const llvm::Instruction *Stmt) const {
+  return ForwardICFG.isIndirectFunctionCall(Stmt);
 }
 
 bool LLVMBasedBackwardsICFG::isVirtualFunctionCall(
-    const llvm::Instruction *stmt) const {
-  return ForwardICFG.isVirtualFunctionCall(stmt);
+    const llvm::Instruction *Stmt) const {
+  return ForwardICFG.isVirtualFunctionCall(Stmt);
 }
 
 std::set<const llvm::Function *>
@@ -78,44 +78,44 @@ LLVMBasedBackwardsICFG::getAllFunctions() const {
 }
 
 const llvm::Function *
-LLVMBasedBackwardsICFG::getFunction(const std::string &fun) const {
-  return ForwardICFG.getFunction(fun);
+LLVMBasedBackwardsICFG::getFunction(const std::string &Fun) const {
+  return ForwardICFG.getFunction(Fun);
 }
 
 std::set<const llvm::Function *>
-LLVMBasedBackwardsICFG::getCalleesOfCallAt(const llvm::Instruction *n) const {
-  return ForwardICFG.getCalleesOfCallAt(n);
+LLVMBasedBackwardsICFG::getCalleesOfCallAt(const llvm::Instruction *N) const {
+  return ForwardICFG.getCalleesOfCallAt(N);
 }
 
 std::set<const llvm::Instruction *>
-LLVMBasedBackwardsICFG::getCallersOf(const llvm::Function *m) const {
-  return ForwardICFG.getCallersOf(m);
+LLVMBasedBackwardsICFG::getCallersOf(const llvm::Function *M) const {
+  return ForwardICFG.getCallersOf(M);
 }
 
 std::set<const llvm::Instruction *>
-LLVMBasedBackwardsICFG::getCallsFromWithin(const llvm::Function *m) const {
-  return ForwardICFG.getCallsFromWithin(m);
+LLVMBasedBackwardsICFG::getCallsFromWithin(const llvm::Function *M) const {
+  return ForwardICFG.getCallsFromWithin(M);
 }
 
 std::set<const llvm::Instruction *>
-LLVMBasedBackwardsICFG::getStartPointsOf(const llvm::Function *m) const {
-  return ForwardICFG.getExitPointsOf(m);
+LLVMBasedBackwardsICFG::getStartPointsOf(const llvm::Function *M) const {
+  return ForwardICFG.getExitPointsOf(M);
 }
 
 std::set<const llvm::Instruction *>
-LLVMBasedBackwardsICFG::getExitPointsOf(const llvm::Function *fun) const {
-  return ForwardICFG.getStartPointsOf(fun);
+LLVMBasedBackwardsICFG::getExitPointsOf(const llvm::Function *Fun) const {
+  return ForwardICFG.getStartPointsOf(Fun);
 }
 
 std::set<const llvm::Instruction *>
 LLVMBasedBackwardsICFG::getReturnSitesOfCallAt(
-    const llvm::Instruction *n) const {
+    const llvm::Instruction *N) const {
   std::set<const llvm::Instruction *> ReturnSites;
-  if (auto Call = llvm::dyn_cast<llvm::CallInst>(n)) {
+  if (auto Call = llvm::dyn_cast<llvm::CallInst>(N)) {
     if (auto Prev = Call->getPrevNode())
       ReturnSites.insert(Prev);
   }
-  if (auto Invoke = llvm::dyn_cast<llvm::InvokeInst>(n)) {
+  if (auto Invoke = llvm::dyn_cast<llvm::InvokeInst>(N)) {
     ReturnSites.insert(&Invoke->getNormalDest()->back());
     ReturnSites.insert(&Invoke->getUnwindDest()->back());
   }
@@ -128,21 +128,21 @@ LLVMBasedBackwardsICFG::allNonCallStartNodes() const {
 }
 
 const llvm::Instruction *
-LLVMBasedBackwardsICFG::getLastInstructionOf(const std::string &name) {
-  return ForwardICFG.getLastInstructionOf(name);
+LLVMBasedBackwardsICFG::getLastInstructionOf(const std::string &Name) {
+  return ForwardICFG.getLastInstructionOf(Name);
 }
 
 std::vector<const llvm::Instruction *>
-LLVMBasedBackwardsICFG::getAllInstructionsOfFunction(const std::string &name) {
-  return ForwardICFG.getAllInstructionsOfFunction(name);
+LLVMBasedBackwardsICFG::getAllInstructionsOfFunction(const std::string &Name) {
+  return ForwardICFG.getAllInstructionsOfFunction(Name);
 }
 
-void LLVMBasedBackwardsICFG::mergeWith(const LLVMBasedBackwardsICFG &other) {
-  ForwardICFG.mergeWith(other.ForwardICFG);
+void LLVMBasedBackwardsICFG::mergeWith(const LLVMBasedBackwardsICFG &Other) {
+  ForwardICFG.mergeWith(Other.ForwardICFG);
 }
 
-bool LLVMBasedBackwardsICFG::isPrimitiveFunction(const std::string &name) {
-  return ForwardICFG.isPrimitiveFunction(name);
+bool LLVMBasedBackwardsICFG::isPrimitiveFunction(const std::string &Name) {
+  return ForwardICFG.isPrimitiveFunction(Name);
 }
 
 void LLVMBasedBackwardsICFG::print(std::ostream &OS) const {

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
@@ -45,8 +45,8 @@ namespace psr {
 
 LLVMBasedBackwardsICFG::LLVMBasedBackwardsICFG(LLVMBasedICFG &ICFG)
     : ForwardICFG(ICFG) {
-  auto cgCopy = ForwardICFG.CallGraph;
-  boost::copy_graph(boost::make_reverse_graph(cgCopy), ForwardICFG.CallGraph);
+  auto CgCopy = ForwardICFG.CallGraph;
+  boost::copy_graph(boost::make_reverse_graph(CgCopy), ForwardICFG.CallGraph);
 }
 
 LLVMBasedBackwardsICFG::LLVMBasedBackwardsICFG(
@@ -54,8 +54,8 @@ LLVMBasedBackwardsICFG::LLVMBasedBackwardsICFG(
     const std::set<std::string> &EntryPoints, LLVMTypeHierarchy *TH,
     LLVMPointsToInfo *PT, SoundnessFlag SF)
     : ForwardICFG(IRDB, CGType, EntryPoints, TH, PT, SF) {
-  auto cgCopy = ForwardICFG.CallGraph;
-  boost::copy_graph(boost::make_reverse_graph(cgCopy), ForwardICFG.CallGraph);
+  auto CgCopy = ForwardICFG.CallGraph;
+  boost::copy_graph(boost::make_reverse_graph(CgCopy), ForwardICFG.CallGraph);
 }
 
 bool LLVMBasedBackwardsICFG::isCallStmt(const llvm::Instruction *Stmt) const {

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedCFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedCFG.cpp
@@ -28,8 +28,8 @@ using namespace psr;
 namespace psr {
 
 const llvm::Function *
-LLVMBasedCFG::getFunctionOf(const llvm::Instruction *stmt) const {
-  return stmt->getFunction();
+LLVMBasedCFG::getFunctionOf(const llvm::Instruction *Stmt) const {
+  return Stmt->getFunction();
 }
 
 vector<const llvm::Instruction *>
@@ -71,9 +71,9 @@ LLVMBasedCFG::getSuccsOf(const llvm::Instruction *I) const {
 }
 
 vector<pair<const llvm::Instruction *, const llvm::Instruction *>>
-LLVMBasedCFG::getAllControlFlowEdges(const llvm::Function *fun) const {
+LLVMBasedCFG::getAllControlFlowEdges(const llvm::Function *Fun) const {
   vector<pair<const llvm::Instruction *, const llvm::Instruction *>> Edges;
-  for (auto &BB : *fun) {
+  for (auto &BB : *Fun) {
     for (auto &I : BB) {
       auto Successors = getSuccsOf(&I);
       for (auto Successor : Successors) {
@@ -85,9 +85,9 @@ LLVMBasedCFG::getAllControlFlowEdges(const llvm::Function *fun) const {
 }
 
 vector<const llvm::Instruction *>
-LLVMBasedCFG::getAllInstructionsOf(const llvm::Function *fun) const {
+LLVMBasedCFG::getAllInstructionsOf(const llvm::Function *Fun) const {
   vector<const llvm::Instruction *> Instructions;
-  for (auto &BB : *fun) {
+  for (auto &BB : *Fun) {
     for (auto &I : BB) {
       Instructions.push_back(&I);
     }
@@ -95,16 +95,16 @@ LLVMBasedCFG::getAllInstructionsOf(const llvm::Function *fun) const {
   return Instructions;
 }
 
-bool LLVMBasedCFG::isExitStmt(const llvm::Instruction *stmt) const {
-  return llvm::isa<llvm::ReturnInst>(stmt);
+bool LLVMBasedCFG::isExitStmt(const llvm::Instruction *Stmt) const {
+  return llvm::isa<llvm::ReturnInst>(Stmt);
 }
 
-bool LLVMBasedCFG::isStartPoint(const llvm::Instruction *stmt) const {
-  return (stmt == &stmt->getFunction()->front().front());
+bool LLVMBasedCFG::isStartPoint(const llvm::Instruction *Stmt) const {
+  return (Stmt == &Stmt->getFunction()->front().front());
 }
 
-bool LLVMBasedCFG::isFieldLoad(const llvm::Instruction *stmt) const {
-  if (auto Load = llvm::dyn_cast<llvm::LoadInst>(stmt)) {
+bool LLVMBasedCFG::isFieldLoad(const llvm::Instruction *Stmt) const {
+  if (auto Load = llvm::dyn_cast<llvm::LoadInst>(Stmt)) {
     if (auto GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(
             Load->getPointerOperand())) {
       return true;
@@ -113,8 +113,8 @@ bool LLVMBasedCFG::isFieldLoad(const llvm::Instruction *stmt) const {
   return false;
 }
 
-bool LLVMBasedCFG::isFieldStore(const llvm::Instruction *stmt) const {
-  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(stmt)) {
+bool LLVMBasedCFG::isFieldStore(const llvm::Instruction *Stmt) const {
+  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(Stmt)) {
     if (auto GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(
             Store->getPointerOperand())) {
       return true;
@@ -123,24 +123,24 @@ bool LLVMBasedCFG::isFieldStore(const llvm::Instruction *stmt) const {
   return false;
 }
 
-bool LLVMBasedCFG::isFallThroughSuccessor(const llvm::Instruction *stmt,
-                                          const llvm::Instruction *succ) const {
+bool LLVMBasedCFG::isFallThroughSuccessor(const llvm::Instruction *Stmt,
+                                          const llvm::Instruction *Succ) const {
   // assert(false && "FallThrough not valid in LLVM IR");
-  if (const llvm::BranchInst *B = llvm::dyn_cast<llvm::BranchInst>(stmt)) {
+  if (const llvm::BranchInst *B = llvm::dyn_cast<llvm::BranchInst>(Stmt)) {
     if (B->isConditional()) {
-      return &B->getSuccessor(1)->front() == succ;
+      return &B->getSuccessor(1)->front() == Succ;
     } else {
-      return &B->getSuccessor(0)->front() == succ;
+      return &B->getSuccessor(0)->front() == Succ;
     }
   }
   return false;
 }
 
-bool LLVMBasedCFG::isBranchTarget(const llvm::Instruction *stmt,
-                                  const llvm::Instruction *succ) const {
-  if (stmt->isTerminator()) {
-    for (unsigned i = 0; i < stmt->getNumSuccessors(); ++i) {
-      if (&*stmt->getSuccessor(i)->begin() == succ) {
+bool LLVMBasedCFG::isBranchTarget(const llvm::Instruction *Stmt,
+                                  const llvm::Instruction *Succ) const {
+  if (Stmt->isTerminator()) {
+    for (unsigned i = 0; i < Stmt->getNumSuccessors(); ++i) {
+      if (&*Stmt->getSuccessor(i)->begin() == Succ) {
         return true;
       }
     }
@@ -148,15 +148,15 @@ bool LLVMBasedCFG::isBranchTarget(const llvm::Instruction *stmt,
   return false;
 }
 
-string LLVMBasedCFG::getStatementId(const llvm::Instruction *stmt) const {
+string LLVMBasedCFG::getStatementId(const llvm::Instruction *Stmt) const {
   return llvm::cast<llvm::MDString>(
-             stmt->getMetadata(PhasarConfig::MetaDataKind())->getOperand(0))
+             Stmt->getMetadata(PhasarConfig::MetaDataKind())->getOperand(0))
       ->getString()
       .str();
 }
 
-string LLVMBasedCFG::getFunctionName(const llvm::Function *fun) const {
-  return fun->getName().str();
+string LLVMBasedCFG::getFunctionName(const llvm::Function *Fun) const {
+  return Fun->getName().str();
 }
 
 void LLVMBasedCFG::print(const llvm::Function *F, std::ostream &OS) const {

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedCFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedCFG.cpp
@@ -45,8 +45,8 @@ LLVMBasedCFG::getPredsOf(const llvm::Instruction *I) const {
   if (Preds.empty()) {
     for (auto &BB : *I->getFunction()) {
       if (const llvm::Instruction *T = BB.getTerminator()) {
-        for (unsigned i = 0; i < T->getNumSuccessors(); ++i) {
-          if (&*T->getSuccessor(i)->begin() == I) {
+        for (unsigned Idx = 0; Idx < T->getNumSuccessors(); ++Idx) {
+          if (&*T->getSuccessor(Idx)->begin() == I) {
             Preds.push_back(T);
           }
         }
@@ -63,8 +63,8 @@ LLVMBasedCFG::getSuccsOf(const llvm::Instruction *I) const {
     Successors.push_back(I->getNextNode());
   }
   if (I->isTerminator()) {
-    for (unsigned i = 0; i < I->getNumSuccessors(); ++i) {
-      Successors.push_back(&*I->getSuccessor(i)->begin());
+    for (unsigned Idx = 0; Idx < I->getNumSuccessors(); ++Idx) {
+      Successors.push_back(&*I->getSuccessor(Idx)->begin());
     }
   }
   return Successors;
@@ -139,8 +139,8 @@ bool LLVMBasedCFG::isFallThroughSuccessor(const llvm::Instruction *Stmt,
 bool LLVMBasedCFG::isBranchTarget(const llvm::Instruction *Stmt,
                                   const llvm::Instruction *Succ) const {
   if (Stmt->isTerminator()) {
-    for (unsigned i = 0; i < Stmt->getNumSuccessors(); ++i) {
-      if (&*Stmt->getSuccessor(i)->begin() == Succ) {
+    for (unsigned I = 0; I < Stmt->getNumSuccessors(); ++I) {
+      if (&*Stmt->getSuccessor(I)->begin() == Succ) {
         return true;
       }
     }

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -96,7 +96,7 @@ LLVMBasedICFG::LLVMBasedICFG(ProjectIRDB &IRDB, CallGraphAnalysisType CGType,
                              SoundnessFlag SF)
     : IRDB(IRDB), CGType(CGType), SF(SF), TH(TH), PT(PT) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
+  auto &LG = lg::get();
   // check for faults in the logic
   if (!TH && (CGType != CallGraphAnalysisType::NORESOLVE)) {
     // no type hierarchy information provided by the user,
@@ -110,7 +110,7 @@ LLVMBasedICFG::LLVMBasedICFG(ProjectIRDB &IRDB, CallGraphAnalysisType CGType,
     this->PT = new LLVMPointsToInfo(IRDB);
     UserPTInfos = false;
   }
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO)
                 << "Starting CallGraphAnalysisType: " << CGType);
   VisitedFunctions.reserve(IRDB.getAllFunctions().size());
   unique_ptr<Resolver> Res([CGType, &IRDB, TH, PT,
@@ -153,7 +153,7 @@ LLVMBasedICFG::LLVMBasedICFG(ProjectIRDB &IRDB, CallGraphAnalysisType CGType,
               PAMM_SEVERITY_LEVEL::Full);
   REG_COUNTER("CG Vertices", getNumOfVertices(), PAMM_SEVERITY_LEVEL::Full);
   REG_COUNTER("CG Edges", getNumOfEdges(), PAMM_SEVERITY_LEVEL::Full);
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << "Call graph has been constructed");
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO) << "Call graph has been constructed");
 }
 
 LLVMBasedICFG::~LLVMBasedICFG() {
@@ -170,25 +170,25 @@ LLVMBasedICFG::~LLVMBasedICFG() {
 void LLVMBasedICFG::constructionWalker(const llvm::Function *F,
                                        Resolver &Resolver) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Walking in function: " << F->getName().str());
   if (F->isDeclaration() || !VisitedFunctions.insert(F).second) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Function already visited or only declaration: "
                   << F->getName().str());
     return;
   }
 
   // add a node for function F to the call graph (if not present already)
-  vertex_t thisFunctionVertexDescriptor;
-  auto fvmItr = FunctionVertexMap.find(F);
-  if (fvmItr != FunctionVertexMap.end())
-    thisFunctionVertexDescriptor = fvmItr->second;
+  vertex_t ThisFunctionVertexDescriptor;
+  auto FvmItr = FunctionVertexMap.find(F);
+  if (FvmItr != FunctionVertexMap.end())
+    ThisFunctionVertexDescriptor = FvmItr->second;
   else {
-    thisFunctionVertexDescriptor =
+    ThisFunctionVertexDescriptor =
         boost::add_vertex(VertexProperties(F), CallGraph);
-    FunctionVertexMap[F] = thisFunctionVertexDescriptor;
+    FunctionVertexMap[F] = ThisFunctionVertexDescriptor;
   }
 
   // iterate all instructions of the current function
@@ -197,63 +197,63 @@ void LLVMBasedICFG::constructionWalker(const llvm::Function *F,
       if (llvm::isa<llvm::CallInst>(I) || llvm::isa<llvm::InvokeInst>(I)) {
         Resolver.preCall(&I);
 
-        llvm::ImmutableCallSite cs(&I);
-        set<const llvm::Function *> possible_targets;
+        llvm::ImmutableCallSite CS(&I);
+        set<const llvm::Function *> PossibleTargets;
         // check if function call can be resolved statically
-        if (cs.getCalledFunction() != nullptr) {
-          possible_targets.insert(cs.getCalledFunction());
-          LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Found static call-site: ");
-          LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                        << "  " << llvmIRToString(cs.getInstruction()));
+        if (CS.getCalledFunction() != nullptr) {
+          PossibleTargets.insert(CS.getCalledFunction());
+          LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "Found static call-site: ");
+          LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                        << "  " << llvmIRToString(CS.getInstruction()));
         } else {
           // still try to resolve the called function statically
-          const llvm::Value *sv = cs.getCalledValue()->stripPointerCasts();
-          const llvm::Function *valueFunction =
-              !sv->hasName() ? nullptr : IRDB.getFunction(sv->getName());
-          if (valueFunction) {
-            possible_targets.insert(valueFunction);
-            LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+          const llvm::Value *SV = CS.getCalledValue()->stripPointerCasts();
+          const llvm::Function *ValueFunction =
+              !SV->hasName() ? nullptr : IRDB.getFunction(SV->getName());
+          if (ValueFunction) {
+            PossibleTargets.insert(ValueFunction);
+            LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                           << "Found static call-site: "
-                          << llvmIRToString(cs.getInstruction()));
+                          << llvmIRToString(CS.getInstruction()));
           } else {
             // the function call must be resolved dynamically
-            LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+            LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                           << "Found dynamic call-site: ");
-            LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                          << "  " << llvmIRToString(cs.getInstruction()));
+            LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                          << "  " << llvmIRToString(CS.getInstruction()));
             // call the resolve routine
-            if (isVirtualFunctionCall(cs.getInstruction())) {
-              possible_targets = Resolver.resolveVirtualCall(cs);
+            if (isVirtualFunctionCall(CS.getInstruction())) {
+              PossibleTargets = Resolver.resolveVirtualCall(CS);
             } else {
-              possible_targets = Resolver.resolveFunctionPointer(cs);
+              PossibleTargets = Resolver.resolveFunctionPointer(CS);
             }
           }
         }
 
-        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                      << "Found " << possible_targets.size()
+        LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                      << "Found " << PossibleTargets.size()
                       << " possible target(s)");
 
-        Resolver.handlePossibleTargets(cs, possible_targets);
+        Resolver.handlePossibleTargets(CS, PossibleTargets);
         // Insert possible target inside the graph and add the link with
         // the current function
-        for (auto &possible_target : possible_targets) {
-          vertex_t targetVertex;
-          auto targetFvmItr = FunctionVertexMap.find(possible_target);
-          if (targetFvmItr != FunctionVertexMap.end())
-            targetVertex = targetFvmItr->second;
+        for (auto &PossibleTarget : PossibleTargets) {
+          vertex_t TargetVertex;
+          auto TargetFvmItr = FunctionVertexMap.find(PossibleTarget);
+          if (TargetFvmItr != FunctionVertexMap.end())
+            TargetVertex = TargetFvmItr->second;
           else {
-            targetVertex =
-                boost::add_vertex(VertexProperties(possible_target), CallGraph);
-            FunctionVertexMap[possible_target] = targetVertex;
+            TargetVertex =
+                boost::add_vertex(VertexProperties(PossibleTarget), CallGraph);
+            FunctionVertexMap[PossibleTarget] = TargetVertex;
           }
-          boost::add_edge(thisFunctionVertexDescriptor, targetVertex,
-                          EdgeProperties(cs.getInstruction()), CallGraph);
+          boost::add_edge(ThisFunctionVertexDescriptor, TargetVertex,
+                          EdgeProperties(CS.getInstruction()), CallGraph);
         }
 
         // continue resolving
-        for (auto possible_target : possible_targets) {
-          constructionWalker(possible_target, Resolver);
+        for (auto PossibleTarget : PossibleTargets) {
+          constructionWalker(PossibleTarget, Resolver);
         }
 
         Resolver.postCall(&I);
@@ -295,90 +295,90 @@ set<const llvm::Function *> LLVMBasedICFG::getAllFunctions() const {
 
 std::vector<const llvm::Instruction *>
 LLVMBasedICFG::getOutEdges(const llvm::Function *F) const {
-  auto functionMapIt = FunctionVertexMap.find(F);
-  if (functionMapIt == FunctionVertexMap.end())
+  auto FunctionMapIt = FunctionVertexMap.find(F);
+  if (FunctionMapIt == FunctionVertexMap.end())
     return {};
 
-  std::vector<const llvm::Instruction *> edges;
-  for (const auto edgeIt : boost::make_iterator_range(
-           boost::out_edges(functionMapIt->second, CallGraph))) {
-    auto edge = CallGraph[edgeIt];
-    edges.push_back(edge.CS);
+  std::vector<const llvm::Instruction *> Edges;
+  for (const auto EdgeIt : boost::make_iterator_range(
+           boost::out_edges(FunctionMapIt->second, CallGraph))) {
+    auto Edge = CallGraph[EdgeIt];
+    Edges.push_back(Edge.CS);
   }
 
-  return edges;
+  return Edges;
 }
 
 LLVMBasedICFG::OutEdgesAndTargets
 LLVMBasedICFG::getOutEdgeAndTarget(const llvm::Function *F) const {
-  auto functionMapIt = FunctionVertexMap.find(F);
-  if (functionMapIt == FunctionVertexMap.end())
+  auto FunctionMapIt = FunctionVertexMap.find(F);
+  if (FunctionMapIt == FunctionVertexMap.end())
     return {};
 
-  OutEdgesAndTargets edges;
-  for (const auto edgeIt : boost::make_iterator_range(
-           boost::out_edges(functionMapIt->second, CallGraph))) {
-    auto edge = CallGraph[edgeIt];
-    auto target = CallGraph[boost::target(edgeIt, CallGraph)];
-    edges.insert(std::make_pair(edge.CS, target.F));
+  OutEdgesAndTargets Edges;
+  for (const auto EdgeIt : boost::make_iterator_range(
+           boost::out_edges(FunctionMapIt->second, CallGraph))) {
+    auto Edge = CallGraph[EdgeIt];
+    auto Target = CallGraph[boost::target(EdgeIt, CallGraph)];
+    Edges.insert(std::make_pair(Edge.CS, Target.F));
   }
 
-  return edges;
+  return Edges;
 }
 
 size_t LLVMBasedICFG::removeEdges(const llvm::Function *F,
                                   const llvm::Instruction *I) {
-  auto functionMapIt = FunctionVertexMap.find(F);
-  if (functionMapIt == FunctionVertexMap.end())
+  auto FunctionMapIt = FunctionVertexMap.find(F);
+  if (FunctionMapIt == FunctionVertexMap.end())
     return 0;
 
-  size_t edgesRemoved = 0;
-  auto outEdges = boost::out_edges(functionMapIt->second, CallGraph);
-  for (auto edgeIt : boost::make_iterator_range(outEdges)) {
-    auto edge = CallGraph[edgeIt];
-    if (edge.CS == I) {
-      boost::remove_edge(edgeIt, CallGraph);
-      ++edgesRemoved;
+  size_t EdgesRemoved = 0;
+  auto OutEdges = boost::out_edges(FunctionMapIt->second, CallGraph);
+  for (auto EdgeIt : boost::make_iterator_range(OutEdges)) {
+    auto Edge = CallGraph[EdgeIt];
+    if (Edge.CS == I) {
+      boost::remove_edge(EdgeIt, CallGraph);
+      ++EdgesRemoved;
     }
   }
-  return edgesRemoved;
+  return EdgesRemoved;
 }
 
 bool LLVMBasedICFG::removeVertex(const llvm::Function *F) {
-  auto functionMapIt = FunctionVertexMap.find(F);
-  if (functionMapIt == FunctionVertexMap.end())
+  auto FunctionMapIt = FunctionVertexMap.find(F);
+  if (FunctionMapIt == FunctionVertexMap.end())
     return false;
 
-  boost::remove_vertex(functionMapIt->second, CallGraph);
-  FunctionVertexMap.erase(functionMapIt);
+  boost::remove_vertex(FunctionMapIt->second, CallGraph);
+  FunctionVertexMap.erase(FunctionMapIt);
   return true;
 }
 
 size_t LLVMBasedICFG::getCallerCount(const llvm::Function *F) const {
-  auto mapEntry = FunctionVertexMap.find(F);
-  if (mapEntry == FunctionVertexMap.end()) {
+  auto MapEntry = FunctionVertexMap.find(F);
+  if (MapEntry == FunctionVertexMap.end()) {
     return 0;
   }
 
-  auto edgeIterators = boost::in_edges(mapEntry->second, CallGraph);
-  return std::distance(edgeIterators.first, edgeIterators.second);
+  auto EdgeIterators = boost::in_edges(MapEntry->second, CallGraph);
+  return std::distance(EdgeIterators.first, EdgeIterators.second);
 }
 
 set<const llvm::Function *>
 LLVMBasedICFG::getCalleesOfCallAt(const llvm::Instruction *N) const {
   if (llvm::isa<llvm::CallInst>(N) || llvm::isa<llvm::InvokeInst>(N)) {
     set<const llvm::Function *> Callees;
-    auto mapEntry = FunctionVertexMap.find(N->getFunction());
-    if (mapEntry == FunctionVertexMap.end()) {
+    auto MapEntry = FunctionVertexMap.find(N->getFunction());
+    if (MapEntry == FunctionVertexMap.end()) {
       return Callees;
     }
-    out_edge_iterator ei, ei_end;
-    for (boost::tie(ei, ei_end) = boost::out_edges(mapEntry->second, CallGraph);
-         ei != ei_end; ++ei) {
-      auto edge = CallGraph[*ei];
-      if (N == edge.CS) {
-        auto target = boost::target(*ei, CallGraph);
-        Callees.insert(CallGraph[target].F);
+    out_edge_iterator EI, EIEnd;
+    for (boost::tie(EI, EIEnd) = boost::out_edges(MapEntry->second, CallGraph);
+         EI != EIEnd; ++EI) {
+      auto Edge = CallGraph[*EI];
+      if (N == Edge.CS) {
+        auto Target = boost::target(*EI, CallGraph);
+        Callees.insert(CallGraph[Target].F);
       }
     }
     return Callees;
@@ -390,15 +390,15 @@ LLVMBasedICFG::getCalleesOfCallAt(const llvm::Instruction *N) const {
 set<const llvm::Instruction *>
 LLVMBasedICFG::getCallersOf(const llvm::Function *F) const {
   set<const llvm::Instruction *> CallersOf;
-  auto mapEntry = FunctionVertexMap.find(F);
-  if (mapEntry == FunctionVertexMap.end()) {
+  auto MapEntry = FunctionVertexMap.find(F);
+  if (MapEntry == FunctionVertexMap.end()) {
     return CallersOf;
   }
-  in_edge_iterator ei, ei_end;
-  for (boost::tie(ei, ei_end) = boost::in_edges(mapEntry->second, CallGraph);
-       ei != ei_end; ++ei) {
-    auto edge = CallGraph[*ei];
-    CallersOf.insert(edge.CS);
+  in_edge_iterator EI, EIEnd;
+  for (boost::tie(EI, EIEnd) = boost::in_edges(MapEntry->second, CallGraph);
+       EI != EIEnd; ++EI) {
+    auto Edge = CallGraph[*EI];
+    CallersOf.insert(Edge.CS);
   }
   return CallersOf;
 }
@@ -429,8 +429,8 @@ LLVMBasedICFG::getStartPointsOf(const llvm::Function *M) const {
     // } else if (!getStartPointsOf(getMethod(m->getName().str())).empty()) {
     // return getStartPointsOf(getMethod(m->getName().str()));
   } else {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    auto &LG = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Could not get starting points of '" << M->getName().str()
                   << "' because it is a declaration");
     return {};
@@ -442,8 +442,8 @@ LLVMBasedICFG::getExitPointsOf(const llvm::Function *Fun) const {
   if (!Fun->isDeclaration()) {
     return {&Fun->back().back()};
   } else {
-    auto &lg = lg::get();
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    auto &LG = lg::get();
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Could not get exit points of '" << Fun->getName().str()
                   << "' which is declaration!");
     return {};
@@ -509,59 +509,59 @@ LLVMBasedICFG::getLastInstructionOf(const string &Name) {
   if (!F) {
     return nullptr;
   }
-  auto last = llvm::inst_end(*F);
-  last--;
-  return &(*last);
+  auto Last = llvm::inst_end(*F);
+  Last--;
+  return &(*Last);
 }
 
 void LLVMBasedICFG::mergeWith(const LLVMBasedICFG &Other) {
   typedef bidigraph_t::vertex_descriptor vertex_t;
   typedef std::map<vertex_t, vertex_t> vertex_map_t;
-  vertex_map_t oldToNewVertexMapping;
-  boost::associative_property_map<vertex_map_t> vertexMapWrapper(
-      oldToNewVertexMapping);
+  vertex_map_t OldToNewVertexMapping;
+  boost::associative_property_map<vertex_map_t> VertexMapWrapper(
+      OldToNewVertexMapping);
   boost::copy_graph(Other.CallGraph, CallGraph,
-                    boost::orig_to_copy(vertexMapWrapper));
+                    boost::orig_to_copy(VertexMapWrapper));
 
   // This vector holds the call-sites that are used to merge the whole-module
   // points-to graphs
   vector<pair<llvm::ImmutableCallSite, const llvm::Function *>> Calls;
-  vertex_iterator vi_v, vi_v_end, vi_u, vi_u_end;
+  vertex_iterator VIv, VIvEnd, VIu, VIuEnd;
   // Iterate the vertices of this graph 'v'
-  for (boost::tie(vi_v, vi_v_end) = boost::vertices(CallGraph);
-       vi_v != vi_v_end; ++vi_v) {
+  for (boost::tie(VIv, VIvEnd) = boost::vertices(CallGraph); VIv != VIvEnd;
+       ++VIv) {
     // Iterate the vertices of the other graph 'u'
-    for (boost::tie(vi_u, vi_u_end) = boost::vertices(CallGraph);
-         vi_u != vi_u_end; ++vi_u) {
+    for (boost::tie(VIu, VIuEnd) = boost::vertices(CallGraph); VIu != VIuEnd;
+         ++VIu) {
       // Check if we have a virtual node that can be replaced with the actual
       // node
-      if (CallGraph[*vi_v].F == CallGraph[*vi_u].F &&
-          CallGraph[*vi_v].F->isDeclaration() &&
-          !CallGraph[*vi_u].F->isDeclaration()) {
-        in_edge_iterator ei, ei_end;
-        for (boost::tie(ei, ei_end) = boost::in_edges(*vi_v, CallGraph);
-             ei != ei_end; ++ei) {
-          auto source = boost::source(*ei, CallGraph);
-          auto edge = CallGraph[*ei];
+      if (CallGraph[*VIv].F == CallGraph[*VIu].F &&
+          CallGraph[*VIv].F->isDeclaration() &&
+          !CallGraph[*VIu].F->isDeclaration()) {
+        in_edge_iterator EI, EIEnd;
+        for (boost::tie(EI, EIEnd) = boost::in_edges(*VIv, CallGraph);
+             EI != EIEnd; ++EI) {
+          auto Source = boost::source(*EI, CallGraph);
+          auto Edge = CallGraph[*EI];
           // This becomes the new edge for this graph to the other graph
-          boost::add_edge(source, *vi_u, edge.CS, CallGraph);
+          boost::add_edge(Source, *VIu, Edge.CS, CallGraph);
           Calls.push_back(
-              make_pair(llvm::ImmutableCallSite(edge.CS), CallGraph[*vi_u].F));
+              make_pair(llvm::ImmutableCallSite(Edge.CS), CallGraph[*VIu].F));
           // Remove the old edge flowing into the virtual node
-          boost::remove_edge(source, *vi_v, CallGraph);
+          boost::remove_edge(Source, *VIv, CallGraph);
         }
         // Remove the virtual node
-        boost::remove_vertex(*vi_v, CallGraph);
+        boost::remove_vertex(*VIv, CallGraph);
       }
     }
   }
 
   // Update the FunctionVertexMap:
-  for (const auto &otherValues : Other.FunctionVertexMap) {
-    auto mappingIter = oldToNewVertexMapping.find(otherValues.second);
-    if (mappingIter != oldToNewVertexMapping.end()) {
+  for (const auto &OtherValues : Other.FunctionVertexMap) {
+    auto MappingIter = OldToNewVertexMapping.find(OtherValues.second);
+    if (MappingIter != OldToNewVertexMapping.end()) {
       FunctionVertexMap.insert(
-          make_pair(otherValues.first, mappingIter->second));
+          make_pair(OtherValues.first, MappingIter->second));
     }
   }
 
@@ -588,14 +588,13 @@ bool LLVMBasedICFG::isPrimitiveFunction(const string &Name) {
 
 void LLVMBasedICFG::print(ostream &OS) const {
   OS << "Call Graph:\n";
-  vertex_iterator ui, ui_end;
-  for (boost::tie(ui, ui_end) = boost::vertices(CallGraph); ui != ui_end;
-       ++ui) {
-    OS << CallGraph[*ui].getFunctionName() << " --> ";
-    out_edge_iterator ei, ei_end;
-    for (boost::tie(ei, ei_end) = boost::out_edges(*ui, CallGraph);
-         ei != ei_end; ++ei)
-      OS << CallGraph[target(*ei, CallGraph)].getFunctionName() << " ";
+  vertex_iterator UI, UIEnd;
+  for (boost::tie(UI, UIEnd) = boost::vertices(CallGraph); UI != UIEnd; ++UI) {
+    OS << CallGraph[*UI].getFunctionName() << " --> ";
+    out_edge_iterator EI, EIEnd;
+    for (boost::tie(EI, EIEnd) = boost::out_edges(*UI, CallGraph); EI != EIEnd;
+         ++EI)
+      OS << CallGraph[target(*EI, CallGraph)].getFunctionName() << " ";
     OS << '\n';
   }
 }
@@ -644,17 +643,17 @@ void LLVMBasedICFG::printInternalPTGAsDot(std::ostream &OS) const {
 
 nlohmann::json LLVMBasedICFG::getAsJson() const {
   nlohmann::json J;
-  vertex_iterator vi_v, vi_v_end;
-  out_edge_iterator ei, ei_end;
+  vertex_iterator VIv, VIvEnd;
+  out_edge_iterator EI, EIEnd;
   // iterate all graph vertices
-  for (boost::tie(vi_v, vi_v_end) = boost::vertices(CallGraph);
-       vi_v != vi_v_end; ++vi_v) {
-    J[PhasarConfig::JsonCallGraphID()][CallGraph[*vi_v].getFunctionName()];
+  for (boost::tie(VIv, VIvEnd) = boost::vertices(CallGraph); VIv != VIvEnd;
+       ++VIv) {
+    J[PhasarConfig::JsonCallGraphID()][CallGraph[*VIv].getFunctionName()];
     // iterate all out edges of vertex vi_v
-    for (boost::tie(ei, ei_end) = boost::out_edges(*vi_v, CallGraph);
-         ei != ei_end; ++ei) {
-      J[PhasarConfig::JsonCallGraphID()][CallGraph[*vi_v].getFunctionName()] +=
-          CallGraph[boost::target(*ei, CallGraph)].getFunctionName();
+    for (boost::tie(EI, EIEnd) = boost::out_edges(*VIv, CallGraph); EI != EIEnd;
+         ++EI) {
+      J[PhasarConfig::JsonCallGraphID()][CallGraph[*VIv].getFunctionName()] +=
+          CallGraph[boost::target(*EI, CallGraph)].getFunctionName();
     }
   }
   return J;
@@ -665,16 +664,16 @@ const PointsToGraph &LLVMBasedICFG::getWholeModulePTG() const {
 }
 
 vector<const llvm::Function *> LLVMBasedICFG::getDependencyOrderedFunctions() {
-  vector<vertex_t> vertices;
-  vector<const llvm::Function *> functions;
-  dependency_visitor deps(vertices);
-  boost::depth_first_search(CallGraph, visitor(deps));
-  for (auto v : vertices) {
-    if (!CallGraph[v].F->isDeclaration()) {
-      functions.push_back(CallGraph[v].F);
+  vector<vertex_t> Vertices;
+  vector<const llvm::Function *> Functions;
+  dependency_visitor Deps(Vertices);
+  boost::depth_first_search(CallGraph, visitor(Deps));
+  for (auto V : Vertices) {
+    if (!CallGraph[V].F->isDeclaration()) {
+      Functions.push_back(CallGraph[V].F);
     }
   }
-  return functions;
+  return Functions;
 }
 
 unsigned LLVMBasedICFG::getNumOfVertices() {

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -61,7 +61,7 @@ struct LLVMBasedICFG::dependency_visitor : boost::default_dfs_visitor {
   std::vector<vertex_t> &Vertices;
   dependency_visitor(std::vector<vertex_t> &V) : Vertices(V) {}
   template <typename Vertex, typename Graph>
-  void finishVertex(Vertex U, const Graph &G) {
+  void finish_vertex(Vertex U, const Graph &G) {
     Vertices.push_back(U);
   }
 };

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -58,11 +58,11 @@ using namespace std;
 namespace psr {
 
 struct LLVMBasedICFG::dependency_visitor : boost::default_dfs_visitor {
-  std::vector<vertex_t> &vertices;
-  dependency_visitor(std::vector<vertex_t> &v) : vertices(v) {}
+  std::vector<vertex_t> &Vertices;
+  dependency_visitor(std::vector<vertex_t> &v) : Vertices(v) {}
   template <typename Vertex, typename Graph>
   void finish_vertex(Vertex u, const Graph &g) {
-    vertices.push_back(u);
+    Vertices.push_back(u);
   }
 };
 

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -61,7 +61,7 @@ struct LLVMBasedICFG::dependency_visitor : boost::default_dfs_visitor {
   std::vector<vertex_t> &Vertices;
   dependency_visitor(std::vector<vertex_t> &V) : Vertices(V) {}
   template <typename Vertex, typename Graph>
-  void finish_vertex(Vertex U, const Graph &G) {
+  void finishVertex(Vertex U, const Graph &G) {
     Vertices.push_back(U);
   }
 };

--- a/lib/PhasarLLVM/ControlFlow/Resolver/CHAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/CHAResolver.cpp
@@ -34,22 +34,22 @@ CHAResolver::CHAResolver(ProjectIRDB &IRDB, LLVMTypeHierarchy &TH)
 
 set<const llvm::Function *>
 CHAResolver::resolveVirtualCall(llvm::ImmutableCallSite CS) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Call virtual function: "
                 << llvmIRToString(CS.getInstruction()));
 
   auto VFTIdx = getVFTIndex(CS);
   if (VFTIdx < 0) {
     // An error occured
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
                      "the vtable index\n"
                   << llvmIRToString(CS.getInstruction()) << "\n");
     return {};
   }
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Virtual function table entry is: " << VFTIdx);
 
   auto ReceiverTy = getReceiverType(CS);

--- a/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
@@ -34,7 +34,7 @@ using namespace psr;
 DTAResolver::DTAResolver(ProjectIRDB &IRDB, LLVMTypeHierarchy &TH)
     : CHAResolver(IRDB, TH) {}
 
-bool DTAResolver::heuristicAntiConstructorThisType(
+bool DTAResolver::heuristic_anti_contructor_this_type(
     const llvm::BitCastInst *BitCast) {
   // We check if the caller is a constructor, and if the this argument has the
   // same type as the source type of the bitcast. If it is the case, it returns
@@ -55,12 +55,12 @@ bool DTAResolver::heuristicAntiConstructorThisType(
   return true;
 }
 
-bool DTAResolver::heuristicAntiConstructorVtablePos(
+bool DTAResolver::heuristic_anti_contructor_vtable_pos(
     const llvm::BitCastInst *BitCast) {
   // Better heuristic than the previous one, can handle the CRTP. Based on the
   // previous one.
 
-  if (heuristicAntiConstructorThisType(BitCast))
+  if (heuristic_anti_contructor_this_type(BitCast))
     return true;
 
   // We know that we are in a constructor and the source type of the bitcast is
@@ -137,7 +137,7 @@ void DTAResolver::otherInst(const llvm::Instruction *Inst) {
     auto DestStructType = llvm::dyn_cast<llvm::StructType>(stripPointer(Dest));
 
     if (SrcStructType && DestStructType &&
-        heuristicAntiConstructorVtablePos(BitCast))
+        heuristic_anti_contructor_vtable_pos(BitCast))
       typegraph.addLink(DestStructType, SrcStructType);
   }
 }

--- a/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
@@ -34,7 +34,7 @@ using namespace psr;
 DTAResolver::DTAResolver(ProjectIRDB &IRDB, LLVMTypeHierarchy &TH)
     : CHAResolver(IRDB, TH) {}
 
-bool DTAResolver::heuristic_anti_contructor_this_type(
+bool DTAResolver::heuristicAntiConstructorThisType(
     const llvm::BitCastInst *BitCast) {
   // We check if the caller is a constructor, and if the this argument has the
   // same type as the source type of the bitcast. If it is the case, it returns
@@ -55,12 +55,12 @@ bool DTAResolver::heuristic_anti_contructor_this_type(
   return true;
 }
 
-bool DTAResolver::heuristic_anti_contructor_vtable_pos(
+bool DTAResolver::heuristicAntiConstructorVtablePos(
     const llvm::BitCastInst *BitCast) {
   // Better heuristic than the previous one, can handle the CRTP. Based on the
   // previous one.
 
-  if (heuristic_anti_contructor_this_type(BitCast))
+  if (heuristicAntiConstructorThisType(BitCast))
     return true;
 
   // We know that we are in a constructor and the source type of the bitcast is
@@ -137,7 +137,7 @@ void DTAResolver::otherInst(const llvm::Instruction *Inst) {
     auto DestStructType = llvm::dyn_cast<llvm::StructType>(stripPointer(Dest));
 
     if (SrcStructType && DestStructType &&
-        heuristic_anti_contructor_vtable_pos(BitCast))
+        heuristicAntiConstructorVtablePos(BitCast))
       typegraph.addLink(DestStructType, SrcStructType);
   }
 }

--- a/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
@@ -40,11 +40,11 @@ bool DTAResolver::heuristic_anti_contructor_this_type(
   // same type as the source type of the bitcast. If it is the case, it returns
   // false, true otherwise.
 
-  if (auto caller = BitCast->getFunction()) {
-    if (isConstructor(caller->getName().str())) {
-      if (auto func_ty = caller->getFunctionType()) {
-        if (auto this_ty = func_ty->getParamType(0)) {
-          if (this_ty == BitCast->getSrcTy()) {
+  if (auto Caller = BitCast->getFunction()) {
+    if (isConstructor(Caller->getName().str())) {
+      if (auto FuncTy = Caller->getFunctionType()) {
+        if (auto ThisTy = FuncTy->getParamType(0)) {
+          if (ThisTy == BitCast->getSrcTy()) {
             return false;
           }
         }
@@ -66,15 +66,14 @@ bool DTAResolver::heuristic_anti_contructor_vtable_pos(
   // We know that we are in a constructor and the source type of the bitcast is
   // the same as the this argument. We then check where the bitcast is against
   // the store instruction of the vtable.
-  auto struct_ty = stripPointer(BitCast->getSrcTy());
-  if (struct_ty == nullptr)
-    throw runtime_error(
-        "struct_ty == nullptr in the heuristic_anti_contructor");
+  auto StructTy = stripPointer(BitCast->getSrcTy());
+  if (StructTy == nullptr)
+    throw runtime_error("StructTy == nullptr in the heuristic_anti_contructor");
 
   // If it doesn't contain vtable, there is no reason to call this class in the
   // DTA graph, so no need to add it
-  if (struct_ty->isStructTy()) {
-    if (Resolver::TH->hasVFTable(llvm::dyn_cast<llvm::StructType>(struct_ty))) {
+  if (StructTy->isStructTy()) {
+    if (Resolver::TH->hasVFTable(llvm::dyn_cast<llvm::StructType>(StructTy))) {
       return false;
     }
   }
@@ -88,112 +87,110 @@ bool DTAResolver::heuristic_anti_contructor_vtable_pos(
   // WARNING: May break when changing llvm version or using clang with version
   // > 5.0.1
 
-  auto caller = BitCast->getFunction();
-  if (caller == nullptr) {
+  auto Caller = BitCast->getFunction();
+  if (Caller == nullptr) {
     throw runtime_error("A bitcast instruction has no associated function");
   }
 
-  int i = 0, vtable_num = 0, bitcast_num = 0;
+  int Idx = 0, VtableNum = 0, BitcastNum = 0;
 
-  for (auto I = llvm::inst_begin(caller), E = llvm::inst_end(caller); I != E;
-       ++I, ++i) {
+  for (auto I = llvm::inst_begin(Caller), E = llvm::inst_end(Caller); I != E;
+       ++I, ++Idx) {
     const auto &Inst = *I;
 
-    if (auto store = llvm::dyn_cast<llvm::StoreInst>(&Inst)) {
+    if (auto Store = llvm::dyn_cast<llvm::StoreInst>(&Inst)) {
       // We got a store instruction, now we are checking if it is a vtable
       // storage
-      if (auto bitcast_expr =
-              llvm::dyn_cast<llvm::ConstantExpr>(store->getValueOperand())) {
-        if (bitcast_expr->isCast()) {
-          if (auto const_gep = llvm::dyn_cast<llvm::ConstantExpr>(
-                  bitcast_expr->getOperand(0))) {
-            auto gep_as_inst = const_gep->getAsInstruction();
-            if (auto gep =
-                    llvm::dyn_cast<llvm::GetElementPtrInst>(gep_as_inst)) {
-              if (auto vtable = llvm::dyn_cast<llvm::Constant>(
-                      gep->getPointerOperand())) {
+      if (auto BitcastExpr =
+              llvm::dyn_cast<llvm::ConstantExpr>(Store->getValueOperand())) {
+        if (BitcastExpr->isCast()) {
+          if (auto ConstGep = llvm::dyn_cast<llvm::ConstantExpr>(
+                  BitcastExpr->getOperand(0))) {
+            auto GepAsInst = ConstGep->getAsInstruction();
+            if (auto Gep = llvm::dyn_cast<llvm::GetElementPtrInst>(GepAsInst)) {
+              if (auto Vtable = llvm::dyn_cast<llvm::Constant>(
+                      Gep->getPointerOperand())) {
                 // We can here assume that we found a vtable
-                vtable_num = i;
+                VtableNum = Idx;
               }
             }
-            gep_as_inst->deleteValue();
+            GepAsInst->deleteValue();
           }
         }
       }
     }
 
     if (&Inst == BitCast)
-      bitcast_num = i;
+      BitcastNum = Idx;
   }
 
-  return (bitcast_num > vtable_num);
+  return (BitcastNum > VtableNum);
 }
 
 void DTAResolver::otherInst(const llvm::Instruction *Inst) {
   if (auto BitCast = llvm::dyn_cast<llvm::BitCastInst>(Inst)) {
     // We add the connection between the two types in the DTA graph
-    auto src = BitCast->getSrcTy();
-    auto dest = BitCast->getDestTy();
+    auto Src = BitCast->getSrcTy();
+    auto Dest = BitCast->getDestTy();
 
-    auto src_struct_type = llvm::dyn_cast<llvm::StructType>(stripPointer(src));
-    auto dest_struct_type =
-        llvm::dyn_cast<llvm::StructType>(stripPointer(dest));
+    auto SrcStructType = llvm::dyn_cast<llvm::StructType>(stripPointer(Src));
+    auto DestStructType = llvm::dyn_cast<llvm::StructType>(stripPointer(Dest));
 
-    if (src_struct_type && dest_struct_type &&
+    if (SrcStructType && DestStructType &&
         heuristic_anti_contructor_vtable_pos(BitCast))
-      typegraph.addLink(dest_struct_type, src_struct_type);
+      typegraph.addLink(DestStructType, SrcStructType);
   }
 }
 
 set<const llvm::Function *>
 DTAResolver::resolveVirtualCall(llvm::ImmutableCallSite CS) {
-  set<const llvm::Function *> possible_call_targets;
-  auto &lg = lg::get();
+  set<const llvm::Function *> PossibleCallTargets;
+  auto &LG = lg::get();
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Call virtual function: "
                 << llvmIRToString(CS.getInstruction()));
 
-  auto vtable_index = getVFTIndex(CS);
-  if (vtable_index < 0) {
+  auto VtableIndex = getVFTIndex(CS);
+  if (VtableIndex < 0) {
     // An error occured
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
                      "the vtable index\n"
                   << llvmIRToString(CS.getInstruction()) << "\n");
     return {};
   }
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Virtual function table entry is: " << vtable_index);
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                << "Virtual function table entry is: " << VtableIndex);
 
-  auto receiver_type = getReceiverType(CS);
+  auto ReceiverType = getReceiverType(CS);
 
-  auto possible_types = typegraph.getTypes(receiver_type);
+  auto PossibleTypes = typegraph.getTypes(ReceiverType);
 
   // WARNING We deactivated the check on allocated because it is
   // unabled to get the types allocated in the used libraries
   // auto allocated_types = IRDB.getAllocatedTypes();
   // auto end_it = allocated_types.end();
-  for (auto possible_type : possible_types) {
-    if (auto possible_type_struct =
-            llvm::dyn_cast<llvm::StructType>(possible_type)) {
+  for (auto PossibleType : PossibleTypes) {
+    if (auto PossibleTypeStruct =
+            llvm::dyn_cast<llvm::StructType>(PossibleType)) {
       // if ( allocated_types.find(possible_type_struct) != end_it ) {
       auto Target =
-          getNonPureVirtualVFTEntry(possible_type_struct, vtable_index, CS);
+          getNonPureVirtualVFTEntry(PossibleTypeStruct, VtableIndex, CS);
       if (Target) {
-        possible_call_targets.insert(Target);
+        PossibleCallTargets.insert(Target);
       }
     }
   }
 
-  if (possible_call_targets.empty())
-    possible_call_targets = CHAResolver::resolveVirtualCall(CS);
+  if (PossibleCallTargets.empty())
+    PossibleCallTargets = CHAResolver::resolveVirtualCall(CS);
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Possible targets are:");
-  for (auto entry : possible_call_targets) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << entry);
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "Possible targets are:");
+  for (auto Entry : PossibleCallTargets) {
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << Entry);
   }
 
-  return possible_call_targets;
+  return PossibleCallTargets;
 }

--- a/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
@@ -44,10 +44,10 @@ void OTFResolver::preCall(const llvm::Instruction *Inst) {
 void OTFResolver::handlePossibleTargets(
     llvm::ImmutableCallSite CS,
     std::set<const llvm::Function *> &CalleeTargets) {
-  auto &lg = lg::get();
+  auto &LG = lg::get();
 
   for (auto CalleeTarget : CalleeTargets) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Target name: " << CalleeTarget->getName().str());
     // Do the merge of the points-to graphs for all possible targets, but
     // only if they are available
@@ -65,55 +65,55 @@ void OTFResolver::postCall(const llvm::Instruction *Inst) {
 
 set<const llvm::Function *>
 OTFResolver::resolveVirtualCall(llvm::ImmutableCallSite CS) {
-  set<const llvm::Function *> possible_call_targets;
-  auto &lg = lg::get();
+  set<const llvm::Function *> PossibleCallTargets;
+  auto &LG = lg::get();
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Call virtual function: "
                 << llvmIRToString(CS.getInstruction()));
 
-  auto vtable_index = getVFTIndex(CS);
-  if (vtable_index < 0) {
+  auto VtableIndex = getVFTIndex(CS);
+  if (VtableIndex < 0) {
     // An error occured
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
                      "the vtable index\n"
                   << llvmIRToString(CS.getInstruction()) << "\n");
     return {};
   }
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Virtual function table entry is: " << vtable_index);
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                << "Virtual function table entry is: " << VtableIndex);
 
-  const llvm::Value *receiver = CS.getArgOperand(0);
+  const llvm::Value *Receiver = CS.getArgOperand(0);
 
-  auto alloc_sites =
-      WholeModulePTG.getReachableAllocationSites(receiver, CallStack);
-  auto possible_allocated_types =
-      WholeModulePTG.computeTypesFromAllocationSites(alloc_sites);
+  auto AllocSites =
+      WholeModulePTG.getReachableAllocationSites(Receiver, CallStack);
+  auto PossibleAllocatedTypes =
+      WholeModulePTG.computeTypesFromAllocationSites(AllocSites);
 
-  auto receiver_type = getReceiverType(CS);
+  auto ReceiverType = getReceiverType(CS);
 
   // Now we must check if we have found some allocated struct types
-  set<const llvm::StructType *> possible_types;
-  for (auto type : possible_allocated_types) {
-    if (auto struct_type =
-            llvm::dyn_cast<llvm::StructType>(stripPointer(type))) {
-      possible_types.insert(struct_type);
+  set<const llvm::StructType *> PossibleTypes;
+  for (auto Type : PossibleAllocatedTypes) {
+    if (auto StructType =
+            llvm::dyn_cast<llvm::StructType>(stripPointer(Type))) {
+      PossibleTypes.insert(StructType);
     }
   }
 
-  for (auto possible_type_struct : possible_types) {
+  for (auto PossibleTypeStruct : PossibleTypes) {
     auto Target =
-        getNonPureVirtualVFTEntry(possible_type_struct, vtable_index, CS);
+        getNonPureVirtualVFTEntry(PossibleTypeStruct, VtableIndex, CS);
     if (Target) {
-      possible_call_targets.insert(Target);
+      PossibleCallTargets.insert(Target);
     }
   }
-  if (possible_call_targets.empty())
+  if (PossibleCallTargets.empty())
     return CHAResolver::resolveVirtualCall(CS);
 
-  return possible_call_targets;
+  return PossibleCallTargets;
 }
 
 std::set<const llvm::Function *>

--- a/lib/PhasarLLVM/ControlFlow/Resolver/RTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/RTAResolver.cpp
@@ -52,50 +52,50 @@ RTAResolver::resolveVirtualCall(llvm::ImmutableCallSite CS) {
   // throw runtime_error("RTA is currently unabled to deal with already built "
   //                     "library, it has been disable until this is fixed");
 
-  set<const llvm::Function *> possible_call_targets;
-  auto &lg = lg::get();
+  set<const llvm::Function *> PossibleCallTargets;
+  auto &LG = lg::get();
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Call virtual function: "
                 << llvmIRToString(CS.getInstruction()));
 
-  auto vtable_index = getVFTIndex(CS);
-  if (vtable_index < 0) {
+  auto VtableIndex = getVFTIndex(CS);
+  if (VtableIndex < 0) {
     // An error occured
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
                      "the vtable index\n"
                   << llvmIRToString(CS.getInstruction()) << "\n");
     return {};
   }
 
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
-                << "Virtual function table entry is: " << vtable_index);
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
+                << "Virtual function table entry is: " << VtableIndex);
 
-  auto receiver_type = getReceiverType(CS);
-
-  // also insert all possible subtypes vtable entries
-  auto reachable_types = Resolver::TH->getSubTypes(receiver_type);
+  auto ReceiverType = getReceiverType(CS);
 
   // also insert all possible subtypes vtable entries
-  auto possible_types = IRDB.getAllocatedStructTypes();
+  auto ReachableTypes = Resolver::TH->getSubTypes(ReceiverType);
 
-  auto end_it = reachable_types.end();
-  for (auto possible_type : possible_types) {
-    if (auto possible_type_struct =
-            llvm::dyn_cast<llvm::StructType>(possible_type)) {
-      if (reachable_types.find(possible_type_struct) != end_it) {
+  // also insert all possible subtypes vtable entries
+  auto PossibleTypes = IRDB.getAllocatedStructTypes();
+
+  auto EndIt = ReachableTypes.end();
+  for (auto PossibleType : PossibleTypes) {
+    if (auto PossibleTypeStruct =
+            llvm::dyn_cast<llvm::StructType>(PossibleType)) {
+      if (ReachableTypes.find(PossibleTypeStruct) != EndIt) {
         auto Target =
-            getNonPureVirtualVFTEntry(possible_type_struct, vtable_index, CS);
+            getNonPureVirtualVFTEntry(PossibleTypeStruct, VtableIndex, CS);
         if (Target) {
-          possible_call_targets.insert(Target);
+          PossibleCallTargets.insert(Target);
         }
       }
     }
   }
 
-  if (possible_call_targets.size() == 0)
+  if (PossibleCallTargets.size() == 0)
     return CHAResolver::resolveVirtualCall(CS);
 
-  return possible_call_targets;
+  return PossibleCallTargets;
 }

--- a/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
@@ -87,13 +87,13 @@ Resolver::getNonPureVirtualVFTEntry(const llvm::StructType *T, unsigned Idx,
   return nullptr;
 }
 
-void Resolver::preCall(const llvm::Instruction *inst) {}
+void Resolver::preCall(const llvm::Instruction *Inst) {}
 
 void Resolver::handlePossibleTargets(
     llvm::ImmutableCallSite CS,
-    std::set<const llvm::Function *> &possible_targets) {}
+    std::set<const llvm::Function *> &PossibleTargets) {}
 
-void Resolver::postCall(const llvm::Instruction *inst) {}
+void Resolver::postCall(const llvm::Instruction *Inst) {}
 
 std::set<const llvm::Function *>
 Resolver::resolveFunctionPointer(llvm::ImmutableCallSite CS) {

--- a/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
@@ -100,8 +100,8 @@ Resolver::resolveFunctionPointer(llvm::ImmutableCallSite CS) {
   // we may wish to optimise this function
   // naive implementation that considers every function whose signature
   // matches the call-site's signature as a callee target
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Call function pointer: "
                 << llvmIRToString(CS.getInstruction()));
   std::set<const llvm::Function *> CalleeTargets;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/BranchSwitchInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/BranchSwitchInstFlowFunction.cpp
@@ -8,44 +8,44 @@ namespace psr {
 
 std::set<ExtendedValue>
 BranchSwitchInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const llvm::Value *condition = nullptr;
+  const llvm::Value *Condition = nullptr;
 
-  if (const auto branchInst = llvm::dyn_cast<llvm::BranchInst>(currentInst)) {
-    bool isConditional = branchInst->isConditional();
+  if (const auto BranchInst = llvm::dyn_cast<llvm::BranchInst>(currentInst)) {
+    bool IsConditional = BranchInst->isConditional();
 
-    if (isConditional)
-      condition = branchInst->getCondition();
-  } else if (const auto switchInst =
+    if (IsConditional)
+      Condition = BranchInst->getCondition();
+  } else if (const auto SwitchInst =
                  llvm::dyn_cast<llvm::SwitchInst>(currentInst)) {
-    condition = switchInst->getCondition();
+    Condition = SwitchInst->getCondition();
   } else {
     assert(false && "This MUST not happen");
   }
 
-  if (condition) {
-    bool isConditionTainted =
-        DataFlowUtils::isValueTainted(condition, Fact) ||
-        DataFlowUtils::isMemoryLocationTainted(condition, Fact);
+  if (Condition) {
+    bool IsConditionTainted =
+        DataFlowUtils::isValueTainted(Condition, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(Condition, Fact);
 
-    if (isConditionTainted) {
-      const auto startBasicBlock = currentInst->getParent();
-      const auto startBasicBlockLabel = startBasicBlock->getName();
+    if (IsConditionTainted) {
+      const auto StartBasicBlock = currentInst->getParent();
+      const auto StartBasicBlockLabel = StartBasicBlock->getName();
 
-      LOG_DEBUG("Searching end of block label for: " << startBasicBlockLabel);
+      LOG_DEBUG("Searching end of block label for: " << StartBasicBlockLabel);
 
-      const auto endBasicBlock =
-          DataFlowUtils::getEndOfTaintedBlock(startBasicBlock);
-      const auto endBasicBlockLabel =
-          endBasicBlock ? endBasicBlock->getName() : "";
+      const auto EndBasicBlock =
+          DataFlowUtils::getEndOfTaintedBlock(StartBasicBlock);
+      const auto EndBasicBlockLabel =
+          EndBasicBlock ? EndBasicBlock->getName() : "";
 
-      LOG_DEBUG("End of block label: " << endBasicBlockLabel);
+      LOG_DEBUG("End of block label: " << EndBasicBlockLabel);
 
-      ExtendedValue ev(currentInst);
-      ev.setEndOfTaintedBlockLabel(endBasicBlockLabel);
+      ExtendedValue EV(currentInst);
+      EV.setEndOfTaintedBlockLabel(EndBasicBlockLabel);
 
       traceStats.add(currentInst);
 
-      return {Fact, ev};
+      return {Fact, EV};
     }
   }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/BranchSwitchInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/BranchSwitchInstFlowFunction.cpp
@@ -7,7 +7,7 @@
 namespace psr {
 
 std::set<ExtendedValue>
-BranchSwitchInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+BranchSwitchInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const llvm::Value *condition = nullptr;
 
   if (const auto branchInst = llvm::dyn_cast<llvm::BranchInst>(currentInst)) {
@@ -24,8 +24,8 @@ BranchSwitchInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
   if (condition) {
     bool isConditionTainted =
-        DataFlowUtils::isValueTainted(condition, fact) ||
-        DataFlowUtils::isMemoryLocationTainted(condition, fact);
+        DataFlowUtils::isValueTainted(condition, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(condition, Fact);
 
     if (isConditionTainted) {
       const auto startBasicBlock = currentInst->getParent();
@@ -45,11 +45,11 @@ BranchSwitchInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       traceStats.add(currentInst);
 
-      return {fact, ev};
+      return {Fact, ev};
     }
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CallToRetFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CallToRetFlowFunction.cpp
@@ -13,9 +13,9 @@ CallToRetFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   /*
    * Kill every global and expect the callee to return all valid ones.
    */
-  bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
+  bool IsGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
       DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
-  if (isGlobalMemLocationFact)
+  if (IsGlobalMemLocationFact)
     return {};
 
   /*
@@ -27,12 +27,12 @@ CallToRetFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
    * Need to keep the list in sync with "killing" functions in
    * getSummaryFlowFunction()!
    */
-  bool isHandledInSummaryFlowFunction =
+  bool IsHandledInSummaryFlowFunction =
       llvm::isa<llvm::MemTransferInst>(currentInst) ||
       llvm::isa<llvm::MemSetInst>(currentInst) ||
       llvm::isa<llvm::VAEndInst>(currentInst);
 
-  if (isHandledInSummaryFlowFunction)
+  if (IsHandledInSummaryFlowFunction)
     return {};
 
   return {Fact};

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CallToRetFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CallToRetFlowFunction.cpp
@@ -9,12 +9,12 @@
 namespace psr {
 
 std::set<ExtendedValue>
-CallToRetFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+CallToRetFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   /*
    * Kill every global and expect the callee to return all valid ones.
    */
   bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
-      DataFlowUtils::getMemoryLocationSeqFromFact(fact));
+      DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
   if (isGlobalMemLocationFact)
     return {};
 
@@ -35,7 +35,7 @@ CallToRetFlowFunction::computeTargetsExt(ExtendedValue &fact) {
   if (isHandledInSummaryFlowFunction)
     return {};
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CheckOperandsFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CheckOperandsFlowFunction.cpp
@@ -7,22 +7,22 @@
 namespace psr {
 
 std::set<ExtendedValue>
-CheckOperandsFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+CheckOperandsFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   for (const auto &use : currentInst->operands()) {
     const auto &operand = use.get();
 
     bool isOperandTainted =
-        DataFlowUtils::isValueTainted(operand, fact) ||
-        DataFlowUtils::isMemoryLocationTainted(operand, fact);
+        DataFlowUtils::isValueTainted(operand, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(operand, Fact);
 
     if (isOperandTainted) {
       traceStats.add(currentInst);
 
-      return {fact, ExtendedValue(currentInst)};
+      return {Fact, ExtendedValue(currentInst)};
     }
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CheckOperandsFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/CheckOperandsFlowFunction.cpp
@@ -8,14 +8,14 @@ namespace psr {
 
 std::set<ExtendedValue>
 CheckOperandsFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  for (const auto &use : currentInst->operands()) {
-    const auto &operand = use.get();
+  for (const auto &Use : currentInst->operands()) {
+    const auto &Operand = Use.get();
 
-    bool isOperandTainted =
-        DataFlowUtils::isValueTainted(operand, Fact) ||
-        DataFlowUtils::isMemoryLocationTainted(operand, Fact);
+    bool IsOperandTainted =
+        DataFlowUtils::isValueTainted(Operand, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(Operand, Fact);
 
-    if (isOperandTainted) {
+    if (IsOperandTainted) {
       traceStats.add(currentInst);
 
       return {Fact, ExtendedValue(currentInst)};

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/FlowFunctionBase.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/FlowFunctionBase.cpp
@@ -8,17 +8,17 @@
 
 namespace psr {
 
-std::set<ExtendedValue> FlowFunctionBase::computeTargets(ExtendedValue fact) {
-  bool isAutoIdentity = DataFlowUtils::isAutoIdentity(currentInst, fact);
+std::set<ExtendedValue> FlowFunctionBase::computeTargets(ExtendedValue Fact) {
+  bool isAutoIdentity = DataFlowUtils::isAutoIdentity(currentInst, Fact);
   if (isAutoIdentity)
-    return {fact};
+    return {Fact};
 
-  bool isBranchOrSwitchFact = llvm::isa<llvm::BranchInst>(fact.getValue()) ||
-                              llvm::isa<llvm::SwitchInst>(fact.getValue());
+  bool isBranchOrSwitchFact = llvm::isa<llvm::BranchInst>(Fact.getValue()) ||
+                              llvm::isa<llvm::SwitchInst>(Fact.getValue());
 
   if (isBranchOrSwitchFact) {
     bool removeTaintedBlockInst =
-        DataFlowUtils::removeTaintedBlockInst(fact, currentInst);
+        DataFlowUtils::removeTaintedBlockInst(Fact, currentInst);
     if (removeTaintedBlockInst)
       return {};
 
@@ -28,11 +28,11 @@ std::set<ExtendedValue> FlowFunctionBase::computeTargets(ExtendedValue fact) {
     if (isAutoGEN) {
       traceStats.add(currentInst);
 
-      return {fact, ExtendedValue(currentInst)};
+      return {Fact, ExtendedValue(currentInst)};
     }
 
     std::set<ExtendedValue> targetFacts;
-    targetFacts.insert(fact);
+    targetFacts.insert(Fact);
 
     /*
      * We are only intercepting the branch fact here. All other facts will still
@@ -80,7 +80,7 @@ std::set<ExtendedValue> FlowFunctionBase::computeTargets(ExtendedValue fact) {
     return targetFacts;
   }
 
-  return computeTargetsExt(fact);
+  return computeTargetsExt(Fact);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GEPInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GEPInstFlowFunction.cpp
@@ -7,11 +7,11 @@
 namespace psr {
 
 std::set<ExtendedValue>
-GEPInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+GEPInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto gepInst = llvm::cast<llvm::GetElementPtrInst>(currentInst);
   const auto gepInstPtr = gepInst->getPointerOperand();
 
-  bool isVarArgFact = fact.isVarArg();
+  bool isVarArgFact = Fact.isVarArg();
   if (isVarArgFact) {
     bool killFact = gepInstPtr->getName().contains_lower("reg_save_area");
     if (killFact)
@@ -24,22 +24,22 @@ GEPInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
           DataFlowUtils::getMemoryLocationSeqFromMatr(gepInstPtr);
 
       bool isVaListEqual = DataFlowUtils::isSubsetMemoryLocationSeq(
-          DataFlowUtils::getVaListMemoryLocationSeqFromFact(fact),
+          DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact),
           gepVaListMemLocationSeq);
       if (isVaListEqual) {
-        ExtendedValue ev(fact);
+        ExtendedValue ev(Fact);
         ev.incrementCurrentVarArgIndex();
 
         return {ev};
       }
     }
   } else {
-    bool isPtrTainted = DataFlowUtils::isValueTainted(gepInstPtr, fact);
+    bool isPtrTainted = DataFlowUtils::isValueTainted(gepInstPtr, Fact);
     if (isPtrTainted)
-      return {fact, ExtendedValue(gepInst)};
+      return {Fact, ExtendedValue(gepInst)};
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GEPInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GEPInstFlowFunction.cpp
@@ -8,35 +8,35 @@ namespace psr {
 
 std::set<ExtendedValue>
 GEPInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto gepInst = llvm::cast<llvm::GetElementPtrInst>(currentInst);
-  const auto gepInstPtr = gepInst->getPointerOperand();
+  const auto GepInst = llvm::cast<llvm::GetElementPtrInst>(currentInst);
+  const auto GepInstPtr = GepInst->getPointerOperand();
 
-  bool isVarArgFact = Fact.isVarArg();
-  if (isVarArgFact) {
-    bool killFact = gepInstPtr->getName().contains_lower("reg_save_area");
-    if (killFact)
+  bool IsVarArgFact = Fact.isVarArg();
+  if (IsVarArgFact) {
+    bool KillFact = GepInstPtr->getName().contains_lower("reg_save_area");
+    if (KillFact)
       return {};
 
-    bool incrementCurrentVarArgIndex =
-        gepInst->getName().contains_lower("overflow_arg_area.next");
-    if (incrementCurrentVarArgIndex) {
-      const auto gepVaListMemLocationSeq =
-          DataFlowUtils::getMemoryLocationSeqFromMatr(gepInstPtr);
+    bool IncrementCurrentVarArgIndex =
+        GepInst->getName().contains_lower("overflow_arg_area.next");
+    if (IncrementCurrentVarArgIndex) {
+      const auto GepVaListMemLocationSeq =
+          DataFlowUtils::getMemoryLocationSeqFromMatr(GepInstPtr);
 
-      bool isVaListEqual = DataFlowUtils::isSubsetMemoryLocationSeq(
+      bool IsVaListEqual = DataFlowUtils::isSubsetMemoryLocationSeq(
           DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact),
-          gepVaListMemLocationSeq);
-      if (isVaListEqual) {
-        ExtendedValue ev(Fact);
-        ev.incrementCurrentVarArgIndex();
+          GepVaListMemLocationSeq);
+      if (IsVaListEqual) {
+        ExtendedValue EV(Fact);
+        EV.incrementCurrentVarArgIndex();
 
-        return {ev};
+        return {EV};
       }
     }
   } else {
-    bool isPtrTainted = DataFlowUtils::isValueTainted(gepInstPtr, Fact);
-    if (isPtrTainted)
-      return {Fact, ExtendedValue(gepInst)};
+    bool IsPtrTainted = DataFlowUtils::isValueTainted(GepInstPtr, Fact);
+    if (IsPtrTainted)
+      return {Fact, ExtendedValue(GepInst)};
   }
 
   return {Fact};

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GenerateFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/GenerateFlowFunction.cpp
@@ -7,13 +7,13 @@
 namespace psr {
 
 std::set<ExtendedValue>
-GenerateFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+GenerateFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   traceStats.add(currentInst);
 
-  if (fact == zeroValue)
+  if (Fact == zeroValue)
     return {ExtendedValue(currentInst)};
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/IdentityFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/IdentityFlowFunction.cpp
@@ -7,8 +7,8 @@
 namespace psr {
 
 std::set<ExtendedValue>
-IdentityFlowFunction::computeTargetsExt(ExtendedValue &fact) {
-  return {fact};
+IdentityFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCallee.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCallee.cpp
@@ -15,8 +15,8 @@
 namespace psr {
 
 std::set<ExtendedValue>
-MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
-  bool isFactVarArgTemplate = fact.isVarArgTemplate();
+MapTaintedValuesToCallee::computeTargets(ExtendedValue Fact) {
+  bool isFactVarArgTemplate = Fact.isVarArgTemplate();
   if (isFactVarArgTemplate)
     return {};
 
@@ -24,9 +24,9 @@ MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
   std::set<ExtendedValue> targetParamFacts;
 
   bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
-      DataFlowUtils::getMemoryLocationSeqFromFact(fact));
+      DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
   if (isGlobalMemLocationFact)
-    targetGlobalFacts.insert(fact);
+    targetGlobalFacts.insert(Fact);
 
   long varArgIndex = 0L;
 
@@ -41,14 +41,14 @@ MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
 
     bool isVarArgParam =
         DataFlowUtils::isVarArgParam(param, zeroValue.getValue());
-    bool isVarArgFact = fact.isVarArg();
+    bool isVarArgFact = Fact.isVarArg();
 
     bool isArgMemLocation = !argMemLocationSeq.empty();
     if (isArgMemLocation) {
 
       const auto factMemLocationSeq =
-          isVarArgFact ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(fact)
-                       : DataFlowUtils::getMemoryLocationSeqFromFact(fact);
+          isVarArgFact ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact)
+                       : DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
       bool genFact = DataFlowUtils::isSubsetMemoryLocationSeq(
           argMemLocationSeq, factMemLocationSeq);
@@ -61,7 +61,7 @@ MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
             DataFlowUtils::joinMemoryLocationSeqs(patchablePart,
                                                   relocatableMemLocationSeq);
 
-        ExtendedValue ev(fact);
+        ExtendedValue ev(Fact);
         if (isVarArgFact) {
           ev.setVaListMemLocationSeq(patchableMemLocationSeq);
         } else {
@@ -75,16 +75,16 @@ MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
 
         LOG_DEBUG("Added patchable memory location (caller -> callee)");
         LOG_DEBUG("Source");
-        DataFlowUtils::dumpFact(fact);
+        DataFlowUtils::dumpFact(Fact);
         LOG_DEBUG("Destination");
         DataFlowUtils::dumpFact(ev);
       }
     } else {
-      bool genFact = DataFlowUtils::isValueTainted(arg, fact);
+      bool genFact = DataFlowUtils::isValueTainted(arg, Fact);
       if (genFact) {
         std::vector<const llvm::Value *> patchablePart{param};
 
-        ExtendedValue ev(fact);
+        ExtendedValue ev(Fact);
         ev.setMemLocationSeq(patchablePart);
         if (isVarArgParam)
           ev.setVarArgIndex(varArgIndex);
@@ -93,7 +93,7 @@ MapTaintedValuesToCallee::computeTargets(ExtendedValue fact) {
 
         LOG_DEBUG("Added patchable memory location (caller -> callee)");
         LOG_DEBUG("Source");
-        DataFlowUtils::dumpFact(fact);
+        DataFlowUtils::dumpFact(Fact);
         LOG_DEBUG("Destination");
         DataFlowUtils::dumpFact(ev);
       }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCallee.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCallee.cpp
@@ -16,103 +16,103 @@ namespace psr {
 
 std::set<ExtendedValue>
 MapTaintedValuesToCallee::computeTargets(ExtendedValue Fact) {
-  bool isFactVarArgTemplate = Fact.isVarArgTemplate();
-  if (isFactVarArgTemplate)
+  bool IsFactVarArgTemplate = Fact.isVarArgTemplate();
+  if (IsFactVarArgTemplate)
     return {};
 
-  std::set<ExtendedValue> targetGlobalFacts;
-  std::set<ExtendedValue> targetParamFacts;
+  std::set<ExtendedValue> TargetGlobalFacts;
+  std::set<ExtendedValue> TargetParamFacts;
 
-  bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
+  bool IsGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
       DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
-  if (isGlobalMemLocationFact)
-    targetGlobalFacts.insert(Fact);
+  if (IsGlobalMemLocationFact)
+    TargetGlobalFacts.insert(Fact);
 
-  long varArgIndex = 0L;
+  long VarArgIndex = 0L;
 
-  const auto sanitizedArgList = DataFlowUtils::getSanitizedArgList(
+  const auto SanitizedArgList = DataFlowUtils::getSanitizedArgList(
       callInst, destFun, zeroValue.getValue());
 
-  for (const auto &argParamTriple : sanitizedArgList) {
+  for (const auto &ArgParamTriple : SanitizedArgList) {
 
-    const auto arg = std::get<0>(argParamTriple);
-    const auto argMemLocationSeq = std::get<1>(argParamTriple);
-    const auto param = std::get<2>(argParamTriple);
+    const auto Arg = std::get<0>(ArgParamTriple);
+    const auto ArgMemLocationSeq = std::get<1>(ArgParamTriple);
+    const auto Param = std::get<2>(ArgParamTriple);
 
-    bool isVarArgParam =
-        DataFlowUtils::isVarArgParam(param, zeroValue.getValue());
-    bool isVarArgFact = Fact.isVarArg();
+    bool IsVarArgParam =
+        DataFlowUtils::isVarArgParam(Param, zeroValue.getValue());
+    bool IsVarArgFact = Fact.isVarArg();
 
-    bool isArgMemLocation = !argMemLocationSeq.empty();
-    if (isArgMemLocation) {
+    bool IsArgMemLocation = !ArgMemLocationSeq.empty();
+    if (IsArgMemLocation) {
 
-      const auto factMemLocationSeq =
-          isVarArgFact ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact)
+      const auto FactMemLocationSeq =
+          IsVarArgFact ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact)
                        : DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
-      bool genFact = DataFlowUtils::isSubsetMemoryLocationSeq(
-          argMemLocationSeq, factMemLocationSeq);
-      if (genFact) {
-        const auto relocatableMemLocationSeq =
-            DataFlowUtils::getRelocatableMemoryLocationSeq(factMemLocationSeq,
-                                                           argMemLocationSeq);
-        std::vector<const llvm::Value *> patchablePart{param};
-        const auto patchableMemLocationSeq =
-            DataFlowUtils::joinMemoryLocationSeqs(patchablePart,
-                                                  relocatableMemLocationSeq);
+      bool GenFact = DataFlowUtils::isSubsetMemoryLocationSeq(
+          ArgMemLocationSeq, FactMemLocationSeq);
+      if (GenFact) {
+        const auto RelocatableMemLocationSeq =
+            DataFlowUtils::getRelocatableMemoryLocationSeq(FactMemLocationSeq,
+                                                           ArgMemLocationSeq);
+        std::vector<const llvm::Value *> PatchablePart{Param};
+        const auto PatchableMemLocationSeq =
+            DataFlowUtils::joinMemoryLocationSeqs(PatchablePart,
+                                                  RelocatableMemLocationSeq);
 
-        ExtendedValue ev(Fact);
-        if (isVarArgFact) {
-          ev.setVaListMemLocationSeq(patchableMemLocationSeq);
+        ExtendedValue EV(Fact);
+        if (IsVarArgFact) {
+          EV.setVaListMemLocationSeq(PatchableMemLocationSeq);
         } else {
-          ev.setMemLocationSeq(patchableMemLocationSeq);
+          EV.setMemLocationSeq(PatchableMemLocationSeq);
         }
 
-        if (isVarArgParam)
-          ev.setVarArgIndex(varArgIndex);
+        if (IsVarArgParam)
+          EV.setVarArgIndex(VarArgIndex);
 
-        targetParamFacts.insert(ev);
+        TargetParamFacts.insert(EV);
 
         LOG_DEBUG("Added patchable memory location (caller -> callee)");
         LOG_DEBUG("Source");
         DataFlowUtils::dumpFact(Fact);
         LOG_DEBUG("Destination");
-        DataFlowUtils::dumpFact(ev);
+        DataFlowUtils::dumpFact(EV);
       }
     } else {
-      bool genFact = DataFlowUtils::isValueTainted(arg, Fact);
-      if (genFact) {
-        std::vector<const llvm::Value *> patchablePart{param};
+      bool GenFact = DataFlowUtils::isValueTainted(Arg, Fact);
+      if (GenFact) {
+        std::vector<const llvm::Value *> PatchablePart{Param};
 
-        ExtendedValue ev(Fact);
-        ev.setMemLocationSeq(patchablePart);
-        if (isVarArgParam)
-          ev.setVarArgIndex(varArgIndex);
+        ExtendedValue EV(Fact);
+        EV.setMemLocationSeq(PatchablePart);
+        if (IsVarArgParam)
+          EV.setVarArgIndex(VarArgIndex);
 
-        targetParamFacts.insert(ev);
+        TargetParamFacts.insert(EV);
 
         LOG_DEBUG("Added patchable memory location (caller -> callee)");
         LOG_DEBUG("Source");
         DataFlowUtils::dumpFact(Fact);
         LOG_DEBUG("Destination");
-        DataFlowUtils::dumpFact(ev);
+        DataFlowUtils::dumpFact(EV);
       }
     }
 
-    if (isVarArgParam)
-      ++varArgIndex;
+    if (IsVarArgParam)
+      ++VarArgIndex;
   }
 
-  bool addLineNumber = !targetParamFacts.empty();
-  if (addLineNumber)
+  bool AddLineNumber = !TargetParamFacts.empty();
+  if (AddLineNumber)
     traceStats.add(callInst);
 
-  std::set<ExtendedValue> targetFacts;
-  std::set_union(targetGlobalFacts.begin(), targetGlobalFacts.end(),
-                 targetParamFacts.begin(), targetParamFacts.end(),
-                 std::inserter(targetFacts, targetFacts.begin()));
+  std::set<ExtendedValue> TargetFacts;
+  std::set_union(TargetGlobalFacts.begin(), TargetGlobalFacts.end(),
+                 TargetParamFacts.begin(), TargetParamFacts.end(),
+                 std::inserter(TargetFacts, TargetFacts.begin()));
 
-  return targetFacts;
+  return TargetFacts;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.cpp
@@ -14,14 +14,14 @@
 namespace psr {
 
 std::set<ExtendedValue>
-MapTaintedValuesToCaller::computeTargets(ExtendedValue fact) {
+MapTaintedValuesToCaller::computeTargets(ExtendedValue Fact) {
   std::set<ExtendedValue> targetGlobalFacts;
   std::set<ExtendedValue> targetRetFacts;
 
   bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
-      DataFlowUtils::getMemoryLocationSeqFromFact(fact));
+      DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
   if (isGlobalMemLocationFact)
-    targetGlobalFacts.insert(fact);
+    targetGlobalFacts.insert(Fact);
 
   const auto retValMemLocationMatr = retInst->getReturnValue();
   if (!retValMemLocationMatr)
@@ -33,7 +33,7 @@ MapTaintedValuesToCaller::computeTargets(ExtendedValue fact) {
   bool isRetValMemLocation = !retValMemLocationSeq.empty();
   if (isRetValMemLocation) {
     const auto factMemLocationSeq =
-        DataFlowUtils::getMemoryLocationSeqFromFact(fact);
+        DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
     bool isArrayDecay = DataFlowUtils::isArrayDecay(retValMemLocationMatr);
     if (isArrayDecay)
@@ -63,12 +63,12 @@ MapTaintedValuesToCaller::computeTargets(ExtendedValue fact) {
 
       LOG_DEBUG("Added patchable memory location (caller <- callee)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }
   } else {
-    bool genFact = DataFlowUtils::isValueTainted(retValMemLocationMatr, fact);
+    bool genFact = DataFlowUtils::isValueTainted(retValMemLocationMatr, Fact);
     if (genFact) {
       std::vector<const llvm::Value *> patchablePart{callInst};
 
@@ -79,7 +79,7 @@ MapTaintedValuesToCaller::computeTargets(ExtendedValue fact) {
 
       LOG_DEBUG("Added patchable memory location (caller <- callee)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.cpp
@@ -15,40 +15,40 @@ namespace psr {
 
 std::set<ExtendedValue>
 MapTaintedValuesToCaller::computeTargets(ExtendedValue Fact) {
-  std::set<ExtendedValue> targetGlobalFacts;
-  std::set<ExtendedValue> targetRetFacts;
+  std::set<ExtendedValue> TargetGlobalFacts;
+  std::set<ExtendedValue> TargetRetFacts;
 
-  bool isGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
+  bool IsGlobalMemLocationFact = DataFlowUtils::isGlobalMemoryLocationSeq(
       DataFlowUtils::getMemoryLocationSeqFromFact(Fact));
-  if (isGlobalMemLocationFact)
-    targetGlobalFacts.insert(Fact);
+  if (IsGlobalMemLocationFact)
+    TargetGlobalFacts.insert(Fact);
 
-  const auto retValMemLocationMatr = retInst->getReturnValue();
-  if (!retValMemLocationMatr)
-    return targetGlobalFacts;
+  const auto RetValMemLocationMatr = retInst->getReturnValue();
+  if (!RetValMemLocationMatr)
+    return TargetGlobalFacts;
 
-  auto retValMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(retValMemLocationMatr);
+  auto RetValMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(RetValMemLocationMatr);
 
-  bool isRetValMemLocation = !retValMemLocationSeq.empty();
-  if (isRetValMemLocation) {
-    const auto factMemLocationSeq =
+  bool IsRetValMemLocation = !RetValMemLocationSeq.empty();
+  if (IsRetValMemLocation) {
+    const auto FactMemLocationSeq =
         DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
-    bool isArrayDecay = DataFlowUtils::isArrayDecay(retValMemLocationMatr);
-    if (isArrayDecay)
-      retValMemLocationSeq.pop_back();
+    bool IsArrayDecay = DataFlowUtils::isArrayDecay(RetValMemLocationMatr);
+    if (IsArrayDecay)
+      RetValMemLocationSeq.pop_back();
 
-    bool genFact = DataFlowUtils::isSubsetMemoryLocationSeq(
-        retValMemLocationSeq, factMemLocationSeq);
-    if (genFact) {
-      const auto relocatableMemLocationSeq =
-          DataFlowUtils::getRelocatableMemoryLocationSeq(factMemLocationSeq,
-                                                         retValMemLocationSeq);
-      std::vector<const llvm::Value *> patchablePart{callInst};
-      const auto patchableMemLocationSeq =
-          DataFlowUtils::joinMemoryLocationSeqs(patchablePart,
-                                                relocatableMemLocationSeq);
+    bool GenFact = DataFlowUtils::isSubsetMemoryLocationSeq(
+        RetValMemLocationSeq, FactMemLocationSeq);
+    if (GenFact) {
+      const auto RelocatableMemLocationSeq =
+          DataFlowUtils::getRelocatableMemoryLocationSeq(FactMemLocationSeq,
+                                                         RetValMemLocationSeq);
+      std::vector<const llvm::Value *> PatchablePart{callInst};
+      const auto PatchableMemLocationSeq =
+          DataFlowUtils::joinMemoryLocationSeqs(PatchablePart,
+                                                RelocatableMemLocationSeq);
 
       /*
        * We need to set this to call inst because we can have the case where we
@@ -56,45 +56,45 @@ MapTaintedValuesToCaller::computeTargets(ExtendedValue Fact) {
        * a memory address). We then land in the else branch below and need to
        * find the call instance (see test case 230-function-ptr-2).
        */
-      ExtendedValue ev(callInst);
-      ev.setMemLocationSeq(patchableMemLocationSeq);
+      ExtendedValue EV(callInst);
+      EV.setMemLocationSeq(PatchableMemLocationSeq);
 
-      targetRetFacts.insert(ev);
+      TargetRetFacts.insert(EV);
 
       LOG_DEBUG("Added patchable memory location (caller <- callee)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
   } else {
-    bool genFact = DataFlowUtils::isValueTainted(retValMemLocationMatr, Fact);
-    if (genFact) {
-      std::vector<const llvm::Value *> patchablePart{callInst};
+    bool GenFact = DataFlowUtils::isValueTainted(RetValMemLocationMatr, Fact);
+    if (GenFact) {
+      std::vector<const llvm::Value *> PatchablePart{callInst};
 
-      ExtendedValue ev(callInst);
-      ev.setMemLocationSeq(patchablePart);
+      ExtendedValue EV(callInst);
+      EV.setMemLocationSeq(PatchablePart);
 
-      targetRetFacts.insert(ev);
+      TargetRetFacts.insert(EV);
 
       LOG_DEBUG("Added patchable memory location (caller <- callee)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
   }
 
-  bool addLineNumbers = !targetRetFacts.empty();
-  if (addLineNumbers)
+  bool AddLineNumbers = !TargetRetFacts.empty();
+  if (AddLineNumbers)
     traceStats.add(callInst);
 
-  std::set<ExtendedValue> targetFacts;
-  std::set_union(targetGlobalFacts.begin(), targetGlobalFacts.end(),
-                 targetRetFacts.begin(), targetRetFacts.end(),
-                 std::inserter(targetFacts, targetFacts.begin()));
+  std::set<ExtendedValue> TargetFacts;
+  std::set_union(TargetGlobalFacts.begin(), TargetGlobalFacts.end(),
+                 TargetRetFacts.begin(), TargetRetFacts.end(),
+                 std::inserter(TargetFacts, TargetFacts.begin()));
 
-  return targetFacts;
+  return TargetFacts;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemSetInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemSetInstFlowFunction.cpp
@@ -9,19 +9,19 @@
 namespace psr {
 
 std::set<ExtendedValue>
-MemSetInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+MemSetInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto memSetInst = llvm::cast<const llvm::MemSetInst>(currentInst);
   const auto dstMemLocationMatr = memSetInst->getRawDest();
 
   bool killFact =
-      DataFlowUtils::isMemoryLocationTainted(dstMemLocationMatr, fact);
+      DataFlowUtils::isMemoryLocationTainted(dstMemLocationMatr, Fact);
   if (killFact) {
     traceStats.add(memSetInst);
 
     return {};
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemSetInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemSetInstFlowFunction.cpp
@@ -10,13 +10,13 @@ namespace psr {
 
 std::set<ExtendedValue>
 MemSetInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto memSetInst = llvm::cast<const llvm::MemSetInst>(currentInst);
-  const auto dstMemLocationMatr = memSetInst->getRawDest();
+  const auto MemSetInst = llvm::cast<const llvm::MemSetInst>(currentInst);
+  const auto DstMemLocationMatr = MemSetInst->getRawDest();
 
-  bool killFact =
-      DataFlowUtils::isMemoryLocationTainted(dstMemLocationMatr, Fact);
-  if (killFact) {
-    traceStats.add(memSetInst);
+  bool KillFact =
+      DataFlowUtils::isMemoryLocationTainted(DstMemLocationMatr, Fact);
+  if (KillFact) {
+    traceStats.add(MemSetInst);
 
     return {};
   }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemTransferInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemTransferInstFlowFunction.cpp
@@ -9,7 +9,7 @@
 namespace psr {
 
 std::set<ExtendedValue>
-MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto memTransferInst =
       llvm::cast<const llvm::MemTransferInst>(currentInst);
 
@@ -17,14 +17,14 @@ MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
   const auto dstMemLocationMatr = memTransferInst->getRawDest();
 
   const auto factMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromFact(fact);
+      DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
   auto srcMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromMatr(srcMemLocationMatr);
   auto dstMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromMatr(dstMemLocationMatr);
 
   bool isArgumentPatch = DataFlowUtils::isPatchableArgumentMemcpy(
-      memTransferInst->getRawSource(), srcMemLocationSeq, fact);
+      memTransferInst->getRawSource(), srcMemLocationSeq, Fact);
   std::set<ExtendedValue> targetFacts;
 
   /*
@@ -33,7 +33,7 @@ MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
   if (isArgumentPatch) {
     const auto patchedMemLocationSeq = DataFlowUtils::patchMemoryLocationFrame(
         factMemLocationSeq, dstMemLocationSeq);
-    ExtendedValue ev(fact);
+    ExtendedValue ev(Fact);
     ev.setMemLocationSeq(patchedMemLocationSeq);
     ev.resetVarArgIndex();
 
@@ -42,7 +42,7 @@ MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
     LOG_DEBUG("Patched memory location (arg/memcpy)");
     LOG_DEBUG("Source");
-    DataFlowUtils::dumpFact(fact);
+    DataFlowUtils::dumpFact(Fact);
     LOG_DEBUG("Destination");
     DataFlowUtils::dumpFact(ev);
   } else {
@@ -66,7 +66,7 @@ MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
       const auto relocatedMemLocationSeq =
           DataFlowUtils::joinMemoryLocationSeqs(dstMemLocationSeq,
                                                 relocatableMemLocationSeq);
-      ExtendedValue ev(fact);
+      ExtendedValue ev(Fact);
       ev.setMemLocationSeq(relocatedMemLocationSeq);
 
       targetFacts.insert(ev);
@@ -74,12 +74,12 @@ MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       LOG_DEBUG("Relocated memory location (memcpy/memmove)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }
     if (!killFact)
-      targetFacts.insert(fact);
+      targetFacts.insert(Fact);
   }
 
   return targetFacts;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemTransferInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MemTransferInstFlowFunction.cpp
@@ -10,79 +10,79 @@ namespace psr {
 
 std::set<ExtendedValue>
 MemTransferInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto memTransferInst =
+  const auto MemTransferInst =
       llvm::cast<const llvm::MemTransferInst>(currentInst);
 
-  const auto srcMemLocationMatr = memTransferInst->getRawSource();
-  const auto dstMemLocationMatr = memTransferInst->getRawDest();
+  const auto SrcMemLocationMatr = MemTransferInst->getRawSource();
+  const auto DstMemLocationMatr = MemTransferInst->getRawDest();
 
-  const auto factMemLocationSeq =
+  const auto FactMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
-  auto srcMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(srcMemLocationMatr);
-  auto dstMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(dstMemLocationMatr);
+  auto SrcMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(SrcMemLocationMatr);
+  auto DstMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(DstMemLocationMatr);
 
-  bool isArgumentPatch = DataFlowUtils::isPatchableArgumentMemcpy(
-      memTransferInst->getRawSource(), srcMemLocationSeq, Fact);
-  std::set<ExtendedValue> targetFacts;
+  bool IsArgumentPatch = DataFlowUtils::isPatchableArgumentMemcpy(
+      MemTransferInst->getRawSource(), SrcMemLocationSeq, Fact);
+  std::set<ExtendedValue> TargetFacts;
 
   /*
    * Patch argument
    */
-  if (isArgumentPatch) {
-    const auto patchedMemLocationSeq = DataFlowUtils::patchMemoryLocationFrame(
-        factMemLocationSeq, dstMemLocationSeq);
-    ExtendedValue ev(Fact);
-    ev.setMemLocationSeq(patchedMemLocationSeq);
-    ev.resetVarArgIndex();
+  if (IsArgumentPatch) {
+    const auto PatchedMemLocationSeq = DataFlowUtils::patchMemoryLocationFrame(
+        FactMemLocationSeq, DstMemLocationSeq);
+    ExtendedValue EV(Fact);
+    EV.setMemLocationSeq(PatchedMemLocationSeq);
+    EV.resetVarArgIndex();
 
-    targetFacts.insert(ev);
-    traceStats.add(memTransferInst, dstMemLocationSeq);
+    TargetFacts.insert(EV);
+    traceStats.add(MemTransferInst, DstMemLocationSeq);
 
     LOG_DEBUG("Patched memory location (arg/memcpy)");
     LOG_DEBUG("Source");
     DataFlowUtils::dumpFact(Fact);
     LOG_DEBUG("Destination");
-    DataFlowUtils::dumpFact(ev);
+    DataFlowUtils::dumpFact(EV);
   } else {
-    bool isSrcArrayDecay = DataFlowUtils::isArrayDecay(srcMemLocationMatr);
-    if (isSrcArrayDecay)
-      srcMemLocationSeq.pop_back();
+    bool IsSrcArrayDecay = DataFlowUtils::isArrayDecay(SrcMemLocationMatr);
+    if (IsSrcArrayDecay)
+      SrcMemLocationSeq.pop_back();
 
-    bool isDstArrayDecay = DataFlowUtils::isArrayDecay(dstMemLocationMatr);
-    if (isDstArrayDecay)
-      dstMemLocationSeq.pop_back();
+    bool IsDstArrayDecay = DataFlowUtils::isArrayDecay(DstMemLocationMatr);
+    if (IsDstArrayDecay)
+      DstMemLocationSeq.pop_back();
 
-    bool genFact = DataFlowUtils::isSubsetMemoryLocationSeq(srcMemLocationSeq,
-                                                            factMemLocationSeq);
-    bool killFact = DataFlowUtils::isSubsetMemoryLocationSeq(
-        dstMemLocationSeq, factMemLocationSeq);
+    bool GenFact = DataFlowUtils::isSubsetMemoryLocationSeq(SrcMemLocationSeq,
+                                                            FactMemLocationSeq);
+    bool KillFact = DataFlowUtils::isSubsetMemoryLocationSeq(
+        DstMemLocationSeq, FactMemLocationSeq);
 
-    if (genFact) {
-      const auto relocatableMemLocationSeq =
-          DataFlowUtils::getRelocatableMemoryLocationSeq(factMemLocationSeq,
-                                                         srcMemLocationSeq);
-      const auto relocatedMemLocationSeq =
-          DataFlowUtils::joinMemoryLocationSeqs(dstMemLocationSeq,
-                                                relocatableMemLocationSeq);
-      ExtendedValue ev(Fact);
-      ev.setMemLocationSeq(relocatedMemLocationSeq);
+    if (GenFact) {
+      const auto RelocatableMemLocationSeq =
+          DataFlowUtils::getRelocatableMemoryLocationSeq(FactMemLocationSeq,
+                                                         SrcMemLocationSeq);
+      const auto RelocatedMemLocationSeq =
+          DataFlowUtils::joinMemoryLocationSeqs(DstMemLocationSeq,
+                                                RelocatableMemLocationSeq);
+      ExtendedValue EV(Fact);
+      EV.setMemLocationSeq(RelocatedMemLocationSeq);
 
-      targetFacts.insert(ev);
-      traceStats.add(memTransferInst, dstMemLocationSeq);
+      TargetFacts.insert(EV);
+      traceStats.add(MemTransferInst, DstMemLocationSeq);
 
       LOG_DEBUG("Relocated memory location (memcpy/memmove)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
-    if (!killFact)
-      targetFacts.insert(Fact);
+    if (!KillFact)
+      TargetFacts.insert(Fact);
   }
 
-  return targetFacts;
+  return TargetFacts;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/PHINodeFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/PHINodeFlowFunction.cpp
@@ -8,19 +8,19 @@ namespace psr {
 
 std::set<ExtendedValue>
 PHINodeFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto phiNodeInst = llvm::cast<llvm::PHINode>(currentInst);
+  const auto PhiNodeInst = llvm::cast<llvm::PHINode>(currentInst);
 
-  for (const auto block : phiNodeInst->blocks()) {
-    const auto incomingValue = phiNodeInst->getIncomingValueForBlock(block);
+  for (const auto Block : PhiNodeInst->blocks()) {
+    const auto IncomingValue = PhiNodeInst->getIncomingValueForBlock(Block);
 
-    bool isIncomingValueTainted =
-        DataFlowUtils::isValueTainted(incomingValue, Fact) ||
-        DataFlowUtils::isMemoryLocationTainted(incomingValue, Fact);
+    bool IsIncomingValueTainted =
+        DataFlowUtils::isValueTainted(IncomingValue, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(IncomingValue, Fact);
 
-    if (isIncomingValueTainted) {
-      traceStats.add(phiNodeInst);
+    if (IsIncomingValueTainted) {
+      traceStats.add(PhiNodeInst);
 
-      return {Fact, ExtendedValue(phiNodeInst)};
+      return {Fact, ExtendedValue(PhiNodeInst)};
     }
   }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/PHINodeFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/PHINodeFlowFunction.cpp
@@ -7,24 +7,24 @@
 namespace psr {
 
 std::set<ExtendedValue>
-PHINodeFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+PHINodeFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto phiNodeInst = llvm::cast<llvm::PHINode>(currentInst);
 
   for (const auto block : phiNodeInst->blocks()) {
     const auto incomingValue = phiNodeInst->getIncomingValueForBlock(block);
 
     bool isIncomingValueTainted =
-        DataFlowUtils::isValueTainted(incomingValue, fact) ||
-        DataFlowUtils::isMemoryLocationTainted(incomingValue, fact);
+        DataFlowUtils::isValueTainted(incomingValue, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(incomingValue, Fact);
 
     if (isIncomingValueTainted) {
       traceStats.add(phiNodeInst);
 
-      return {fact, ExtendedValue(phiNodeInst)};
+      return {Fact, ExtendedValue(phiNodeInst)};
     }
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/ReturnInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/ReturnInstFlowFunction.cpp
@@ -8,13 +8,13 @@ namespace psr {
 
 std::set<ExtendedValue>
 ReturnInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto retInst = llvm::cast<llvm::ReturnInst>(currentInst);
-  const auto retValMemLocationMatr = retInst->getReturnValue();
+  const auto RetInst = llvm::cast<llvm::ReturnInst>(currentInst);
+  const auto RetValMemLocationMatr = RetInst->getReturnValue();
 
-  if (retValMemLocationMatr) {
-    bool isRetValTainted =
-        DataFlowUtils::isValueTainted(retValMemLocationMatr, Fact) ||
-        DataFlowUtils::isMemoryLocationTainted(retValMemLocationMatr, Fact);
+  if (RetValMemLocationMatr) {
+    bool IsRetValTainted =
+        DataFlowUtils::isValueTainted(RetValMemLocationMatr, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(RetValMemLocationMatr, Fact);
 
     /*
      * We don't need to GEN/KILL any facts here as this is all handled
@@ -22,8 +22,8 @@ ReturnInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
      * function is to make sure that a tainted return statement of an
      * entry point is added as for that case no mapping function is called.
      */
-    if (isRetValTainted)
-      traceStats.add(retInst);
+    if (IsRetValTainted)
+      traceStats.add(RetInst);
   }
 
   return {Fact};

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/ReturnInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/ReturnInstFlowFunction.cpp
@@ -7,14 +7,14 @@
 namespace psr {
 
 std::set<ExtendedValue>
-ReturnInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+ReturnInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto retInst = llvm::cast<llvm::ReturnInst>(currentInst);
   const auto retValMemLocationMatr = retInst->getReturnValue();
 
   if (retValMemLocationMatr) {
     bool isRetValTainted =
-        DataFlowUtils::isValueTainted(retValMemLocationMatr, fact) ||
-        DataFlowUtils::isMemoryLocationTainted(retValMemLocationMatr, fact);
+        DataFlowUtils::isValueTainted(retValMemLocationMatr, Fact) ||
+        DataFlowUtils::isMemoryLocationTainted(retValMemLocationMatr, Fact);
 
     /*
      * We don't need to GEN/KILL any facts here as this is all handled
@@ -26,7 +26,7 @@ ReturnInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
       traceStats.add(retInst);
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
@@ -8,29 +8,29 @@ namespace psr {
 
 std::set<ExtendedValue>
 StoreInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  const auto storeInst = llvm::cast<llvm::StoreInst>(currentInst);
+  const auto StoreInst = llvm::cast<llvm::StoreInst>(currentInst);
 
-  const auto srcMemLocationMatr = storeInst->getValueOperand();
-  const auto dstMemLocationMatr = storeInst->getPointerOperand();
+  const auto SrcMemLocationMatr = StoreInst->getValueOperand();
+  const auto DstMemLocationMatr = StoreInst->getPointerOperand();
 
-  const auto factMemLocationSeq =
+  const auto FactMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
-  auto srcMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(srcMemLocationMatr);
-  auto dstMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(dstMemLocationMatr);
+  auto SrcMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(SrcMemLocationMatr);
+  auto DstMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(DstMemLocationMatr);
 
-  bool isArgumentPatch =
-      DataFlowUtils::isPatchableArgumentStore(srcMemLocationMatr, Fact);
-  bool isVaListArgumentPatch =
-      DataFlowUtils::isPatchableVaListArgument(srcMemLocationMatr, Fact);
+  bool IsArgumentPatch =
+      DataFlowUtils::isPatchableArgumentStore(SrcMemLocationMatr, Fact);
+  bool IsVaListArgumentPatch =
+      DataFlowUtils::isPatchableVaListArgument(SrcMemLocationMatr, Fact);
 
-  bool isReturnValuePatch =
-      DataFlowUtils::isPatchableReturnValue(srcMemLocationMatr, Fact);
+  bool IsReturnValuePatch =
+      DataFlowUtils::isPatchableReturnValue(SrcMemLocationMatr, Fact);
 
-  bool isSrcMemLocation = !srcMemLocationSeq.empty();
+  bool IsSrcMemLocation = !SrcMemLocationSeq.empty();
 
-  std::set<ExtendedValue> targetFacts;
+  std::set<ExtendedValue> TargetFacts;
 
   /*
    * Patch argument
@@ -43,72 +43,72 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
    * foo(va_list args))
    *
    */
-  if (isArgumentPatch) {
-    bool patchMemLocation = !dstMemLocationSeq.empty();
-    if (patchMemLocation) {
-      bool isArgCoerced =
-          srcMemLocationMatr->getName().contains_lower("coerce");
-      if (isArgCoerced) {
-        assert(dstMemLocationSeq.size() > 1);
-        dstMemLocationSeq.pop_back();
+  if (IsArgumentPatch) {
+    bool PatchMemLocation = !DstMemLocationSeq.empty();
+    if (PatchMemLocation) {
+      bool IsArgCoerced =
+          SrcMemLocationMatr->getName().contains_lower("coerce");
+      if (IsArgCoerced) {
+        assert(DstMemLocationSeq.size() > 1);
+        DstMemLocationSeq.pop_back();
       }
 
-      const auto patchableMemLocationSeq =
-          isVaListArgumentPatch
+      const auto PatchableMemLocationSeq =
+          IsVaListArgumentPatch
               ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact)
               : DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
-      const auto patchedMemLocationSeq =
-          DataFlowUtils::patchMemoryLocationFrame(patchableMemLocationSeq,
-                                                  dstMemLocationSeq);
+      const auto PatchedMemLocationSeq =
+          DataFlowUtils::patchMemoryLocationFrame(PatchableMemLocationSeq,
+                                                  DstMemLocationSeq);
 
-      ExtendedValue ev(Fact);
+      ExtendedValue EV(Fact);
 
-      if (isVaListArgumentPatch) {
-        ev.setVaListMemLocationSeq(patchedMemLocationSeq);
+      if (IsVaListArgumentPatch) {
+        EV.setVaListMemLocationSeq(PatchedMemLocationSeq);
       } else {
-        ev.setMemLocationSeq(patchedMemLocationSeq);
-        ev.resetVarArgIndex();
+        EV.setMemLocationSeq(PatchedMemLocationSeq);
+        EV.resetVarArgIndex();
       }
 
-      targetFacts.insert(ev);
-      traceStats.add(storeInst, dstMemLocationSeq);
+      TargetFacts.insert(EV);
+      traceStats.add(StoreInst, DstMemLocationSeq);
 
       LOG_DEBUG("Patched memory location (arg/store)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
   }
   /*
    * Patch return value
    */
-  else if (isReturnValuePatch) {
-    bool patchMemLocation = !dstMemLocationSeq.empty();
-    if (patchMemLocation) {
-      bool isExtractValue =
-          llvm::isa<llvm::ExtractValueInst>(srcMemLocationMatr);
-      if (isExtractValue) {
-        assert(dstMemLocationSeq.size() > 1);
-        dstMemLocationSeq.pop_back();
+  else if (IsReturnValuePatch) {
+    bool PatchMemLocation = !DstMemLocationSeq.empty();
+    if (PatchMemLocation) {
+      bool IsExtractValue =
+          llvm::isa<llvm::ExtractValueInst>(SrcMemLocationMatr);
+      if (IsExtractValue) {
+        assert(DstMemLocationSeq.size() > 1);
+        DstMemLocationSeq.pop_back();
       }
 
-      const auto patchedMemLocationSeq =
-          DataFlowUtils::patchMemoryLocationFrame(factMemLocationSeq,
-                                                  dstMemLocationSeq);
+      const auto PatchedMemLocationSeq =
+          DataFlowUtils::patchMemoryLocationFrame(FactMemLocationSeq,
+                                                  DstMemLocationSeq);
 
-      ExtendedValue ev(Fact);
-      ev.setMemLocationSeq(patchedMemLocationSeq);
+      ExtendedValue EV(Fact);
+      EV.setMemLocationSeq(PatchedMemLocationSeq);
 
-      targetFacts.insert(ev);
-      traceStats.add(storeInst, dstMemLocationSeq);
+      TargetFacts.insert(EV);
+      traceStats.add(StoreInst, DstMemLocationSeq);
 
       LOG_DEBUG("Patched memory location (ret/store)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
   }
   /*
@@ -118,57 +118,57 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
    * desination as the store instruction is defined as <store, ty val, *ty dst>
    * that means we need to remove all facts that started at the destination.
    */
-  else if (isSrcMemLocation) {
-    bool isArrayDecay = DataFlowUtils::isArrayDecay(srcMemLocationMatr);
-    if (isArrayDecay)
-      srcMemLocationSeq.pop_back();
+  else if (IsSrcMemLocation) {
+    bool IsArrayDecay = DataFlowUtils::isArrayDecay(SrcMemLocationMatr);
+    if (IsArrayDecay)
+      SrcMemLocationSeq.pop_back();
 
-    bool genFact = DataFlowUtils::isSubsetMemoryLocationSeq(srcMemLocationSeq,
-                                                            factMemLocationSeq);
-    bool killFact = DataFlowUtils::isSubsetMemoryLocationSeq(
-                        dstMemLocationSeq, factMemLocationSeq) ||
+    bool GenFact = DataFlowUtils::isSubsetMemoryLocationSeq(SrcMemLocationSeq,
+                                                            FactMemLocationSeq);
+    bool KillFact = DataFlowUtils::isSubsetMemoryLocationSeq(
+                        DstMemLocationSeq, FactMemLocationSeq) ||
                     DataFlowUtils::isKillAfterStoreFact(Fact);
 
-    if (genFact) {
-      const auto relocatableMemLocationSeq =
-          DataFlowUtils::getRelocatableMemoryLocationSeq(factMemLocationSeq,
-                                                         srcMemLocationSeq);
-      const auto relocatedMemLocationSeq =
-          DataFlowUtils::joinMemoryLocationSeqs(dstMemLocationSeq,
-                                                relocatableMemLocationSeq);
+    if (GenFact) {
+      const auto RelocatableMemLocationSeq =
+          DataFlowUtils::getRelocatableMemoryLocationSeq(FactMemLocationSeq,
+                                                         SrcMemLocationSeq);
+      const auto RelocatedMemLocationSeq =
+          DataFlowUtils::joinMemoryLocationSeqs(DstMemLocationSeq,
+                                                RelocatableMemLocationSeq);
 
-      ExtendedValue ev(Fact);
-      ev.setMemLocationSeq(relocatedMemLocationSeq);
+      ExtendedValue EV(Fact);
+      EV.setMemLocationSeq(RelocatedMemLocationSeq);
 
-      targetFacts.insert(ev);
-      traceStats.add(storeInst, dstMemLocationSeq);
+      TargetFacts.insert(EV);
+      traceStats.add(StoreInst, DstMemLocationSeq);
 
       LOG_DEBUG("Relocated memory location (store)");
       LOG_DEBUG("Source");
       DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
-      DataFlowUtils::dumpFact(ev);
+      DataFlowUtils::dumpFact(EV);
     }
-    if (!killFact)
-      targetFacts.insert(Fact);
+    if (!KillFact)
+      TargetFacts.insert(Fact);
   } else {
-    bool genFact = DataFlowUtils::isValueTainted(srcMemLocationMatr, Fact);
-    bool killFact = DataFlowUtils::isSubsetMemoryLocationSeq(
-                        dstMemLocationSeq, factMemLocationSeq) ||
+    bool GenFact = DataFlowUtils::isValueTainted(SrcMemLocationMatr, Fact);
+    bool KillFact = DataFlowUtils::isSubsetMemoryLocationSeq(
+                        DstMemLocationSeq, FactMemLocationSeq) ||
                     DataFlowUtils::isKillAfterStoreFact(Fact);
 
-    if (genFact) {
-      ExtendedValue ev(storeInst);
-      ev.setMemLocationSeq(dstMemLocationSeq);
+    if (GenFact) {
+      ExtendedValue EV(StoreInst);
+      EV.setMemLocationSeq(DstMemLocationSeq);
 
-      targetFacts.insert(ev);
-      traceStats.add(storeInst, dstMemLocationSeq);
+      TargetFacts.insert(EV);
+      traceStats.add(StoreInst, DstMemLocationSeq);
     }
-    if (!killFact)
-      targetFacts.insert(Fact);
+    if (!KillFact)
+      TargetFacts.insert(Fact);
   }
 
-  return targetFacts;
+  return TargetFacts;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
@@ -7,26 +7,26 @@
 namespace psr {
 
 std::set<ExtendedValue>
-StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+StoreInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   const auto storeInst = llvm::cast<llvm::StoreInst>(currentInst);
 
   const auto srcMemLocationMatr = storeInst->getValueOperand();
   const auto dstMemLocationMatr = storeInst->getPointerOperand();
 
   const auto factMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromFact(fact);
+      DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
   auto srcMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromMatr(srcMemLocationMatr);
   auto dstMemLocationSeq =
       DataFlowUtils::getMemoryLocationSeqFromMatr(dstMemLocationMatr);
 
   bool isArgumentPatch =
-      DataFlowUtils::isPatchableArgumentStore(srcMemLocationMatr, fact);
+      DataFlowUtils::isPatchableArgumentStore(srcMemLocationMatr, Fact);
   bool isVaListArgumentPatch =
-      DataFlowUtils::isPatchableVaListArgument(srcMemLocationMatr, fact);
+      DataFlowUtils::isPatchableVaListArgument(srcMemLocationMatr, Fact);
 
   bool isReturnValuePatch =
-      DataFlowUtils::isPatchableReturnValue(srcMemLocationMatr, fact);
+      DataFlowUtils::isPatchableReturnValue(srcMemLocationMatr, Fact);
 
   bool isSrcMemLocation = !srcMemLocationSeq.empty();
 
@@ -55,14 +55,14 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       const auto patchableMemLocationSeq =
           isVaListArgumentPatch
-              ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(fact)
-              : DataFlowUtils::getMemoryLocationSeqFromFact(fact);
+              ? DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact)
+              : DataFlowUtils::getMemoryLocationSeqFromFact(Fact);
 
       const auto patchedMemLocationSeq =
           DataFlowUtils::patchMemoryLocationFrame(patchableMemLocationSeq,
                                                   dstMemLocationSeq);
 
-      ExtendedValue ev(fact);
+      ExtendedValue ev(Fact);
 
       if (isVaListArgumentPatch) {
         ev.setVaListMemLocationSeq(patchedMemLocationSeq);
@@ -76,7 +76,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       LOG_DEBUG("Patched memory location (arg/store)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }
@@ -98,7 +98,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
           DataFlowUtils::patchMemoryLocationFrame(factMemLocationSeq,
                                                   dstMemLocationSeq);
 
-      ExtendedValue ev(fact);
+      ExtendedValue ev(Fact);
       ev.setMemLocationSeq(patchedMemLocationSeq);
 
       targetFacts.insert(ev);
@@ -106,7 +106,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       LOG_DEBUG("Patched memory location (ret/store)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }
@@ -127,7 +127,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
                                                             factMemLocationSeq);
     bool killFact = DataFlowUtils::isSubsetMemoryLocationSeq(
                         dstMemLocationSeq, factMemLocationSeq) ||
-                    DataFlowUtils::isKillAfterStoreFact(fact);
+                    DataFlowUtils::isKillAfterStoreFact(Fact);
 
     if (genFact) {
       const auto relocatableMemLocationSeq =
@@ -137,7 +137,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
           DataFlowUtils::joinMemoryLocationSeqs(dstMemLocationSeq,
                                                 relocatableMemLocationSeq);
 
-      ExtendedValue ev(fact);
+      ExtendedValue ev(Fact);
       ev.setMemLocationSeq(relocatedMemLocationSeq);
 
       targetFacts.insert(ev);
@@ -145,17 +145,17 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
 
       LOG_DEBUG("Relocated memory location (store)");
       LOG_DEBUG("Source");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
       LOG_DEBUG("Destination");
       DataFlowUtils::dumpFact(ev);
     }
     if (!killFact)
-      targetFacts.insert(fact);
+      targetFacts.insert(Fact);
   } else {
-    bool genFact = DataFlowUtils::isValueTainted(srcMemLocationMatr, fact);
+    bool genFact = DataFlowUtils::isValueTainted(srcMemLocationMatr, Fact);
     bool killFact = DataFlowUtils::isSubsetMemoryLocationSeq(
                         dstMemLocationSeq, factMemLocationSeq) ||
-                    DataFlowUtils::isKillAfterStoreFact(fact);
+                    DataFlowUtils::isKillAfterStoreFact(Fact);
 
     if (genFact) {
       ExtendedValue ev(storeInst);
@@ -165,7 +165,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
       traceStats.add(storeInst, dstMemLocationSeq);
     }
     if (!killFact)
-      targetFacts.insert(fact);
+      targetFacts.insert(Fact);
   }
 
   return targetFacts;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAEndInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAEndInstFlowFunction.cpp
@@ -10,26 +10,26 @@ namespace psr {
 
 std::set<ExtendedValue>
 VAEndInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  bool isVarArgFact = Fact.isVarArg();
-  if (!isVarArgFact)
+  bool IsVarArgFact = Fact.isVarArg();
+  if (!IsVarArgFact)
     return {Fact};
 
-  const auto vaEndInst = llvm::cast<llvm::VAEndInst>(currentInst);
-  const auto vaEndMemLocationMatr = vaEndInst->getArgList();
+  const auto VaEndInst = llvm::cast<llvm::VAEndInst>(currentInst);
+  const auto VaEndMemLocationMatr = VaEndInst->getArgList();
 
-  auto vaEndMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(vaEndMemLocationMatr);
+  auto VaEndMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(VaEndMemLocationMatr);
 
-  bool isValidMemLocationSeq = !vaEndMemLocationSeq.empty();
-  if (isValidMemLocationSeq) {
-    bool isArrayDecay = DataFlowUtils::isArrayDecay(vaEndMemLocationMatr);
-    if (isArrayDecay)
-      vaEndMemLocationSeq.pop_back();
+  bool IsValidMemLocationSeq = !VaEndMemLocationSeq.empty();
+  if (IsValidMemLocationSeq) {
+    bool IsArrayDecay = DataFlowUtils::isArrayDecay(VaEndMemLocationMatr);
+    if (IsArrayDecay)
+      VaEndMemLocationSeq.pop_back();
 
-    bool isVaListEqual = DataFlowUtils::isMemoryLocationSeqsEqual(
+    bool IsVaListEqual = DataFlowUtils::isMemoryLocationSeqsEqual(
         DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact),
-        vaEndMemLocationSeq);
-    if (isVaListEqual) {
+        VaEndMemLocationSeq);
+    if (IsVaListEqual) {
       LOG_DEBUG("Killed VarArg");
       DataFlowUtils::dumpFact(Fact);
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAEndInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAEndInstFlowFunction.cpp
@@ -9,10 +9,10 @@
 namespace psr {
 
 std::set<ExtendedValue>
-VAEndInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
-  bool isVarArgFact = fact.isVarArg();
+VAEndInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
+  bool isVarArgFact = Fact.isVarArg();
   if (!isVarArgFact)
-    return {fact};
+    return {Fact};
 
   const auto vaEndInst = llvm::cast<llvm::VAEndInst>(currentInst);
   const auto vaEndMemLocationMatr = vaEndInst->getArgList();
@@ -27,17 +27,17 @@ VAEndInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
       vaEndMemLocationSeq.pop_back();
 
     bool isVaListEqual = DataFlowUtils::isMemoryLocationSeqsEqual(
-        DataFlowUtils::getVaListMemoryLocationSeqFromFact(fact),
+        DataFlowUtils::getVaListMemoryLocationSeqFromFact(Fact),
         vaEndMemLocationSeq);
     if (isVaListEqual) {
       LOG_DEBUG("Killed VarArg");
-      DataFlowUtils::dumpFact(fact);
+      DataFlowUtils::dumpFact(Fact);
 
       return {};
     }
   }
 
-  return {fact};
+  return {Fact};
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAStartInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAStartInstFlowFunction.cpp
@@ -10,38 +10,38 @@ namespace psr {
 
 std::set<ExtendedValue>
 VAStartInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
-  std::set<ExtendedValue> targetFacts;
-  targetFacts.insert(Fact);
+  std::set<ExtendedValue> TargetFacts;
+  TargetFacts.insert(Fact);
 
-  bool isVarArgTemplateFact = Fact.isVarArgTemplate();
-  if (!isVarArgTemplateFact)
-    return targetFacts;
+  bool IsVarArgTemplateFact = Fact.isVarArgTemplate();
+  if (!IsVarArgTemplateFact)
+    return TargetFacts;
 
-  const auto vaStartInst = llvm::cast<llvm::VAStartInst>(currentInst);
-  const auto vaListMemLocationMatr = vaStartInst->getArgList();
+  const auto VaStartInst = llvm::cast<llvm::VAStartInst>(currentInst);
+  const auto VaListMemLocationMatr = VaStartInst->getArgList();
 
-  auto vaListMemLocationSeq =
-      DataFlowUtils::getMemoryLocationSeqFromMatr(vaListMemLocationMatr);
+  auto VaListMemLocationSeq =
+      DataFlowUtils::getMemoryLocationSeqFromMatr(VaListMemLocationMatr);
 
-  bool isValidMemLocationSeq = !vaListMemLocationSeq.empty();
-  if (isValidMemLocationSeq) {
-    bool isArrayDecay = DataFlowUtils::isArrayDecay(vaListMemLocationMatr);
-    if (isArrayDecay)
-      vaListMemLocationSeq.pop_back();
+  bool IsValidMemLocationSeq = !VaListMemLocationSeq.empty();
+  if (IsValidMemLocationSeq) {
+    bool IsArrayDecay = DataFlowUtils::isArrayDecay(VaListMemLocationMatr);
+    if (IsArrayDecay)
+      VaListMemLocationSeq.pop_back();
 
-    ExtendedValue ev(Fact);
-    ev.setVaListMemLocationSeq(vaListMemLocationSeq);
+    ExtendedValue EV(Fact);
+    EV.setVaListMemLocationSeq(VaListMemLocationSeq);
 
-    targetFacts.insert(ev);
+    TargetFacts.insert(EV);
 
     LOG_DEBUG("Created new VarArg from template");
     LOG_DEBUG("Template");
     DataFlowUtils::dumpFact(Fact);
     LOG_DEBUG("VarArg");
-    DataFlowUtils::dumpFact(ev);
+    DataFlowUtils::dumpFact(EV);
   }
 
-  return targetFacts;
+  return TargetFacts;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAStartInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/VAStartInstFlowFunction.cpp
@@ -9,11 +9,11 @@
 namespace psr {
 
 std::set<ExtendedValue>
-VAStartInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
+VAStartInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
   std::set<ExtendedValue> targetFacts;
-  targetFacts.insert(fact);
+  targetFacts.insert(Fact);
 
-  bool isVarArgTemplateFact = fact.isVarArgTemplate();
+  bool isVarArgTemplateFact = Fact.isVarArgTemplate();
   if (!isVarArgTemplateFact)
     return targetFacts;
 
@@ -29,14 +29,14 @@ VAStartInstFlowFunction::computeTargetsExt(ExtendedValue &fact) {
     if (isArrayDecay)
       vaListMemLocationSeq.pop_back();
 
-    ExtendedValue ev(fact);
+    ExtendedValue ev(Fact);
     ev.setVaListMemLocationSeq(vaListMemLocationSeq);
 
     targetFacts.insert(ev);
 
     LOG_DEBUG("Created new VarArg from template");
     LOG_DEBUG("Template");
-    DataFlowUtils::dumpFact(fact);
+    DataFlowUtils::dumpFact(Fact);
     LOG_DEBUG("VarArg");
     DataFlowUtils::dumpFact(ev);
   }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovRetValWriter.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovRetValWriter.cpp
@@ -7,75 +7,75 @@
 namespace psr {
 
 static void filterReturnValues(TraceStats::FileStats &FileStats) {
-  for (auto fileStatsIt = FileStats.begin(); fileStatsIt != FileStats.end();) {
-    const auto file = fileStatsIt->first;
-    auto &functionStats = fileStatsIt->second;
+  for (auto FileStatsIt = FileStats.begin(); FileStatsIt != FileStats.end();) {
+    const auto File = FileStatsIt->first;
+    auto &FunctionStats = FileStatsIt->second;
 
-    for (auto functionStatsIt = functionStats.begin();
-         functionStatsIt != functionStats.end();) {
-      const auto function = functionStatsIt->first;
-      auto &lineNumberStats = functionStatsIt->second;
+    for (auto FunctionStatsIt = FunctionStats.begin();
+         FunctionStatsIt != FunctionStats.end();) {
+      const auto Function = FunctionStatsIt->first;
+      auto &LineNumberStats = FunctionStatsIt->second;
 
-      for (auto lineNumberStatsIt = lineNumberStats.begin();
-           lineNumberStatsIt != lineNumberStats.end();) {
-        bool isLineNumberRetVal = lineNumberStatsIt->isReturnValue();
-        if (!isLineNumberRetVal) {
-          lineNumberStatsIt = lineNumberStats.erase(lineNumberStatsIt);
+      for (auto LineNumberStatsIt = LineNumberStats.begin();
+           LineNumberStatsIt != LineNumberStats.end();) {
+        bool IsLineNumberRetVal = LineNumberStatsIt->isReturnValue();
+        if (!IsLineNumberRetVal) {
+          LineNumberStatsIt = LineNumberStats.erase(LineNumberStatsIt);
         } else {
-          ++lineNumberStatsIt;
+          ++LineNumberStatsIt;
         }
       }
 
-      bool isLineNumberStatsEmpty = lineNumberStats.empty();
-      if (isLineNumberStatsEmpty) {
-        functionStatsIt = functionStats.erase(functionStatsIt);
+      bool IsLineNumberStatsEmpty = LineNumberStats.empty();
+      if (IsLineNumberStatsEmpty) {
+        FunctionStatsIt = FunctionStats.erase(FunctionStatsIt);
       } else {
-        ++functionStatsIt;
+        ++FunctionStatsIt;
       }
     }
 
-    bool isFunctionStatsEmpty = functionStats.empty();
-    if (isFunctionStatsEmpty) {
-      fileStatsIt = FileStats.erase(fileStatsIt);
+    bool IsFunctionStatsEmpty = FunctionStats.empty();
+    if (IsFunctionStatsEmpty) {
+      FileStatsIt = FileStats.erase(FileStatsIt);
     } else {
-      ++fileStatsIt;
+      ++FileStatsIt;
     }
   }
 }
 
 void LcovRetValWriter::write() const {
-  std::ofstream writer(getOutFile());
+  std::ofstream Writer(getOutFile());
 
   LOG_INFO("Writing lcov return value trace to: " << getOutFile());
 
-  TraceStats::FileStats stats = getTraceStats().getStats();
+  TraceStats::FileStats Stats = getTraceStats().getStats();
 
-  filterReturnValues(stats);
+  filterReturnValues(Stats);
 
-  for (const auto &fileEntry : stats) {
-    const auto file = fileEntry.first;
-    const auto functionStats = fileEntry.second;
+  for (const auto &FileEntry : Stats) {
+    const auto File = FileEntry.first;
+    const auto FunctionStats = FileEntry.second;
 
-    writer << "SF:" << file << "\n";
+    Writer << "SF:" << File << "\n";
 
-    for (const auto &functionEntry : functionStats) {
-      const auto function = functionEntry.first;
+    for (const auto &FunctionEntry : FunctionStats) {
+      const auto Function = FunctionEntry.first;
 
-      writer << "FNDA:"
-             << "1," << function << "\n";
+      Writer << "FNDA:"
+             << "1," << Function << "\n";
     }
 
-    for (const auto &functionEntry : functionStats) {
-      const auto lineNumberStats = functionEntry.second;
+    for (const auto &FunctionEntry : FunctionStats) {
+      const auto LineNumberStats = FunctionEntry.second;
 
-      for (const auto &lineNumberEntry : lineNumberStats) {
+      for (const auto &LineNumberEntry : LineNumberStats) {
 
-        writer << "DA:" << lineNumberEntry.getLineNumber() << ",1"
+        Writer << "DA:" << LineNumberEntry.getLineNumber() << ",1"
                << "\n";
       }
     }
 
-    writer << "end_of_record"
+    Writer << "end_of_record"
            << "\n";
   }
 }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovRetValWriter.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovRetValWriter.cpp
@@ -6,8 +6,8 @@
 
 namespace psr {
 
-static void filterReturnValues(TraceStats::FileStats &fileStats) {
-  for (auto fileStatsIt = fileStats.begin(); fileStatsIt != fileStats.end();) {
+static void filterReturnValues(TraceStats::FileStats &FileStats) {
+  for (auto fileStatsIt = FileStats.begin(); fileStatsIt != FileStats.end();) {
     const auto file = fileStatsIt->first;
     auto &functionStats = fileStatsIt->second;
 
@@ -36,7 +36,7 @@ static void filterReturnValues(TraceStats::FileStats &fileStats) {
 
     bool isFunctionStatsEmpty = functionStats.empty();
     if (isFunctionStatsEmpty) {
-      fileStatsIt = fileStats.erase(fileStatsIt);
+      fileStatsIt = FileStats.erase(fileStatsIt);
     } else {
       ++fileStatsIt;
     }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovWriter.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LcovWriter.cpp
@@ -7,34 +7,34 @@
 namespace psr {
 
 void LcovWriter::write() const {
-  std::ofstream writer(getOutFile());
+  std::ofstream Writer(getOutFile());
 
   LOG_INFO("Writing lcov trace to: " << getOutFile());
 
-  for (const auto &fileEntry : getTraceStats().getStats()) {
-    const auto file = fileEntry.first;
-    const auto functionStats = fileEntry.second;
+  for (const auto &FileEntry : getTraceStats().getStats()) {
+    const auto File = FileEntry.first;
+    const auto FunctionStats = FileEntry.second;
 
-    writer << "SF:" << file << "\n";
+    Writer << "SF:" << File << "\n";
 
-    for (const auto &functionEntry : functionStats) {
-      const auto function = functionEntry.first;
+    for (const auto &FunctionEntry : FunctionStats) {
+      const auto Function = FunctionEntry.first;
 
-      writer << "FNDA:"
-             << "1," << function << "\n";
+      Writer << "FNDA:"
+             << "1," << Function << "\n";
     }
 
-    for (const auto &functionEntry : functionStats) {
-      const auto lineNumberStats = functionEntry.second;
+    for (const auto &FunctionEntry : FunctionStats) {
+      const auto LineNumberStats = FunctionEntry.second;
 
-      for (const auto &lineNumberEntry : lineNumberStats) {
+      for (const auto &LineNumberEntry : LineNumberStats) {
 
-        writer << "DA:" << lineNumberEntry.getLineNumber() << ",1"
+        Writer << "DA:" << LineNumberEntry.getLineNumber() << ",1"
                << "\n";
       }
     }
 
-    writer << "end_of_record"
+    Writer << "end_of_record"
            << "\n";
   }
 }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LineNumberWriter.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/LineNumberWriter.cpp
@@ -7,19 +7,19 @@
 namespace psr {
 
 void LineNumberWriter::write() const {
-  std::ofstream writer(getOutFile());
+  std::ofstream Writer(getOutFile());
 
   LOG_INFO("Writing line number trace to: " << getOutFile());
 
-  for (const auto &fileEntry : getTraceStats().getStats()) {
-    const auto functionStats = fileEntry.second;
+  for (const auto &FileEntry : getTraceStats().getStats()) {
+    const auto FunctionStats = FileEntry.second;
 
-    for (const auto &functionEntry : functionStats) {
-      const auto lineNumberStats = functionEntry.second;
+    for (const auto &FunctionEntry : FunctionStats) {
+      const auto LineNumberStats = FunctionEntry.second;
 
-      for (const auto &lineNumberEntry : lineNumberStats) {
+      for (const auto &LineNumberEntry : LineNumberStats) {
 
-        writer << lineNumberEntry.getLineNumber() << "\n";
+        Writer << LineNumberEntry.getLineNumber() << "\n";
       }
     }
   }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.cpp
@@ -16,21 +16,21 @@ using namespace psr;
 
 namespace psr {
 
-IFDSIDESolverConfig::IFDSIDESolverConfig(bool followReturnsPastSeeds,
-                                         bool autoAddZero, bool computeValues,
-                                         bool recordEdges, bool emitESG,
-                                         bool computePersistedSummaries)
-    : followReturnsPastSeeds(followReturnsPastSeeds), autoAddZero(autoAddZero),
-      computeValues(computeValues), recordEdges(recordEdges), emitESG(emitESG),
-      computePersistedSummaries(computePersistedSummaries) {}
+IFDSIDESolverConfig::IFDSIDESolverConfig(bool FollowReturnsPastSeeds,
+                                         bool AutoAddZero, bool ComputeValues,
+                                         bool RecordEdges, bool EmitESG,
+                                         bool ComputePersistedSummaries)
+    : followReturnsPastSeeds(FollowReturnsPastSeeds), autoAddZero(AutoAddZero),
+      computeValues(ComputeValues), recordEdges(RecordEdges), emitESG(EmitESG),
+      computePersistedSummaries(ComputePersistedSummaries) {}
 
-ostream &operator<<(ostream &os, const IFDSIDESolverConfig &sc) {
-  return os << "IFDSIDESolverConfig:\n"
-            << "\tfollowReturnsPastSeeds: " << sc.followReturnsPastSeeds << "\n"
-            << "\tautoAddZero: " << sc.autoAddZero << "\n"
-            << "\tcomputeValues: " << sc.computeValues << "\n"
-            << "\trecordEdges: " << sc.recordEdges << "\n"
-            << "\tcomputePersistedSummaries: " << sc.computePersistedSummaries;
+ostream &operator<<(ostream &OS, const IFDSIDESolverConfig &SC) {
+  return OS << "IFDSIDESolverConfig:\n"
+            << "\tfollowReturnsPastSeeds: " << SC.followReturnsPastSeeds << "\n"
+            << "\tautoAddZero: " << SC.autoAddZero << "\n"
+            << "\tcomputeValues: " << SC.computeValues << "\n"
+            << "\trecordEdges: " << SC.recordEdges << "\n"
+            << "\tcomputePersistedSummaries: " << SC.computePersistedSummaries;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/AutoKillTMPs.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/AutoKillTMPs.cpp
@@ -24,13 +24,13 @@ AutoKillTMPs::AutoKillTMPs(
 
 std::set<const llvm::Value *>
 AutoKillTMPs::computeTargets(const llvm::Value *Source) {
-  std::set<const llvm::Value *> result = delegate->computeTargets(Source);
-  for (const llvm::Use &u : inst->operands()) {
-    if (llvm::isa<llvm::LoadInst>(u)) {
-      result.erase(u);
+  std::set<const llvm::Value *> Result = delegate->computeTargets(Source);
+  for (const llvm::Use &U : inst->operands()) {
+    if (llvm::isa<llvm::LoadInst>(U)) {
+      Result.erase(U);
     }
   }
-  return result;
+  return Result;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/AutoKillTMPs.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/AutoKillTMPs.cpp
@@ -18,13 +18,13 @@ using namespace psr;
 namespace psr {
 
 AutoKillTMPs::AutoKillTMPs(
-    std::shared_ptr<FlowFunction<const llvm::Value *>> ff,
-    const llvm::Instruction *in)
-    : delegate(ff), inst(in) {}
+    std::shared_ptr<FlowFunction<const llvm::Value *>> FF,
+    const llvm::Instruction *In)
+    : delegate(FF), inst(In) {}
 
 std::set<const llvm::Value *>
-AutoKillTMPs::computeTargets(const llvm::Value *source) {
-  std::set<const llvm::Value *> result = delegate->computeTargets(source);
+AutoKillTMPs::computeTargets(const llvm::Value *Source) {
+  std::set<const llvm::Value *> result = delegate->computeTargets(Source);
   for (const llvm::Use &u : inst->operands()) {
     if (llvm::isa<llvm::LoadInst>(u)) {
       result.erase(u);

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
@@ -22,12 +22,12 @@ using namespace psr;
 namespace psr {
 
 MapFactsToCallee::MapFactsToCallee(
-    llvm::ImmutableCallSite callSite, const llvm::Function *destFun,
-    function<bool(const llvm::Value *)> predicate)
-    : destFun(destFun), predicate(predicate) {
+    llvm::ImmutableCallSite CallSite, const llvm::Function *DestFun,
+    function<bool(const llvm::Value *)> Predicate)
+    : destFun(DestFun), predicate(Predicate) {
   // Set up the actual parameters
-  for (unsigned idx = 0; idx < callSite.getNumArgOperands(); ++idx) {
-    actuals.push_back(callSite.getArgOperand(idx));
+  for (unsigned idx = 0; idx < CallSite.getNumArgOperands(); ++idx) {
+    actuals.push_back(CallSite.getArgOperand(idx));
   }
   // Set up the formal parameters
   for (unsigned idx = 0; idx < destFun->arg_size(); ++idx) {
@@ -36,14 +36,14 @@ MapFactsToCallee::MapFactsToCallee(
 }
 
 set<const llvm::Value *>
-MapFactsToCallee::computeTargets(const llvm::Value *source) {
-  if (!LLVMZeroValue::getInstance()->isLLVMZeroValue(source)) {
+MapFactsToCallee::computeTargets(const llvm::Value *Source) {
+  if (!LLVMZeroValue::getInstance()->isLLVMZeroValue(Source)) {
     set<const llvm::Value *> res;
     // Handle C-style varargs functions
     if (destFun->isVarArg()) {
       // Map actual parameter into corresponding formal parameter.
       for (unsigned idx = 0; idx < actuals.size(); ++idx) {
-        if (source == actuals[idx] && predicate(actuals[idx])) {
+        if (Source == actuals[idx] && predicate(actuals[idx])) {
           if (idx >= destFun->arg_size() && !destFun->isDeclaration()) {
             // Over-approximate by trying to add the
             //   alloca [1 x %struct.__va_list_tag], align 16
@@ -75,14 +75,14 @@ MapFactsToCallee::computeTargets(const llvm::Value *source) {
       // Handle ordinary case
       // Map actual parameter into corresponding formal parameter.
       for (unsigned idx = 0; idx < actuals.size(); ++idx) {
-        if (source == actuals[idx] && predicate(actuals[idx])) {
+        if (Source == actuals[idx] && predicate(actuals[idx])) {
           res.insert(formals[idx]); // corresponding formal
         }
       }
       return res;
     }
   } else {
-    return {source};
+    return {Source};
   }
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions/MapFactsToCallee.cpp
@@ -26,25 +26,25 @@ MapFactsToCallee::MapFactsToCallee(
     function<bool(const llvm::Value *)> Predicate)
     : destFun(DestFun), predicate(Predicate) {
   // Set up the actual parameters
-  for (unsigned idx = 0; idx < CallSite.getNumArgOperands(); ++idx) {
-    actuals.push_back(CallSite.getArgOperand(idx));
+  for (unsigned Idx = 0; Idx < CallSite.getNumArgOperands(); ++Idx) {
+    actuals.push_back(CallSite.getArgOperand(Idx));
   }
   // Set up the formal parameters
-  for (unsigned idx = 0; idx < destFun->arg_size(); ++idx) {
-    formals.push_back(getNthFunctionArgument(destFun, idx));
+  for (unsigned Idx = 0; Idx < destFun->arg_size(); ++Idx) {
+    formals.push_back(getNthFunctionArgument(destFun, Idx));
   }
 }
 
 set<const llvm::Value *>
 MapFactsToCallee::computeTargets(const llvm::Value *Source) {
   if (!LLVMZeroValue::getInstance()->isLLVMZeroValue(Source)) {
-    set<const llvm::Value *> res;
+    set<const llvm::Value *> Res;
     // Handle C-style varargs functions
     if (destFun->isVarArg()) {
       // Map actual parameter into corresponding formal parameter.
-      for (unsigned idx = 0; idx < actuals.size(); ++idx) {
-        if (Source == actuals[idx] && predicate(actuals[idx])) {
-          if (idx >= destFun->arg_size() && !destFun->isDeclaration()) {
+      for (unsigned Idx = 0; Idx < actuals.size(); ++Idx) {
+        if (Source == actuals[Idx] && predicate(actuals[Idx])) {
+          if (Idx >= destFun->arg_size() && !destFun->isDeclaration()) {
             // Over-approximate by trying to add the
             //   alloca [1 x %struct.__va_list_tag], align 16
             // to the results
@@ -60,26 +60,26 @@ MapFactsToCallee::computeTargets(const llvm::Value *Source) {
                       Alloc->getAllocatedType()
                               ->getArrayElementType()
                               ->getStructName() == "struct.__va_list_tag") {
-                    res.insert(Alloc);
+                    Res.insert(Alloc);
                   }
                 }
               }
             }
           } else {
-            res.insert(formals[idx]); // corresponding formal
+            Res.insert(formals[Idx]); // corresponding formal
           }
         }
       }
-      return res;
+      return Res;
     } else {
       // Handle ordinary case
       // Map actual parameter into corresponding formal parameter.
-      for (unsigned idx = 0; idx < actuals.size(); ++idx) {
-        if (Source == actuals[idx] && predicate(actuals[idx])) {
-          res.insert(formals[idx]); // corresponding formal
+      for (unsigned Idx = 0; Idx < actuals.size(); ++Idx) {
+        if (Source == actuals[Idx] && predicate(actuals[Idx])) {
+          Res.insert(formals[Idx]); // corresponding formal
         }
       }
-      return res;
+      return Res;
     }
   } else {
     return {Source};

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ObservedCallingContexts.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ObservedCallingContexts.cpp
@@ -32,7 +32,7 @@ void ObservedCallingContexts::print() {
   for (auto &entry : ObservedCTX) {
     cout << entry.first << "\n";
     for (auto &ctx : entry.second) {
-      for_each(ctx.begin(), ctx.end(), [](bool b) { cout << b; });
+      for_each(ctx.begin(), ctx.end(), [](bool B) { cout << B; });
     }
   }
 }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ObservedCallingContexts.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ObservedCallingContexts.cpp
@@ -29,10 +29,10 @@ set<vector<bool>> ObservedCallingContexts::getObservedCTX(string FName) {
 }
 
 void ObservedCallingContexts::print() {
-  for (auto &entry : ObservedCTX) {
-    cout << entry.first << "\n";
-    for (auto &ctx : entry.second) {
-      for_each(ctx.begin(), ctx.end(), [](bool B) { cout << B; });
+  for (auto &Entry : ObservedCTX) {
+    cout << Entry.first << "\n";
+    for (auto &Ctx : Entry.second) {
+      for_each(Ctx.begin(), Ctx.end(), [](bool B) { cout << B; });
     }
   }
 }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.cpp
@@ -42,35 +42,35 @@ IDEProtoAnalysis::IDEProtoAnalysis(const ProjectIRDB *IRDB,
 // start formulating our analysis by specifying the parts required for IFDS
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getNormalFlowFunction(IDEProtoAnalysis::n_t curr,
-                                        IDEProtoAnalysis::n_t succ) {
+IDEProtoAnalysis::getNormalFlowFunction(IDEProtoAnalysis::n_t Curr,
+                                        IDEProtoAnalysis::n_t Succ) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getCallFlowFunction(IDEProtoAnalysis::n_t callStmt,
-                                      IDEProtoAnalysis::f_t destFun) {
+IDEProtoAnalysis::getCallFlowFunction(IDEProtoAnalysis::n_t CallStmt,
+                                      IDEProtoAnalysis::f_t DestFun) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getRetFlowFunction(IDEProtoAnalysis::n_t callSite,
-                                     IDEProtoAnalysis::f_t calleeFun,
-                                     IDEProtoAnalysis::n_t exitStmt,
-                                     IDEProtoAnalysis::n_t retSite) {
+IDEProtoAnalysis::getRetFlowFunction(IDEProtoAnalysis::n_t CallSite,
+                                     IDEProtoAnalysis::f_t CalleeFun,
+                                     IDEProtoAnalysis::n_t ExitStmt,
+                                     IDEProtoAnalysis::n_t RetSite) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getCallToRetFlowFunction(IDEProtoAnalysis::n_t callSite,
-                                           IDEProtoAnalysis::n_t retSite,
-                                           set<IDEProtoAnalysis::f_t> callees) {
+IDEProtoAnalysis::getCallToRetFlowFunction(IDEProtoAnalysis::n_t CallSite,
+                                           IDEProtoAnalysis::n_t RetSite,
+                                           set<IDEProtoAnalysis::f_t> Callees) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getSummaryFlowFunction(IDEProtoAnalysis::n_t callStmt,
-                                         IDEProtoAnalysis::f_t destFun) {
+IDEProtoAnalysis::getSummaryFlowFunction(IDEProtoAnalysis::n_t CallStmt,
+                                         IDEProtoAnalysis::f_t DestFun) {
   return nullptr;
 }
 
@@ -91,52 +91,52 @@ IDEProtoAnalysis::d_t IDEProtoAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IDEProtoAnalysis::isZeroValue(IDEProtoAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IDEProtoAnalysis::isZeroValue(IDEProtoAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 // in addition provide specifications for the IDE parts
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
-IDEProtoAnalysis::getNormalEdgeFunction(IDEProtoAnalysis::n_t curr,
-                                        IDEProtoAnalysis::d_t currNode,
-                                        IDEProtoAnalysis::n_t succ,
-                                        IDEProtoAnalysis::d_t succNode) {
+IDEProtoAnalysis::getNormalEdgeFunction(IDEProtoAnalysis::n_t Curr,
+                                        IDEProtoAnalysis::d_t CurrNode,
+                                        IDEProtoAnalysis::n_t Succ,
+                                        IDEProtoAnalysis::d_t SuccNode) {
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
-IDEProtoAnalysis::getCallEdgeFunction(IDEProtoAnalysis::n_t callStmt,
-                                      IDEProtoAnalysis::d_t srcNode,
-                                      IDEProtoAnalysis::f_t destinationFunction,
-                                      IDEProtoAnalysis::d_t destNode) {
+IDEProtoAnalysis::getCallEdgeFunction(IDEProtoAnalysis::n_t CallStmt,
+                                      IDEProtoAnalysis::d_t SrcNode,
+                                      IDEProtoAnalysis::f_t DestinationFunction,
+                                      IDEProtoAnalysis::d_t DestNode) {
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
-IDEProtoAnalysis::getReturnEdgeFunction(IDEProtoAnalysis::n_t callSite,
-                                        IDEProtoAnalysis::f_t calleeFunction,
-                                        IDEProtoAnalysis::n_t exitStmt,
-                                        IDEProtoAnalysis::d_t exitNode,
-                                        IDEProtoAnalysis::n_t reSite,
-                                        IDEProtoAnalysis::d_t retNode) {
+IDEProtoAnalysis::getReturnEdgeFunction(IDEProtoAnalysis::n_t CallSite,
+                                        IDEProtoAnalysis::f_t CalleeFunction,
+                                        IDEProtoAnalysis::n_t ExitStmt,
+                                        IDEProtoAnalysis::d_t ExitNode,
+                                        IDEProtoAnalysis::n_t ReSite,
+                                        IDEProtoAnalysis::d_t RetNode) {
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
-IDEProtoAnalysis::getCallToRetEdgeFunction(IDEProtoAnalysis::n_t callSite,
-                                           IDEProtoAnalysis::d_t callNode,
-                                           IDEProtoAnalysis::n_t retSite,
-                                           IDEProtoAnalysis::d_t retSiteNode,
-                                           set<IDEProtoAnalysis::f_t> callees) {
+IDEProtoAnalysis::getCallToRetEdgeFunction(IDEProtoAnalysis::n_t CallSite,
+                                           IDEProtoAnalysis::d_t CallNode,
+                                           IDEProtoAnalysis::n_t RetSite,
+                                           IDEProtoAnalysis::d_t RetSiteNode,
+                                           set<IDEProtoAnalysis::f_t> Callees) {
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
-IDEProtoAnalysis::getSummaryEdgeFunction(IDEProtoAnalysis::n_t callSite,
-                                         IDEProtoAnalysis::d_t callNode,
-                                         IDEProtoAnalysis::n_t retSite,
-                                         IDEProtoAnalysis::d_t retSiteNode) {
+IDEProtoAnalysis::getSummaryEdgeFunction(IDEProtoAnalysis::n_t CallSite,
+                                         IDEProtoAnalysis::d_t CallNode,
+                                         IDEProtoAnalysis::n_t RetSite,
+                                         IDEProtoAnalysis::d_t RetSiteNode) {
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
@@ -150,8 +150,8 @@ IDEProtoAnalysis::l_t IDEProtoAnalysis::bottomElement() {
   return nullptr;
 }
 
-IDEProtoAnalysis::l_t IDEProtoAnalysis::join(IDEProtoAnalysis::l_t lhs,
-                                             IDEProtoAnalysis::l_t rhs) {
+IDEProtoAnalysis::l_t IDEProtoAnalysis::join(IDEProtoAnalysis::l_t Lhs,
+                                             IDEProtoAnalysis::l_t Rhs) {
   cout << "IDEProtoAnalysis::join()\n";
   return nullptr;
 }
@@ -163,48 +163,48 @@ IDEProtoAnalysis::allTopFunction() {
 }
 
 IDEProtoAnalysis::l_t IDEProtoAnalysis::IDEProtoAnalysisAllTop::computeTarget(
-    IDEProtoAnalysis::l_t source) {
+    IDEProtoAnalysis::l_t Source) {
   cout << "IDEProtoAnalysis::IDEProtoAnalysisAllTop::computeTarget()\n";
   return nullptr;
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
 IDEProtoAnalysis::IDEProtoAnalysisAllTop::composeWith(
-    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> secondFunction) {
+    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> SecondFunction) {
   cout << "IDEProtoAnalysis::IDEProtoAnalysisAllTop::composeWith()\n";
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>>
 IDEProtoAnalysis::IDEProtoAnalysisAllTop::joinWith(
-    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> otherFunction) {
+    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> OtherFunction) {
   cout << "IDEProtoAnalysis::IDEProtoAnalysisAllTop::joinWith()\n";
   return EdgeIdentity<IDEProtoAnalysis::l_t>::getInstance();
 }
 
 bool IDEProtoAnalysis::IDEProtoAnalysisAllTop::equal_to(
-    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> other) const {
+    shared_ptr<EdgeFunction<IDEProtoAnalysis::l_t>> Other) const {
   cout << "IDEProtoAnalysis::IDEProtoAnalysisAllTop::equalTo()\n";
   return false;
 }
 
-void IDEProtoAnalysis::printNode(ostream &os, IDEProtoAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+void IDEProtoAnalysis::printNode(ostream &OS, IDEProtoAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IDEProtoAnalysis::printDataFlowFact(ostream &os,
-                                         IDEProtoAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+void IDEProtoAnalysis::printDataFlowFact(ostream &OS,
+                                         IDEProtoAnalysis::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IDEProtoAnalysis::printFunction(ostream &os,
-                                     IDEProtoAnalysis::f_t m) const {
-  os << m->getName().str();
+void IDEProtoAnalysis::printFunction(ostream &OS,
+                                     IDEProtoAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
-void IDEProtoAnalysis::printEdgeFact(ostream &os,
-                                     IDEProtoAnalysis::l_t l) const {
-  os << llvmIRToString(l);
+void IDEProtoAnalysis::printEdgeFact(ostream &OS,
+                                     IDEProtoAnalysis::l_t L) const {
+  OS << llvmIRToString(L);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.cpp
@@ -43,33 +43,33 @@ IDESolverTest::IDESolverTest(const ProjectIRDB *IRDB,
 // start formulating our analysis by specifying the parts required for IFDS
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
-IDESolverTest::getNormalFlowFunction(IDESolverTest::n_t curr,
-                                     IDESolverTest::n_t succ) {
+IDESolverTest::getNormalFlowFunction(IDESolverTest::n_t Curr,
+                                     IDESolverTest::n_t Succ) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
-IDESolverTest::getCallFlowFunction(IDESolverTest::n_t callStmt,
-                                   IDESolverTest::f_t destFun) {
+IDESolverTest::getCallFlowFunction(IDESolverTest::n_t CallStmt,
+                                   IDESolverTest::f_t DestFun) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>> IDESolverTest::getRetFlowFunction(
-    IDESolverTest::n_t callSite, IDESolverTest::f_t calleeFun,
-    IDESolverTest::n_t exitStmt, IDESolverTest::n_t retSite) {
+    IDESolverTest::n_t CallSite, IDESolverTest::f_t CalleeFun,
+    IDESolverTest::n_t ExitStmt, IDESolverTest::n_t RetSite) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
-IDESolverTest::getCallToRetFlowFunction(IDESolverTest::n_t callSite,
-                                        IDESolverTest::n_t retSite,
-                                        set<IDESolverTest::f_t> callees) {
+IDESolverTest::getCallToRetFlowFunction(IDESolverTest::n_t CallSite,
+                                        IDESolverTest::n_t RetSite,
+                                        set<IDESolverTest::f_t> Callees) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDESolverTest::d_t>>
-IDESolverTest::getSummaryFlowFunction(IDESolverTest::n_t callStmt,
-                                      IDESolverTest::f_t destFun) {
+IDESolverTest::getSummaryFlowFunction(IDESolverTest::n_t CallStmt,
+                                      IDESolverTest::f_t DestFun) {
   return nullptr;
 }
 
@@ -89,50 +89,50 @@ IDESolverTest::d_t IDESolverTest::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IDESolverTest::isZeroValue(IDESolverTest::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IDESolverTest::isZeroValue(IDESolverTest::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 // in addition provide specifications for the IDE parts
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
-IDESolverTest::getNormalEdgeFunction(IDESolverTest::n_t curr,
-                                     IDESolverTest::d_t currNode,
-                                     IDESolverTest::n_t succ,
-                                     IDESolverTest::d_t succNode) {
+IDESolverTest::getNormalEdgeFunction(IDESolverTest::n_t Curr,
+                                     IDESolverTest::d_t CurrNode,
+                                     IDESolverTest::n_t Succ,
+                                     IDESolverTest::d_t SuccNode) {
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>> IDESolverTest::getCallEdgeFunction(
-    IDESolverTest::n_t callStmt, IDESolverTest::d_t srcNode,
-    IDESolverTest::f_t destinationFunction, IDESolverTest::d_t destNode) {
+    IDESolverTest::n_t CallStmt, IDESolverTest::d_t SrcNode,
+    IDESolverTest::f_t DestinationFunction, IDESolverTest::d_t DestNode) {
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
-IDESolverTest::getReturnEdgeFunction(IDESolverTest::n_t callSite,
-                                     IDESolverTest::f_t calleeFunction,
-                                     IDESolverTest::n_t exitStmt,
-                                     IDESolverTest::d_t exitNode,
-                                     IDESolverTest::n_t reSite,
-                                     IDESolverTest::d_t retNode) {
+IDESolverTest::getReturnEdgeFunction(IDESolverTest::n_t CallSite,
+                                     IDESolverTest::f_t CalleeFunction,
+                                     IDESolverTest::n_t ExitStmt,
+                                     IDESolverTest::d_t ExitNode,
+                                     IDESolverTest::n_t ReSite,
+                                     IDESolverTest::d_t RetNode) {
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
-IDESolverTest::getCallToRetEdgeFunction(IDESolverTest::n_t callSite,
-                                        IDESolverTest::d_t callNode,
-                                        IDESolverTest::n_t retSite,
-                                        IDESolverTest::d_t retSiteNode,
-                                        set<IDESolverTest::f_t> callees) {
+IDESolverTest::getCallToRetEdgeFunction(IDESolverTest::n_t CallSite,
+                                        IDESolverTest::d_t CallNode,
+                                        IDESolverTest::n_t RetSite,
+                                        IDESolverTest::d_t RetSiteNode,
+                                        set<IDESolverTest::f_t> Callees) {
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
-IDESolverTest::getSummaryEdgeFunction(IDESolverTest::n_t callStmt,
-                                      IDESolverTest::d_t callNode,
-                                      IDESolverTest::n_t retSite,
-                                      IDESolverTest::d_t retSiteNode) {
+IDESolverTest::getSummaryEdgeFunction(IDESolverTest::n_t CallStmt,
+                                      IDESolverTest::d_t CallNode,
+                                      IDESolverTest::n_t RetSite,
+                                      IDESolverTest::d_t RetSiteNode) {
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
@@ -146,8 +146,8 @@ IDESolverTest::l_t IDESolverTest::bottomElement() {
   return nullptr;
 }
 
-IDESolverTest::l_t IDESolverTest::join(IDESolverTest::l_t lhs,
-                                       IDESolverTest::l_t rhs) {
+IDESolverTest::l_t IDESolverTest::join(IDESolverTest::l_t Lhs,
+                                       IDESolverTest::l_t Rhs) {
   cout << "IDESolverTest::join()\n";
   return nullptr;
 }
@@ -158,45 +158,45 @@ shared_ptr<EdgeFunction<IDESolverTest::l_t>> IDESolverTest::allTopFunction() {
 }
 
 IDESolverTest::l_t
-IDESolverTest::IDESolverTestAllTop::computeTarget(IDESolverTest::l_t source) {
+IDESolverTest::IDESolverTestAllTop::computeTarget(IDESolverTest::l_t Source) {
   cout << "IDESolverTest::IDESolverTestAllTop::computeTarget()\n";
   return nullptr;
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
 IDESolverTest::IDESolverTestAllTop::composeWith(
-    shared_ptr<EdgeFunction<IDESolverTest::l_t>> secondFunction) {
+    shared_ptr<EdgeFunction<IDESolverTest::l_t>> SecondFunction) {
   cout << "IDESolverTest::IDESolverTestAllTop::composeWith()\n";
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDESolverTest::l_t>>
 IDESolverTest::IDESolverTestAllTop::joinWith(
-    shared_ptr<EdgeFunction<IDESolverTest::l_t>> otherFunction) {
+    shared_ptr<EdgeFunction<IDESolverTest::l_t>> OtherFunction) {
   cout << "IDESolverTest::IDESolverTestAllTop::joinWith()\n";
   return EdgeIdentity<IDESolverTest::l_t>::getInstance();
 }
 
 bool IDESolverTest::IDESolverTestAllTop::equal_to(
-    shared_ptr<EdgeFunction<IDESolverTest::l_t>> other) const {
+    shared_ptr<EdgeFunction<IDESolverTest::l_t>> Other) const {
   cout << "IDESolverTest::IDESolverTestAllTop::equalTo()\n";
   return false;
 }
 
-void IDESolverTest::printNode(ostream &os, IDESolverTest::n_t n) const {
-  os << llvmIRToString(n);
+void IDESolverTest::printNode(ostream &OS, IDESolverTest::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IDESolverTest::printDataFlowFact(ostream &os, IDESolverTest::d_t d) const {
-  os << llvmIRToString(d);
+void IDESolverTest::printDataFlowFact(ostream &OS, IDESolverTest::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IDESolverTest::printFunction(ostream &os, IDESolverTest::f_t m) const {
-  os << m->getName().str();
+void IDESolverTest::printFunction(ostream &OS, IDESolverTest::f_t M) const {
+  OS << M->getName().str();
 }
 
-void IDESolverTest::printEdgeFact(ostream &os, IDESolverTest::l_t l) const {
-  os << "empty V test";
+void IDESolverTest::printEdgeFact(ostream &OS, IDESolverTest::l_t L) const {
+  OS << "empty V test";
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
@@ -27,7 +27,7 @@ using namespace std;
 using namespace psr;
 namespace psr {
 
-bool IDETaintAnalysis::set_contains_str(set<string> S, string Str) {
+bool IDETaintAnalysis::setContainsStr(set<string> S, string Str) {
   return S.find(Str) != S.end();
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
@@ -27,7 +27,7 @@ using namespace std;
 using namespace psr;
 namespace psr {
 
-bool IDETaintAnalysis::setContainsStr(set<string> S, string Str) {
+bool IDETaintAnalysis::set_contains_str(set<string> S, string Str) {
   return S.find(Str) != S.end();
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
@@ -27,8 +27,8 @@ using namespace std;
 using namespace psr;
 namespace psr {
 
-bool IDETaintAnalysis::set_contains_str(set<string> s, string str) {
-  return s.find(str) != s.end();
+bool IDETaintAnalysis::set_contains_str(set<string> S, string Str) {
+  return S.find(Str) != S.end();
 }
 
 IDETaintAnalysis::IDETaintAnalysis(const ProjectIRDB *IRDB,
@@ -43,35 +43,35 @@ IDETaintAnalysis::IDETaintAnalysis(const ProjectIRDB *IRDB,
 // start formulating our analysis by specifying the parts required for IFDS
 
 shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getNormalFlowFunction(IDETaintAnalysis::n_t curr,
-                                        IDETaintAnalysis::n_t succ) {
+IDETaintAnalysis::getNormalFlowFunction(IDETaintAnalysis::n_t Curr,
+                                        IDETaintAnalysis::n_t Succ) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getCallFlowFunction(IDETaintAnalysis::n_t callStmt,
-                                      IDETaintAnalysis::f_t destFun) {
+IDETaintAnalysis::getCallFlowFunction(IDETaintAnalysis::n_t CallStmt,
+                                      IDETaintAnalysis::f_t DestFun) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getRetFlowFunction(IDETaintAnalysis::n_t callSite,
-                                     IDETaintAnalysis::f_t calleeFun,
-                                     IDETaintAnalysis::n_t exitStmt,
-                                     IDETaintAnalysis::n_t retSite) {
+IDETaintAnalysis::getRetFlowFunction(IDETaintAnalysis::n_t CallSite,
+                                     IDETaintAnalysis::f_t CalleeFun,
+                                     IDETaintAnalysis::n_t ExitStmt,
+                                     IDETaintAnalysis::n_t RetSite) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getCallToRetFlowFunction(IDETaintAnalysis::n_t callSite,
-                                           IDETaintAnalysis::n_t retSite,
-                                           set<IDETaintAnalysis::f_t> callees) {
+IDETaintAnalysis::getCallToRetFlowFunction(IDETaintAnalysis::n_t CallSite,
+                                           IDETaintAnalysis::n_t RetSite,
+                                           set<IDETaintAnalysis::f_t> Callees) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getSummaryFlowFunction(IDETaintAnalysis::n_t callStmt,
-                                         IDETaintAnalysis::f_t destFun) {
+IDETaintAnalysis::getSummaryFlowFunction(IDETaintAnalysis::n_t CallStmt,
+                                         IDETaintAnalysis::f_t DestFun) {
   return nullptr;
 }
 
@@ -91,52 +91,52 @@ IDETaintAnalysis::d_t IDETaintAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IDETaintAnalysis::isZeroValue(IDETaintAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IDETaintAnalysis::isZeroValue(IDETaintAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 // in addition provide specifications for the IDE parts
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
-IDETaintAnalysis::getNormalEdgeFunction(IDETaintAnalysis::n_t curr,
-                                        IDETaintAnalysis::d_t currNode,
-                                        IDETaintAnalysis::n_t succ,
-                                        IDETaintAnalysis::d_t succNode) {
+IDETaintAnalysis::getNormalEdgeFunction(IDETaintAnalysis::n_t Curr,
+                                        IDETaintAnalysis::d_t CurrNode,
+                                        IDETaintAnalysis::n_t Succ,
+                                        IDETaintAnalysis::d_t SuccNode) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
-IDETaintAnalysis::getCallEdgeFunction(IDETaintAnalysis::n_t callStmt,
-                                      IDETaintAnalysis::d_t srcNode,
-                                      IDETaintAnalysis::f_t destinationFunction,
-                                      IDETaintAnalysis::d_t destNode) {
+IDETaintAnalysis::getCallEdgeFunction(IDETaintAnalysis::n_t CallStmt,
+                                      IDETaintAnalysis::d_t SrcNode,
+                                      IDETaintAnalysis::f_t DestinationFunction,
+                                      IDETaintAnalysis::d_t DestNode) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
-IDETaintAnalysis::getReturnEdgeFunction(IDETaintAnalysis::n_t callSite,
-                                        IDETaintAnalysis::f_t calleeFunction,
-                                        IDETaintAnalysis::n_t exitStmt,
-                                        IDETaintAnalysis::d_t exitNode,
-                                        IDETaintAnalysis::n_t reSite,
-                                        IDETaintAnalysis::d_t retNode) {
+IDETaintAnalysis::getReturnEdgeFunction(IDETaintAnalysis::n_t CallSite,
+                                        IDETaintAnalysis::f_t CalleeFunction,
+                                        IDETaintAnalysis::n_t ExitStmt,
+                                        IDETaintAnalysis::d_t ExitNode,
+                                        IDETaintAnalysis::n_t ReSite,
+                                        IDETaintAnalysis::d_t RetNode) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
-IDETaintAnalysis::getCallToRetEdgeFunction(IDETaintAnalysis::n_t callSite,
-                                           IDETaintAnalysis::d_t callNode,
-                                           IDETaintAnalysis::n_t retSite,
-                                           IDETaintAnalysis::d_t retSiteNode,
-                                           set<IDETaintAnalysis::f_t> callees) {
+IDETaintAnalysis::getCallToRetEdgeFunction(IDETaintAnalysis::n_t CallSite,
+                                           IDETaintAnalysis::d_t CallNode,
+                                           IDETaintAnalysis::n_t RetSite,
+                                           IDETaintAnalysis::d_t RetSiteNode,
+                                           set<IDETaintAnalysis::f_t> Callees) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
-IDETaintAnalysis::getSummaryEdgeFunction(IDETaintAnalysis::n_t callStmt,
-                                         IDETaintAnalysis::d_t callNode,
-                                         IDETaintAnalysis::n_t retSite,
-                                         IDETaintAnalysis::d_t retSiteNode) {
+IDETaintAnalysis::getSummaryEdgeFunction(IDETaintAnalysis::n_t CallStmt,
+                                         IDETaintAnalysis::d_t CallNode,
+                                         IDETaintAnalysis::n_t RetSite,
+                                         IDETaintAnalysis::d_t RetSiteNode) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
@@ -144,8 +144,8 @@ IDETaintAnalysis::l_t IDETaintAnalysis::topElement() { return nullptr; }
 
 IDETaintAnalysis::l_t IDETaintAnalysis::bottomElement() { return nullptr; }
 
-IDETaintAnalysis::l_t IDETaintAnalysis::join(IDETaintAnalysis::l_t lhs,
-                                             IDETaintAnalysis::l_t rhs) {
+IDETaintAnalysis::l_t IDETaintAnalysis::join(IDETaintAnalysis::l_t Lhs,
+                                             IDETaintAnalysis::l_t Rhs) {
   return nullptr;
 }
 
@@ -155,44 +155,44 @@ IDETaintAnalysis::allTopFunction() {
 }
 
 IDETaintAnalysis::l_t IDETaintAnalysis::IDETainAnalysisAllTop::computeTarget(
-    IDETaintAnalysis::l_t source) {
+    IDETaintAnalysis::l_t Source) {
   return nullptr;
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
 IDETaintAnalysis::IDETainAnalysisAllTop::composeWith(
-    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> secondFunction) {
+    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> SecondFunction) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>>
 IDETaintAnalysis::IDETainAnalysisAllTop::joinWith(
-    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> otherFunction) {
+    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> OtherFunction) {
   return EdgeIdentity<IDETaintAnalysis::l_t>::getInstance();
 }
 
 bool IDETaintAnalysis::IDETainAnalysisAllTop::equal_to(
-    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> other) const {
+    shared_ptr<EdgeFunction<IDETaintAnalysis::l_t>> Other) const {
   return false;
 }
 
-void IDETaintAnalysis::printNode(ostream &os, IDETaintAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+void IDETaintAnalysis::printNode(ostream &OS, IDETaintAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IDETaintAnalysis::printDataFlowFact(ostream &os,
-                                         IDETaintAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+void IDETaintAnalysis::printDataFlowFact(ostream &OS,
+                                         IDETaintAnalysis::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IDETaintAnalysis::printFunction(ostream &os,
-                                     IDETaintAnalysis::f_t m) const {
-  os << m->getName().str();
+void IDETaintAnalysis::printFunction(ostream &OS,
+                                     IDETaintAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
-void IDETaintAnalysis::printEdgeFact(ostream &os,
-                                     IDETaintAnalysis::l_t v) const {
-  os << llvmIRToString(v);
+void IDETaintAnalysis::printEdgeFact(ostream &OS,
+                                     IDETaintAnalysis::l_t V) const {
+  OS << llvmIRToString(V);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -132,7 +132,7 @@ IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallStmt,
                                           IDETypeStateAnalysis::f_t DestFun) {
   // Kill all data-flow facts if we hit a function of the target API.
   // Those functions are modled within Call-To-Return.
-  if (TSD.isAPIFunction(cxxDemangle(DestFun->getName().str()))) {
+  if (TSD.isAPIFunction(cxx_demangle(DestFun->getName().str()))) {
     return KillAll<IDETypeStateAnalysis::d_t>::getInstance();
   }
   // Otherwise, if we have an ordinary function call, we can just use the
@@ -244,7 +244,7 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
     set<IDETypeStateAnalysis::f_t> Callees) {
   const llvm::ImmutableCallSite CS(CallSite);
   for (auto Callee : Callees) {
-    std::string DemangledFname = cxxDemangle(Callee->getName().str());
+    std::string DemangledFname = cxx_demangle(Callee->getName().str());
     // Generate the return value of factory functions from zero value
     if (TSD.isFactoryFunction(DemangledFname)) {
       struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
@@ -374,7 +374,7 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
   auto &LG = lg::get();
   const llvm::ImmutableCallSite CS(CallSite);
   for (auto Callee : Callees) {
-    std::string DemangledFname = cxxDemangle(Callee->getName().str());
+    std::string DemangledFname = cxx_demangle(Callee->getName().str());
 
     // For now we assume that we can only generate from the return value.
     // We apply the same edge function for the return value, i.e. callsite.

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -56,11 +56,11 @@ IDETypeStateAnalysis::IDETypeStateAnalysis(const ProjectIRDB *IRDB,
 // Start formulating our analysis by specifying the parts required for IFDS
 
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
-IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
-                                            IDETypeStateAnalysis::n_t succ) {
+IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t Curr,
+                                            IDETypeStateAnalysis::n_t Succ) {
   // Check if Alloca's type matches the target type. If so, generate from zero
   // value.
-  if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
+  if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
     if (hasMatchingType(Alloca)) {
       return make_shared<Gen<IDETypeStateAnalysis::d_t>>(Alloca,
                                                          getZeroValue());
@@ -68,7 +68,7 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
   }
   // Check load instructions for target type. Generate from the loaded value and
   // kill the load instruction if it was generated previously (strong update!).
-  if (auto Load = llvm::dyn_cast<llvm::LoadInst>(curr)) {
+  if (auto Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
     if (hasMatchingType(Load)) {
       struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
         const llvm::LoadInst *Load;
@@ -76,14 +76,14 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
         TSFlowFunction(const llvm::LoadInst *L) : Load(L) {}
         ~TSFlowFunction() override = default;
         set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t source) override {
-          if (source == Load) {
+        computeTargets(IDETypeStateAnalysis::d_t Source) override {
+          if (Source == Load) {
             return {};
           }
-          if (source == Load->getPointerOperand()) {
-            return {source, Load};
+          if (Source == Load->getPointerOperand()) {
+            return {Source, Load};
           }
-          return {source};
+          return {Source};
         }
       };
       return make_shared<TSFlowFunction>(Load);
@@ -92,11 +92,11 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
   // Check store instructions for target type. Perform a strong update, i.e.
   // kill the alloca pointed to by the pointer-operand and all alloca's related
   // to the value-operand and then generate them from the value-operand.
-  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
+  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
     if (hasMatchingType(Store)) {
       auto RelevantAliasesAndAllocas = getLocalAliasesAndAllocas(
           Store->getValueOperand(),
-          curr->getParent()->getParent()->getName().str());
+          Curr->getParent()->getParent()->getName().str());
 
       struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
         const llvm::StoreInst *Store;
@@ -106,19 +106,19 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
             : Store(S), AliasesAndAllocas(AA) {}
         ~TSFlowFunction() override = default;
         set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t source) override {
+        computeTargets(IDETypeStateAnalysis::d_t Source) override {
           // We kill all relevant loacal aliases and alloca's
-          if (source != Store->getValueOperand() &&
-              AliasesAndAllocas.find(source) != AliasesAndAllocas.end()) {
+          if (Source != Store->getValueOperand() &&
+              AliasesAndAllocas.find(Source) != AliasesAndAllocas.end()) {
             return {};
           }
           // Generate all local aliases and relevant alloca's from the stored
           // value
-          if (source == Store->getValueOperand()) {
-            AliasesAndAllocas.insert(source);
+          if (Source == Store->getValueOperand()) {
+            AliasesAndAllocas.insert(Source);
             return AliasesAndAllocas;
           }
-          return {source};
+          return {Source};
         }
       };
       return make_shared<TSFlowFunction>(Store, RelevantAliasesAndAllocas);
@@ -128,28 +128,28 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t curr,
 }
 
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
-IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t callStmt,
-                                          IDETypeStateAnalysis::f_t destFun) {
+IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallStmt,
+                                          IDETypeStateAnalysis::f_t DestFun) {
   // Kill all data-flow facts if we hit a function of the target API.
   // Those functions are modled within Call-To-Return.
-  if (TSD.isAPIFunction(cxx_demangle(destFun->getName().str()))) {
+  if (TSD.isAPIFunction(cxx_demangle(DestFun->getName().str()))) {
     return KillAll<IDETypeStateAnalysis::d_t>::getInstance();
   }
   // Otherwise, if we have an ordinary function call, we can just use the
   // standard mapping.
-  if (llvm::isa<llvm::CallInst>(callStmt) ||
-      llvm::isa<llvm::InvokeInst>(callStmt)) {
-    return make_shared<MapFactsToCallee>(llvm::ImmutableCallSite(callStmt),
-                                         destFun);
+  if (llvm::isa<llvm::CallInst>(CallStmt) ||
+      llvm::isa<llvm::InvokeInst>(CallStmt)) {
+    return make_shared<MapFactsToCallee>(llvm::ImmutableCallSite(CallStmt),
+                                         DestFun);
   }
   assert(false && "callStmt not a CallInst nor a InvokeInst");
 }
 
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
-IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
-                                         IDETypeStateAnalysis::f_t calleeFun,
-                                         IDETypeStateAnalysis::n_t exitStmt,
-                                         IDETypeStateAnalysis::n_t retSite) {
+IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t CallSite,
+                                         IDETypeStateAnalysis::f_t CalleeFun,
+                                         IDETypeStateAnalysis::n_t ExitStmt,
+                                         IDETypeStateAnalysis::n_t RetSite) {
   // Besides mapping the formal parameter back into the actual parameter and
   // propagating the return value into the caller context, we also propagate
   // all related alloca's of the formal parameter and the return value.
@@ -160,27 +160,27 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
     IDETypeStateAnalysis *Analysis;
     std::vector<const llvm::Value *> Actuals;
     std::vector<const llvm::Value *> Formals;
-    TSFlowFunction(llvm::ImmutableCallSite cs, const llvm::Function *calleeFun,
-                   const llvm::Instruction *exitstmt,
-                   IDETypeStateAnalysis *analysis)
-        : CallSite(cs), CalleeFun(calleeFun),
-          ExitStmt(llvm::dyn_cast<llvm::ReturnInst>(exitstmt)),
-          Analysis(analysis) {
+    TSFlowFunction(llvm::ImmutableCallSite CS, const llvm::Function *CalleeFun,
+                   const llvm::Instruction *ExitStmt,
+                   IDETypeStateAnalysis *Analysis)
+        : CallSite(CS), CalleeFun(CalleeFun),
+          ExitStmt(llvm::dyn_cast<llvm::ReturnInst>(ExitStmt)),
+          Analysis(Analysis) {
       // Set up the actual parameters
       for (unsigned idx = 0; idx < CallSite.getNumArgOperands(); ++idx) {
         Actuals.push_back(CallSite.getArgOperand(idx));
       }
       // Set up the formal parameters
-      for (unsigned idx = 0; idx < calleeFun->arg_size(); ++idx) {
-        Formals.push_back(getNthFunctionArgument(calleeFun, idx));
+      for (unsigned idx = 0; idx < CalleeFun->arg_size(); ++idx) {
+        Formals.push_back(getNthFunctionArgument(CalleeFun, idx));
       }
     }
 
     ~TSFlowFunction() override = default;
 
     set<IDETypeStateAnalysis::d_t>
-    computeTargets(IDETypeStateAnalysis::d_t source) override {
-      if (!LLVMZeroValue::getInstance()->isLLVMZeroValue(source)) {
+    computeTargets(IDETypeStateAnalysis::d_t Source) override {
+      if (!LLVMZeroValue::getInstance()->isLLVMZeroValue(Source)) {
         set<const llvm::Value *> res;
         // Handle C-style varargs functions
         if (CalleeFun->isVarArg() && !CalleeFun->isDeclaration()) {
@@ -204,7 +204,7 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
             }
           }
           // Generate the varargs things by using an over-approximation
-          if (source == AllocVarArg) {
+          if (Source == AllocVarArg) {
             for (unsigned idx = Formals.size(); idx < Actuals.size(); ++idx) {
               res.insert(Actuals[idx]);
             }
@@ -213,12 +213,12 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
         // Handle ordinary case
         // Map formal parameter into corresponding actual parameter.
         for (unsigned idx = 0; idx < Formals.size(); ++idx) {
-          if (source == Formals[idx]) {
+          if (Source == Formals[idx]) {
             res.insert(Actuals[idx]); // corresponding actual
           }
         }
         // Collect the return value
-        if (source == ExitStmt->getReturnValue()) {
+        if (Source == ExitStmt->getReturnValue()) {
           res.insert(CallSite.getInstruction());
         }
         // Collect all relevant alloca's to map into caller context
@@ -230,20 +230,20 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t callSite,
         res.insert(RelAllocas.begin(), RelAllocas.end());
         return res;
       } else {
-        return {source};
+        return {Source};
       }
     }
   };
-  return make_shared<TSFlowFunction>(llvm::ImmutableCallSite(callSite),
-                                     calleeFun, exitStmt, this);
+  return make_shared<TSFlowFunction>(llvm::ImmutableCallSite(CallSite),
+                                     CalleeFun, ExitStmt, this);
 }
 
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getCallToRetFlowFunction(
-    IDETypeStateAnalysis::n_t callSite, IDETypeStateAnalysis::n_t retSite,
-    set<IDETypeStateAnalysis::f_t> callees) {
-  const llvm::ImmutableCallSite CS(callSite);
-  for (auto Callee : callees) {
+    IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::n_t RetSite,
+    set<IDETypeStateAnalysis::f_t> Callees) {
+  const llvm::ImmutableCallSite CS(CallSite);
+  for (auto Callee : Callees) {
     std::string demangledFname = cxx_demangle(Callee->getName().str());
     // Generate the return value of factory functions from zero value
     if (TSD.isFactoryFunction(demangledFname)) {
@@ -255,17 +255,17 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
             : CallSite(CS), ZeroValue(Z) {}
         ~TSFlowFunction() override = default;
         set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t source) override {
-          if (source == CallSite) {
+        computeTargets(IDETypeStateAnalysis::d_t Source) override {
+          if (Source == CallSite) {
             return {};
           }
-          if (source == ZeroValue) {
-            return {source, CallSite};
+          if (Source == ZeroValue) {
+            return {Source, CallSite};
           }
-          return {source};
+          return {Source};
         }
       };
-      return make_shared<TSFlowFunction>(callSite, getZeroValue());
+      return make_shared<TSFlowFunction>(CallSite, getZeroValue());
     }
 
     // Handle all functions that are not modeld with special semantics.
@@ -294,7 +294,7 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
 
 shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
 IDETypeStateAnalysis::getSummaryFlowFunction(
-    IDETypeStateAnalysis::n_t callStmt, IDETypeStateAnalysis::f_t destFun) {
+    IDETypeStateAnalysis::n_t CallStmt, IDETypeStateAnalysis::f_t DestFun) {
   return nullptr;
 }
 
@@ -314,31 +314,31 @@ IDETypeStateAnalysis::d_t IDETypeStateAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IDETypeStateAnalysis::isZeroValue(IDETypeStateAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IDETypeStateAnalysis::isZeroValue(IDETypeStateAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 // in addition provide specifications for the IDE parts
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::getNormalEdgeFunction(
-    IDETypeStateAnalysis::n_t curr, IDETypeStateAnalysis::d_t currNode,
-    IDETypeStateAnalysis::n_t succ, IDETypeStateAnalysis::d_t succNode) {
+    IDETypeStateAnalysis::n_t Curr, IDETypeStateAnalysis::d_t CurrNode,
+    IDETypeStateAnalysis::n_t Succ, IDETypeStateAnalysis::d_t SuccNode) {
   // Set alloca instructions of target type to uninitialized.
-  if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
+  if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
     if (hasMatchingType(Alloca)) {
-      if (currNode == getZeroValue() && succNode == Alloca) {
+      if (CurrNode == getZeroValue() && SuccNode == Alloca) {
         struct TSAllocaEF : public TSEdgeFunction {
-          TSAllocaEF(const TypeStateDescription &tsd, const std::string &tok)
-              : TSEdgeFunction(tsd, tok) {}
+          TSAllocaEF(const TypeStateDescription &Tsd, const std::string &Tok)
+              : TSEdgeFunction(Tsd, Tok) {}
 
           IDETypeStateAnalysis::l_t
-          computeTarget(IDETypeStateAnalysis::l_t source) override {
+          computeTarget(IDETypeStateAnalysis::l_t Source) override {
             CurrentState = TSD.uninit();
             return CurrentState;
           }
 
-          void print(std::ostream &OS, bool isForDebug = false) const override {
+          void print(std::ostream &OS, bool IsForDebug = false) const override {
             OS << "Alloca(" << TSD.stateToString(CurrentState) << ")";
           }
         };
@@ -351,47 +351,47 @@ IDETypeStateAnalysis::getNormalEdgeFunction(
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::getCallEdgeFunction(
-    IDETypeStateAnalysis::n_t callStmt, IDETypeStateAnalysis::d_t srcNode,
-    IDETypeStateAnalysis::f_t destinationFunction,
-    IDETypeStateAnalysis::d_t destNode) {
+    IDETypeStateAnalysis::n_t CallStmt, IDETypeStateAnalysis::d_t SrcNode,
+    IDETypeStateAnalysis::f_t DestinationFunction,
+    IDETypeStateAnalysis::d_t DestNode) {
   return EdgeIdentity<IDETypeStateAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::getReturnEdgeFunction(
-    IDETypeStateAnalysis::n_t callSite,
-    IDETypeStateAnalysis::f_t calleeFunction,
-    IDETypeStateAnalysis::n_t exitStmt, IDETypeStateAnalysis::d_t exitNode,
-    IDETypeStateAnalysis::n_t reSite, IDETypeStateAnalysis::d_t retNode) {
+    IDETypeStateAnalysis::n_t CallSite,
+    IDETypeStateAnalysis::f_t CalleeFunction,
+    IDETypeStateAnalysis::n_t ExitStmt, IDETypeStateAnalysis::d_t ExitNode,
+    IDETypeStateAnalysis::n_t ReSite, IDETypeStateAnalysis::d_t RetNode) {
   return EdgeIdentity<IDETypeStateAnalysis::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::getCallToRetEdgeFunction(
-    IDETypeStateAnalysis::n_t callSite, IDETypeStateAnalysis::d_t callNode,
-    IDETypeStateAnalysis::n_t retSite, IDETypeStateAnalysis::d_t retSiteNode,
-    std::set<IDETypeStateAnalysis::f_t> callees) {
+    IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::d_t CallNode,
+    IDETypeStateAnalysis::n_t RetSite, IDETypeStateAnalysis::d_t RetSiteNode,
+    std::set<IDETypeStateAnalysis::f_t> Callees) {
   auto &lg = lg::get();
-  const llvm::ImmutableCallSite CS(callSite);
-  for (auto Callee : callees) {
+  const llvm::ImmutableCallSite CS(CallSite);
+  for (auto Callee : Callees) {
     std::string demangledFname = cxx_demangle(Callee->getName().str());
 
     // For now we assume that we can only generate from the return value.
     // We apply the same edge function for the return value, i.e. callsite.
     if (TSD.isFactoryFunction(demangledFname)) {
       LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Processing factory function");
-      if (isZeroValue(callNode) && retSiteNode == CS.getInstruction()) {
+      if (isZeroValue(CallNode) && RetSiteNode == CS.getInstruction()) {
         struct TSFactoryEF : public TSEdgeFunction {
-          TSFactoryEF(const TypeStateDescription &tsd, const std::string &tok)
-              : TSEdgeFunction(tsd, tok) {}
+          TSFactoryEF(const TypeStateDescription &Tsd, const std::string &Tok)
+              : TSEdgeFunction(Tsd, Tok) {}
 
           IDETypeStateAnalysis::l_t
-          computeTarget(IDETypeStateAnalysis::l_t source) override {
+          computeTarget(IDETypeStateAnalysis::l_t Source) override {
             CurrentState = TSD.start();
             return CurrentState;
           }
 
-          void print(std::ostream &OS, bool isForDebug = false) const override {
+          void print(std::ostream &OS, bool IsForDebug = false) const override {
             OS << "Factory(" << TSD.stateToString(CurrentState) << ")";
           }
         };
@@ -408,8 +408,8 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
         std::set<IDETypeStateAnalysis::d_t> PointsToAndAllocas =
             getWMAliasesAndAllocas(CS.getArgument(Idx));
 
-        if (callNode == retSiteNode &&
-            PointsToAndAllocas.find(callNode) != PointsToAndAllocas.end()) {
+        if (CallNode == RetSiteNode &&
+            PointsToAndAllocas.find(CallNode) != PointsToAndAllocas.end()) {
           return make_shared<TSEdgeFunction>(TSD, demangledFname);
         }
       }
@@ -420,8 +420,8 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::getSummaryEdgeFunction(
-    IDETypeStateAnalysis::n_t callStmt, IDETypeStateAnalysis::d_t callNode,
-    IDETypeStateAnalysis::n_t retSite, IDETypeStateAnalysis::d_t retSiteNode) {
+    IDETypeStateAnalysis::n_t CallStmt, IDETypeStateAnalysis::d_t CallNode,
+    IDETypeStateAnalysis::n_t RetSite, IDETypeStateAnalysis::d_t RetSiteNode) {
   return nullptr;
 }
 
@@ -432,14 +432,14 @@ IDETypeStateAnalysis::l_t IDETypeStateAnalysis::bottomElement() {
 }
 
 IDETypeStateAnalysis::l_t
-IDETypeStateAnalysis::join(IDETypeStateAnalysis::l_t lhs,
-                           IDETypeStateAnalysis::l_t rhs) {
-  if (lhs == TOP && rhs != BOTTOM) {
-    return rhs;
-  } else if (rhs == TOP && lhs != BOTTOM) {
-    return lhs;
-  } else if (lhs == rhs) {
-    return lhs;
+IDETypeStateAnalysis::join(IDETypeStateAnalysis::l_t Lhs,
+                           IDETypeStateAnalysis::l_t Rhs) {
+  if (Lhs == TOP && Rhs != BOTTOM) {
+    return Rhs;
+  } else if (Rhs == TOP && Lhs != BOTTOM) {
+    return Lhs;
+  } else if (Lhs == Rhs) {
+    return Lhs;
   } else {
     return BOTTOM;
   }
@@ -450,69 +450,69 @@ IDETypeStateAnalysis::allTopFunction() {
   return make_shared<AllTop<IDETypeStateAnalysis::l_t>>(TOP);
 }
 
-void IDETypeStateAnalysis::printNode(std::ostream &os, n_t n) const {
-  os << llvmIRToString(n);
+void IDETypeStateAnalysis::printNode(std::ostream &OS, n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IDETypeStateAnalysis::printDataFlowFact(std::ostream &os, d_t d) const {
-  os << llvmIRToString(d);
+void IDETypeStateAnalysis::printDataFlowFact(std::ostream &OS, d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IDETypeStateAnalysis::printFunction(ostream &os,
-                                         IDETypeStateAnalysis::f_t m) const {
-  os << m->getName().str();
+void IDETypeStateAnalysis::printFunction(ostream &OS,
+                                         IDETypeStateAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
-void IDETypeStateAnalysis::printEdgeFact(ostream &os,
-                                         IDETypeStateAnalysis::l_t l) const {
-  os << TSD.stateToString(l);
+void IDETypeStateAnalysis::printEdgeFact(ostream &OS,
+                                         IDETypeStateAnalysis::l_t L) const {
+  OS << TSD.stateToString(L);
 }
 
 shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::TSEdgeFunctionComposer::joinWith(
-    shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> otherFunction) {
-  if (otherFunction.get() == this ||
-      otherFunction->equal_to(this->shared_from_this())) {
+    shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> OtherFunction) {
+  if (OtherFunction.get() == this ||
+      OtherFunction->equal_to(this->shared_from_this())) {
     return this->shared_from_this();
   }
   if (auto *AT = dynamic_cast<AllTop<IDETypeStateAnalysis::l_t> *>(
-          otherFunction.get())) {
+          OtherFunction.get())) {
     return this->shared_from_this();
   }
   return make_shared<AllBottom<IDETypeStateAnalysis::l_t>>(botElement);
 }
 
 IDETypeStateAnalysis::l_t IDETypeStateAnalysis::TSEdgeFunction::computeTarget(
-    IDETypeStateAnalysis::l_t source) {
+    IDETypeStateAnalysis::l_t Source) {
   auto &lg = lg::get();
-  CurrentState = TSD.getNextState(Token, source);
+  CurrentState = TSD.getNextState(Token, Source);
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
                 << "State machine transition: (" << Token << " , "
-                << TSD.stateToString(source) << ") -> "
+                << TSD.stateToString(Source) << ") -> "
                 << TSD.stateToString(CurrentState));
   return CurrentState;
 }
 
 std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::TSEdgeFunction::composeWith(
-    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> secondFunction) {
+    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> SecondFunction) {
   if (auto *AB = dynamic_cast<AllBottom<IDETypeStateAnalysis::l_t> *>(
-          secondFunction.get())) {
+          SecondFunction.get())) {
     return this->shared_from_this();
   }
   if (auto *EI = dynamic_cast<EdgeIdentity<IDETypeStateAnalysis::l_t> *>(
-          secondFunction.get())) {
+          SecondFunction.get())) {
     return this->shared_from_this();
   }
   return make_shared<TSEdgeFunctionComposer>(this->shared_from_this(),
-                                             secondFunction, TSD.bottom());
+                                             SecondFunction, TSD.bottom());
 }
 
 std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>>
 IDETypeStateAnalysis::TSEdgeFunction::joinWith(
-    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> otherFunction) {
-  if (otherFunction.get() == this ||
-      otherFunction->equal_to(this->shared_from_this())) {
+    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> OtherFunction) {
+  if (OtherFunction.get() == this ||
+      OtherFunction->equal_to(this->shared_from_this())) {
     return this->shared_from_this();
   }
   // if (auto *EI = dynamic_cast<EdgeIdentity<IDETypeStateAnalysis::l_t> *>(
@@ -520,23 +520,23 @@ IDETypeStateAnalysis::TSEdgeFunction::joinWith(
   //   return this->shared_from_this();
   // }
   if (auto *AT = dynamic_cast<AllTop<IDETypeStateAnalysis::l_t> *>(
-          otherFunction.get())) {
+          OtherFunction.get())) {
     return this->shared_from_this();
   }
   return make_shared<AllBottom<IDETypeStateAnalysis::l_t>>(TSD.bottom());
 }
 
 bool IDETypeStateAnalysis::TSEdgeFunction::equal_to(
-    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> other) const {
+    std::shared_ptr<EdgeFunction<IDETypeStateAnalysis::l_t>> Other) const {
   if (auto *TSEF =
-          dynamic_cast<IDETypeStateAnalysis::TSEdgeFunction *>(other.get())) {
+          dynamic_cast<IDETypeStateAnalysis::TSEdgeFunction *>(Other.get())) {
     return this->CurrentState == TSEF->CurrentState;
   }
-  return this == other.get();
+  return this == Other.get();
 }
 
 void IDETypeStateAnalysis::TSEdgeFunction::print(ostream &OS,
-                                                 bool isForDebug) const {
+                                                 bool IsForDebug) const {
   OS << "TSEF(" << TSD.stateToString(CurrentState) << ")";
 }
 
@@ -688,32 +688,32 @@ bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
 void IDETypeStateAnalysis::emitTextReport(
     const SolverResults<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
                         IDETypeStateAnalysis::l_t> &SR,
-    std::ostream &os) {
-  os << "\n======= TYPE STATE RESULTS =======\n";
+    std::ostream &OS) {
+  OS << "\n======= TYPE STATE RESULTS =======\n";
   for (auto &f : ICF->getAllFunctions()) {
-    os << '\n' << getFunctionNameFromIR(f) << '\n';
+    OS << '\n' << getFunctionNameFromIR(f) << '\n';
     for (auto &BB : *f) {
       for (auto &I : BB) {
         auto results = SR.resultsAt(&I, true);
         if (ICF->isExitStmt(&I)) {
-          os << "\nAt exit stmt: " << NtoString(&I) << '\n';
+          OS << "\nAt exit stmt: " << NtoString(&I) << '\n';
           for (auto res : results) {
             if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(res.first)) {
               if (res.second == TSD.error()) {
-                os << "\n=== ERROR STATE DETECTED ===\nAlloca: "
+                OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
                    << DtoString(res.first) << '\n';
                 for (auto Pred : ICF->getPredsOf(&I)) {
-                  os << "\nPredecessor: " << NtoString(Pred) << '\n';
+                  OS << "\nPredecessor: " << NtoString(Pred) << '\n';
                   auto PredResults = SR.resultsAt(Pred, true);
                   for (auto Res : PredResults) {
                     if (Res.first == Alloca) {
-                      os << "Pred State: " << LtoString(Res.second) << '\n';
+                      OS << "Pred State: " << LtoString(Res.second) << '\n';
                     }
                   }
                 }
-                os << "============================\n";
+                OS << "============================\n";
               } else {
-                os << "\nAlloca : " << DtoString(res.first)
+                OS << "\nAlloca : " << DtoString(res.first)
                    << "\nState  : " << LtoString(res.second) << '\n';
               }
             }
@@ -722,26 +722,26 @@ void IDETypeStateAnalysis::emitTextReport(
           for (auto res : results) {
             if (auto Alloca = llvm::dyn_cast<llvm::AllocaInst>(res.first)) {
               if (res.second == TSD.error()) {
-                os << "\n=== ERROR STATE DETECTED ===\nAlloca: "
+                OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
                    << DtoString(res.first) << '\n'
                    << "\nAt IR Inst: " << NtoString(&I) << '\n';
                 for (auto Pred : ICF->getPredsOf(&I)) {
-                  os << "\nPredecessor: " << NtoString(Pred) << '\n';
+                  OS << "\nPredecessor: " << NtoString(Pred) << '\n';
                   auto PredResults = SR.resultsAt(Pred, true);
                   for (auto Res : PredResults) {
                     if (Res.first == Alloca) {
-                      os << "Pred State: " << LtoString(Res.second) << '\n';
+                      OS << "Pred State: " << LtoString(Res.second) << '\n';
                     }
                   }
                 }
-                os << "============================\n";
+                OS << "============================\n";
               }
             }
           }
         }
       }
     }
-    os << "\n--------------------------------------------\n";
+    OS << "\n--------------------------------------------\n";
   }
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -132,7 +132,7 @@ IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallStmt,
                                           IDETypeStateAnalysis::f_t DestFun) {
   // Kill all data-flow facts if we hit a function of the target API.
   // Those functions are modled within Call-To-Return.
-  if (TSD.isAPIFunction(cxx_demangle(DestFun->getName().str()))) {
+  if (TSD.isAPIFunction(cxxDemangle(DestFun->getName().str()))) {
     return KillAll<IDETypeStateAnalysis::d_t>::getInstance();
   }
   // Otherwise, if we have an ordinary function call, we can just use the
@@ -244,7 +244,7 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
     set<IDETypeStateAnalysis::f_t> Callees) {
   const llvm::ImmutableCallSite CS(CallSite);
   for (auto Callee : Callees) {
-    std::string DemangledFname = cxx_demangle(Callee->getName().str());
+    std::string DemangledFname = cxxDemangle(Callee->getName().str());
     // Generate the return value of factory functions from zero value
     if (TSD.isFactoryFunction(DemangledFname)) {
       struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
@@ -374,7 +374,7 @@ IDETypeStateAnalysis::getCallToRetEdgeFunction(
   auto &LG = lg::get();
   const llvm::ImmutableCallSite CS(CallSite);
   for (auto Callee : Callees) {
-    std::string DemangledFname = cxx_demangle(Callee->getName().str());
+    std::string DemangledFname = cxxDemangle(Callee->getName().str());
 
     // For now we assume that we can only generate from the return value.
     // We apply the same edge function for the return value, i.e. callsite.

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -76,7 +76,7 @@ IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t Curr,
         if (auto VTable =
                 llvm::dyn_cast<llvm::GlobalVariable>(CFInst->getOperand(0))) {
           if (VTable->hasName() &&
-              cxxDemangle(VTable->getName().str()).find("vtable") !=
+              cxx_demangle(VTable->getName().str()).find("vtable") !=
                   string::npos) {
             LOG_IF_ENABLE(
                 BOOST_LOG_SEV(LG, DEBUG)

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -76,7 +76,7 @@ IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t Curr,
         if (auto VTable =
                 llvm::dyn_cast<llvm::GlobalVariable>(CFInst->getOperand(0))) {
           if (VTable->hasName() &&
-              cxx_demangle(VTable->getName().str()).find("vtable") !=
+              cxxDemangle(VTable->getName().str()).find("vtable") !=
                   string::npos) {
             LOG_IF_ENABLE(
                 BOOST_LOG_SEV(LG, DEBUG)

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
@@ -144,15 +144,15 @@ IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
-  const auto destFunName = DestFun->getName();
+  const auto DestFunName = DestFun->getName();
 
   /*
    * We exclude function ptr calls as they will be applied to every
    * function matching its signature (@see LLVMBasedICFG.cpp:217).
    */
-  const auto callInst = llvm::cast<llvm::CallInst>(CallStmt);
-  bool isStaticCallSite = callInst->getCalledFunction();
-  if (!isStaticCallSite)
+  const auto CallInst = llvm::cast<llvm::CallInst>(CallStmt);
+  bool IsStaticCallSite = CallInst->getCalledFunction();
+  if (!IsStaticCallSite)
     return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
@@ -160,7 +160,7 @@ IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
    * Exclude blacklisted functions here.
    */
 
-  if (taintConfig.isSink(destFunName))
+  if (taintConfig.isSink(DestFunName))
     return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
@@ -186,15 +186,15 @@ IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
   /*
    * Provide summary for tainted functions.
    */
-  if (taintConfig.isSource(destFunName))
+  if (taintConfig.isSource(DestFunName))
     return std::make_shared<GenerateFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
   /*
    * Skip all (other) declarations.
    */
-  bool isDeclaration = DestFun->isDeclaration();
-  if (isDeclaration)
+  bool IsDeclaration = DestFun->isDeclaration();
+  if (IsDeclaration)
     return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
@@ -206,20 +206,20 @@ IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
 
 std::map<const llvm::Instruction *, std::set<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::initialSeeds() {
-  std::map<const llvm::Instruction *, std::set<ExtendedValue>> seedMap;
-  for (const auto &entryPoint : this->EntryPoints) {
-    if (taintConfig.isSink(entryPoint))
+  std::map<const llvm::Instruction *, std::set<ExtendedValue>> SeedMap;
+  for (const auto &EntryPoint : this->EntryPoints) {
+    if (taintConfig.isSink(EntryPoint))
       continue;
-    seedMap.insert(
-        std::make_pair(&ICF->getFunction(entryPoint)->front().front(),
+    SeedMap.insert(
+        std::make_pair(&ICF->getFunction(EntryPoint)->front().front(),
                        std::set<ExtendedValue>({getZeroValue()})));
   }
   // additionally, add initial seeds if there are any
-  auto taintConfigSeeds = taintConfig.getInitialSeeds();
-  for (auto &seed : taintConfigSeeds) {
-    seedMap[seed.first].insert(seed.second.begin(), seed.second.end());
+  auto TaintConfigSeeds = taintConfig.getInitialSeeds();
+  for (auto &Seed : TaintConfigSeeds) {
+    SeedMap[Seed.first].insert(Seed.second.begin(), Seed.second.end());
   }
-  return seedMap;
+  return SeedMap;
 }
 
 void IFDSFieldSensTaintAnalysis::emitTextReport(
@@ -227,24 +227,24 @@ void IFDSFieldSensTaintAnalysis::emitTextReport(
         &SolverResults,
     std::ostream &OS) {
   std::string FirstEntryPoints = *EntryPoints.begin();
-  const std::string lcovTraceFile =
+  const std::string LcovTraceFile =
       DataFlowUtils::getTraceFilenamePrefix(FirstEntryPoints + "-trace.txt");
-  const std::string lcovRetValTraceFile = DataFlowUtils::getTraceFilenamePrefix(
+  const std::string LcovRetValTraceFile = DataFlowUtils::getTraceFilenamePrefix(
       FirstEntryPoints + "-return-value-trace.txt");
 
 #ifdef DEBUG_BUILD
   // Write line number trace (for tests only)
   LineNumberWriter lineNumberWriter(traceStats, "line-numbers.txt");
-  lineNumberWriter.write();
+  LineNumberWriter.write();
 #endif
 
   // Write lcov trace
-  LcovWriter lcovWriter(traceStats, lcovTraceFile);
-  lcovWriter.write();
+  LcovWriter LcovWriter(traceStats, LcovTraceFile);
+  LcovWriter.write();
 
   // Write lcov return value trace
-  LcovRetValWriter lcovRetValWriter(traceStats, lcovRetValTraceFile);
-  lcovRetValWriter.write();
+  LcovRetValWriter LcovRetValWriter(traceStats, LcovRetValTraceFile);
+  LcovRetValWriter.write();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
@@ -48,60 +48,60 @@ IFDSFieldSensTaintAnalysis::IFDSFieldSensTaintAnalysis(
 
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getNormalFlowFunction(
-    const llvm::Instruction *currentInst,
-    const llvm::Instruction *successorInst) {
-  if (taintConfig.isSource(currentInst)) {
+    const llvm::Instruction *CurrentInst,
+    const llvm::Instruction *SuccessorInst) {
+  if (taintConfig.isSource(CurrentInst)) {
     // TODO: generate current inst wrapped in an ExtendedValue
   }
 
-  if (taintConfig.isSink(currentInst)) {
+  if (taintConfig.isSink(CurrentInst)) {
     // TODO: report leak as done for the functions
   }
 
-  if (DataFlowUtils::isReturnValue(currentInst, successorInst))
-    return std::make_shared<ReturnInstFlowFunction>(successorInst, traceStats,
+  if (DataFlowUtils::isReturnValue(CurrentInst, SuccessorInst))
+    return std::make_shared<ReturnInstFlowFunction>(SuccessorInst, traceStats,
                                                     getZeroValue());
 
-  if (llvm::isa<llvm::StoreInst>(currentInst))
-    return std::make_shared<StoreInstFlowFunction>(currentInst, traceStats,
+  if (llvm::isa<llvm::StoreInst>(CurrentInst))
+    return std::make_shared<StoreInstFlowFunction>(CurrentInst, traceStats,
                                                    getZeroValue());
 
-  if (llvm::isa<llvm::BranchInst>(currentInst) ||
-      llvm::isa<llvm::SwitchInst>(currentInst))
+  if (llvm::isa<llvm::BranchInst>(CurrentInst) ||
+      llvm::isa<llvm::SwitchInst>(CurrentInst))
     return std::make_shared<BranchSwitchInstFlowFunction>(
-        currentInst, traceStats, getZeroValue());
+        CurrentInst, traceStats, getZeroValue());
 
-  if (llvm::isa<llvm::GetElementPtrInst>(currentInst))
-    return std::make_shared<GEPInstFlowFunction>(currentInst, traceStats,
+  if (llvm::isa<llvm::GetElementPtrInst>(CurrentInst))
+    return std::make_shared<GEPInstFlowFunction>(CurrentInst, traceStats,
                                                  getZeroValue());
 
-  if (llvm::isa<llvm::PHINode>(currentInst))
-    return std::make_shared<PHINodeFlowFunction>(currentInst, traceStats,
+  if (llvm::isa<llvm::PHINode>(CurrentInst))
+    return std::make_shared<PHINodeFlowFunction>(CurrentInst, traceStats,
                                                  getZeroValue());
 
-  if (DataFlowUtils::isCheckOperandsInst(currentInst))
-    return std::make_shared<CheckOperandsFlowFunction>(currentInst, traceStats,
+  if (DataFlowUtils::isCheckOperandsInst(CurrentInst))
+    return std::make_shared<CheckOperandsFlowFunction>(CurrentInst, traceStats,
                                                        getZeroValue());
 
-  return std::make_shared<IdentityFlowFunction>(currentInst, traceStats,
+  return std::make_shared<IdentityFlowFunction>(CurrentInst, traceStats,
                                                 getZeroValue());
 }
 
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getCallFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return std::make_shared<MapTaintedValuesToCallee>(
-      llvm::cast<llvm::CallInst>(callStmt), destFun, traceStats,
+      llvm::cast<llvm::CallInst>(CallStmt), DestFun, traceStats,
       getZeroValue());
 }
 
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Function *calleeFun,
-    const llvm::Instruction *exitStmt, const llvm::Instruction *retSite) {
+    const llvm::Instruction *CallSite, const llvm::Function *CalleeFun,
+    const llvm::Instruction *ExitStmt, const llvm::Instruction *RetSite) {
   return std::make_shared<MapTaintedValuesToCaller>(
-      llvm::cast<llvm::CallInst>(callSite),
-      llvm::cast<llvm::ReturnInst>(exitStmt), traceStats, getZeroValue());
+      llvm::cast<llvm::CallInst>(CallSite),
+      llvm::cast<llvm::ReturnInst>(ExitStmt), traceStats, getZeroValue());
 }
 
 /*
@@ -112,8 +112,8 @@ IFDSFieldSensTaintAnalysis::getRetFlowFunction(
  */
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Instruction *retSite,
-    std::set<const llvm::Function *> callees) {
+    const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
+    std::set<const llvm::Function *> Callees) {
   /*
    * It is important to wrap the identity call here. Consider the following
    * example:
@@ -132,7 +132,7 @@ IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
    * instruction will be pushed when the flow function is called with the branch
    * instruction fact.
    */
-  return std::make_shared<CallToRetFlowFunction>(callSite, traceStats,
+  return std::make_shared<CallToRetFlowFunction>(CallSite, traceStats,
                                                  getZeroValue());
 }
 
@@ -143,17 +143,17 @@ IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
  */
 std::shared_ptr<FlowFunction<ExtendedValue>>
 IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
-  const auto destFunName = destFun->getName();
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
+  const auto destFunName = DestFun->getName();
 
   /*
    * We exclude function ptr calls as they will be applied to every
    * function matching its signature (@see LLVMBasedICFG.cpp:217).
    */
-  const auto callInst = llvm::cast<llvm::CallInst>(callStmt);
+  const auto callInst = llvm::cast<llvm::CallInst>(CallStmt);
   bool isStaticCallSite = callInst->getCalledFunction();
   if (!isStaticCallSite)
-    return std::make_shared<IdentityFlowFunction>(callStmt, traceStats,
+    return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
   /*
@@ -161,41 +161,41 @@ IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
    */
 
   if (taintConfig.isSink(destFunName))
-    return std::make_shared<IdentityFlowFunction>(callStmt, traceStats,
+    return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
   /*
    * Intrinsics.
    */
-  if (llvm::isa<llvm::MemTransferInst>(callStmt))
-    return std::make_shared<MemTransferInstFlowFunction>(callStmt, traceStats,
+  if (llvm::isa<llvm::MemTransferInst>(CallStmt))
+    return std::make_shared<MemTransferInstFlowFunction>(CallStmt, traceStats,
                                                          getZeroValue());
 
-  if (llvm::isa<llvm::MemSetInst>(callStmt))
-    return std::make_shared<MemSetInstFlowFunction>(callStmt, traceStats,
+  if (llvm::isa<llvm::MemSetInst>(CallStmt))
+    return std::make_shared<MemSetInstFlowFunction>(CallStmt, traceStats,
                                                     getZeroValue());
 
-  if (llvm::isa<llvm::VAStartInst>(callStmt))
-    return std::make_shared<VAStartInstFlowFunction>(callStmt, traceStats,
+  if (llvm::isa<llvm::VAStartInst>(CallStmt))
+    return std::make_shared<VAStartInstFlowFunction>(CallStmt, traceStats,
                                                      getZeroValue());
 
-  if (llvm::isa<llvm::VAEndInst>(callStmt))
-    return std::make_shared<VAEndInstFlowFunction>(callStmt, traceStats,
+  if (llvm::isa<llvm::VAEndInst>(CallStmt))
+    return std::make_shared<VAEndInstFlowFunction>(CallStmt, traceStats,
                                                    getZeroValue());
 
   /*
    * Provide summary for tainted functions.
    */
   if (taintConfig.isSource(destFunName))
-    return std::make_shared<GenerateFlowFunction>(callStmt, traceStats,
+    return std::make_shared<GenerateFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
   /*
    * Skip all (other) declarations.
    */
-  bool isDeclaration = destFun->isDeclaration();
+  bool isDeclaration = DestFun->isDeclaration();
   if (isDeclaration)
-    return std::make_shared<IdentityFlowFunction>(callStmt, traceStats,
+    return std::make_shared<IdentityFlowFunction>(CallStmt, traceStats,
                                                   getZeroValue());
 
   /*
@@ -224,8 +224,8 @@ IFDSFieldSensTaintAnalysis::initialSeeds() {
 
 void IFDSFieldSensTaintAnalysis::emitTextReport(
     const SolverResults<const llvm::Instruction *, ExtendedValue, BinaryDomain>
-        &solverResults,
-    std::ostream &os) {
+        &SolverResults,
+    std::ostream &OS) {
   std::string FirstEntryPoints = *EntryPoints.begin();
   const std::string lcovTraceFile =
       DataFlowUtils::getTraceFilenamePrefix(FirstEntryPoints + "-trace.txt");

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
@@ -95,8 +95,8 @@ IFDSLinearConstantAnalysis::getSummaryFlowFunction(
 
 map<IFDSLinearConstantAnalysis::n_t, set<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::initialSeeds() {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "IFDSLinearConstantAnalysis::initialSeeds()");
   map<IFDSLinearConstantAnalysis::n_t, set<IFDSLinearConstantAnalysis::d_t>>
       SeedMap;
@@ -110,8 +110,8 @@ IFDSLinearConstantAnalysis::initialSeeds() {
 
 IFDSLinearConstantAnalysis::d_t
 IFDSLinearConstantAnalysis::createZeroValue() const {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "IFDSLinearConstantAnalysis::createZeroValue()");
   // create a special value to represent the zero value!
   return LCAPair(LLVMZeroValue::getInstance(), 0);

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
@@ -25,26 +25,26 @@
 using namespace std;
 using namespace psr;
 
-size_t hash<LCAPair>::operator()(const LCAPair &k) const {
-  return hash<const llvm::Value *>()(k.first) ^ hash<int>()(k.second);
+size_t hash<LCAPair>::operator()(const LCAPair &K) const {
+  return hash<const llvm::Value *>()(K.first) ^ hash<int>()(K.second);
 }
 
 namespace psr {
 
 LCAPair::LCAPair() : first(nullptr), second(0) {}
 
-LCAPair::LCAPair(const llvm::Value *V, int i) : first(V), second(i) {}
+LCAPair::LCAPair(const llvm::Value *V, int I) : first(V), second(I) {}
 
-bool operator==(const LCAPair &lhs, const LCAPair &rhs) {
-  return tie(lhs.first, lhs.second) == tie(rhs.first, rhs.second);
+bool operator==(const LCAPair &Lhs, const LCAPair &Rhs) {
+  return tie(Lhs.first, Lhs.second) == tie(Rhs.first, Rhs.second);
 }
 
-bool operator!=(const LCAPair &lhs, const LCAPair &rhs) {
-  return !(lhs == rhs);
+bool operator!=(const LCAPair &Lhs, const LCAPair &Rhs) {
+  return !(Lhs == Rhs);
 }
 
-bool operator<(const LCAPair &lhs, const LCAPair &rhs) {
-  return tie(lhs.first, lhs.second) < tie(rhs.first, rhs.second);
+bool operator<(const LCAPair &Lhs, const LCAPair &Rhs) {
+  return tie(Lhs.first, Lhs.second) < tie(Rhs.first, Rhs.second);
 }
 
 IFDSLinearConstantAnalysis::IFDSLinearConstantAnalysis(
@@ -57,39 +57,39 @@ IFDSLinearConstantAnalysis::IFDSLinearConstantAnalysis(
 
 shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getNormalFlowFunction(
-    IFDSLinearConstantAnalysis::n_t curr,
-    IFDSLinearConstantAnalysis::n_t succ) {
+    IFDSLinearConstantAnalysis::n_t Curr,
+    IFDSLinearConstantAnalysis::n_t Succ) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getCallFlowFunction(
-    IFDSLinearConstantAnalysis::n_t callStmt,
-    IFDSLinearConstantAnalysis::f_t destFun) {
+    IFDSLinearConstantAnalysis::n_t CallStmt,
+    IFDSLinearConstantAnalysis::f_t DestFun) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getRetFlowFunction(
-    IFDSLinearConstantAnalysis::n_t callSite,
-    IFDSLinearConstantAnalysis::f_t calleeFun,
-    IFDSLinearConstantAnalysis::n_t exitStmt,
-    IFDSLinearConstantAnalysis::n_t retSite) {
+    IFDSLinearConstantAnalysis::n_t CallSite,
+    IFDSLinearConstantAnalysis::f_t CalleeFun,
+    IFDSLinearConstantAnalysis::n_t ExitStmt,
+    IFDSLinearConstantAnalysis::n_t RetSite) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getCallToRetFlowFunction(
-    IFDSLinearConstantAnalysis::n_t callSite,
-    IFDSLinearConstantAnalysis::n_t retSite,
-    set<IFDSLinearConstantAnalysis::f_t> callees) {
+    IFDSLinearConstantAnalysis::n_t CallSite,
+    IFDSLinearConstantAnalysis::n_t RetSite,
+    set<IFDSLinearConstantAnalysis::f_t> Callees) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
 IFDSLinearConstantAnalysis::getSummaryFlowFunction(
-    IFDSLinearConstantAnalysis::n_t callStmt,
-    IFDSLinearConstantAnalysis::f_t destFun) {
+    IFDSLinearConstantAnalysis::n_t CallStmt,
+    IFDSLinearConstantAnalysis::f_t DestFun) {
   return nullptr;
 }
 
@@ -118,23 +118,23 @@ IFDSLinearConstantAnalysis::createZeroValue() const {
 }
 
 bool IFDSLinearConstantAnalysis::isZeroValue(
-    IFDSLinearConstantAnalysis::d_t d) const {
-  return d == ZeroValue;
+    IFDSLinearConstantAnalysis::d_t D) const {
+  return D == ZeroValue;
 }
 
 void IFDSLinearConstantAnalysis::printNode(
-    ostream &os, IFDSLinearConstantAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+    ostream &OS, IFDSLinearConstantAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
 void IFDSLinearConstantAnalysis::printDataFlowFact(
-    ostream &os, IFDSLinearConstantAnalysis::d_t d) const {
-  os << '<' + llvmIRToString(d.first) + ", " + std::to_string(d.second) + '>';
+    ostream &OS, IFDSLinearConstantAnalysis::d_t D) const {
+  OS << '<' + llvmIRToString(D.first) + ", " + std::to_string(D.second) + '>';
 }
 
 void IFDSLinearConstantAnalysis::printFunction(
-    ostream &os, IFDSLinearConstantAnalysis::f_t m) const {
-  os << m->getName().str();
+    ostream &OS, IFDSLinearConstantAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.cpp
@@ -37,9 +37,9 @@ IFDSProtoAnalysis::IFDSProtoAnalysis(const ProjectIRDB *IRDB,
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
-IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t curr,
-                                         IFDSProtoAnalysis::n_t succ) {
-  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
+IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t Curr,
+                                         IFDSProtoAnalysis::n_t Succ) {
+  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
     return make_shared<Gen<IFDSProtoAnalysis::d_t>>(Store->getPointerOperand(),
                                                     getZeroValue());
   }
@@ -47,29 +47,29 @@ IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t curr,
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
-IFDSProtoAnalysis::getCallFlowFunction(IFDSProtoAnalysis::n_t callStmt,
-                                       IFDSProtoAnalysis::f_t destFun) {
+IFDSProtoAnalysis::getCallFlowFunction(IFDSProtoAnalysis::n_t CallStmt,
+                                       IFDSProtoAnalysis::f_t DestFun) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
-IFDSProtoAnalysis::getRetFlowFunction(IFDSProtoAnalysis::n_t callSite,
-                                      IFDSProtoAnalysis::f_t calleeFun,
-                                      IFDSProtoAnalysis::n_t exitStmt,
-                                      IFDSProtoAnalysis::n_t retSite) {
+IFDSProtoAnalysis::getRetFlowFunction(IFDSProtoAnalysis::n_t CallSite,
+                                      IFDSProtoAnalysis::f_t CalleeFun,
+                                      IFDSProtoAnalysis::n_t ExitStmt,
+                                      IFDSProtoAnalysis::n_t RetSite) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
 IFDSProtoAnalysis::getCallToRetFlowFunction(
-    IFDSProtoAnalysis::n_t callSite, IFDSProtoAnalysis::n_t retSite,
-    set<IFDSProtoAnalysis::f_t> callees) {
+    IFDSProtoAnalysis::n_t CallSite, IFDSProtoAnalysis::n_t RetSite,
+    set<IFDSProtoAnalysis::f_t> Callees) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
-IFDSProtoAnalysis::getSummaryFlowFunction(IFDSProtoAnalysis::n_t callStmt,
-                                          IFDSProtoAnalysis::f_t destFun) {
+IFDSProtoAnalysis::getSummaryFlowFunction(IFDSProtoAnalysis::n_t CallStmt,
+                                          IFDSProtoAnalysis::f_t DestFun) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
@@ -89,22 +89,22 @@ IFDSProtoAnalysis::d_t IFDSProtoAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IFDSProtoAnalysis::isZeroValue(IFDSProtoAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IFDSProtoAnalysis::isZeroValue(IFDSProtoAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
-void IFDSProtoAnalysis::printNode(ostream &os, IFDSProtoAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+void IFDSProtoAnalysis::printNode(ostream &OS, IFDSProtoAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IFDSProtoAnalysis::printDataFlowFact(ostream &os,
-                                          IFDSProtoAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+void IFDSProtoAnalysis::printDataFlowFact(ostream &OS,
+                                          IFDSProtoAnalysis::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IFDSProtoAnalysis::printFunction(ostream &os,
-                                      IFDSProtoAnalysis::f_t m) const {
-  os << m->getName().str();
+void IFDSProtoAnalysis::printFunction(ostream &OS,
+                                      IFDSProtoAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.cpp
@@ -36,35 +36,35 @@ IFDSSignAnalysis::IFDSSignAnalysis(const ProjectIRDB *IRDB,
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getNormalFlowFunction(IFDSSignAnalysis::n_t curr,
-                                        IFDSSignAnalysis::n_t succ) {
+IFDSSignAnalysis::getNormalFlowFunction(IFDSSignAnalysis::n_t Curr,
+                                        IFDSSignAnalysis::n_t Succ) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getCallFlowFunction(IFDSSignAnalysis::n_t callStmt,
-                                      IFDSSignAnalysis::f_t destFun) {
+IFDSSignAnalysis::getCallFlowFunction(IFDSSignAnalysis::n_t CallStmt,
+                                      IFDSSignAnalysis::f_t DestFun) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getRetFlowFunction(IFDSSignAnalysis::n_t callSite,
-                                     IFDSSignAnalysis::f_t calleeFun,
-                                     IFDSSignAnalysis::n_t exitStmt,
-                                     IFDSSignAnalysis::n_t retSite) {
+IFDSSignAnalysis::getRetFlowFunction(IFDSSignAnalysis::n_t CallSite,
+                                     IFDSSignAnalysis::f_t CalleeFun,
+                                     IFDSSignAnalysis::n_t ExitStmt,
+                                     IFDSSignAnalysis::n_t RetSite) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getCallToRetFlowFunction(IFDSSignAnalysis::n_t callSite,
-                                           IFDSSignAnalysis::n_t retSite,
-                                           set<IFDSSignAnalysis::f_t> callees) {
+IFDSSignAnalysis::getCallToRetFlowFunction(IFDSSignAnalysis::n_t CallSite,
+                                           IFDSSignAnalysis::n_t RetSite,
+                                           set<IFDSSignAnalysis::f_t> Callees) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getSummaryFlowFunction(IFDSSignAnalysis::n_t callStmt,
-                                         IFDSSignAnalysis::f_t destFun) {
+IFDSSignAnalysis::getSummaryFlowFunction(IFDSSignAnalysis::n_t CallStmt,
+                                         IFDSSignAnalysis::f_t DestFun) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
@@ -84,22 +84,22 @@ IFDSSignAnalysis::d_t IFDSSignAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IFDSSignAnalysis::isZeroValue(IFDSSignAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IFDSSignAnalysis::isZeroValue(IFDSSignAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
-void IFDSSignAnalysis::printNode(ostream &os, IFDSSignAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+void IFDSSignAnalysis::printNode(ostream &OS, IFDSSignAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IFDSSignAnalysis::printDataFlowFact(ostream &os,
-                                         IFDSSignAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+void IFDSSignAnalysis::printDataFlowFact(ostream &OS,
+                                         IFDSSignAnalysis::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IFDSSignAnalysis::printFunction(ostream &os,
-                                     IFDSSignAnalysis::f_t m) const {
-  os << m->getName().str();
+void IFDSSignAnalysis::printFunction(ostream &OS,
+                                     IFDSSignAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -70,8 +70,8 @@ IFDSSolverTest::getSummaryFlowFunction(IFDSSolverTest::n_t CallStmt,
 
 map<IFDSSolverTest::n_t, set<IFDSSolverTest::d_t>>
 IFDSSolverTest::initialSeeds() {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "IFDSSolverTest::initialSeeds()");
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "IFDSSolverTest::initialSeeds()");
   map<IFDSSolverTest::n_t, set<IFDSSolverTest::d_t>> SeedMap;
   for (auto &EntryPoint : EntryPoints) {
     SeedMap.insert(make_pair(&ICF->getFunction(EntryPoint)->front().front(),

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -36,35 +36,35 @@ IFDSSolverTest::IFDSSolverTest(const ProjectIRDB *IRDB,
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getNormalFlowFunction(IFDSSolverTest::n_t curr,
-                                      IFDSSolverTest::n_t succ) {
+IFDSSolverTest::getNormalFlowFunction(IFDSSolverTest::n_t Curr,
+                                      IFDSSolverTest::n_t Succ) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getCallFlowFunction(IFDSSolverTest::n_t callStmt,
-                                    IFDSSolverTest::f_t destFun) {
+IFDSSolverTest::getCallFlowFunction(IFDSSolverTest::n_t CallStmt,
+                                    IFDSSolverTest::f_t DestFun) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getRetFlowFunction(IFDSSolverTest::n_t callSite,
-                                   IFDSSolverTest::f_t calleeFun,
-                                   IFDSSolverTest::n_t exitStmt,
-                                   IFDSSolverTest::n_t retSite) {
+IFDSSolverTest::getRetFlowFunction(IFDSSolverTest::n_t CallSite,
+                                   IFDSSolverTest::f_t CalleeFun,
+                                   IFDSSolverTest::n_t ExitStmt,
+                                   IFDSSolverTest::n_t RetSite) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getCallToRetFlowFunction(IFDSSolverTest::n_t callSite,
-                                         IFDSSolverTest::n_t retSite,
-                                         set<IFDSSolverTest::f_t> callees) {
+IFDSSolverTest::getCallToRetFlowFunction(IFDSSolverTest::n_t CallSite,
+                                         IFDSSolverTest::n_t RetSite,
+                                         set<IFDSSolverTest::f_t> Callees) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getSummaryFlowFunction(IFDSSolverTest::n_t callStmt,
-                                       IFDSSolverTest::f_t destFun) {
+IFDSSolverTest::getSummaryFlowFunction(IFDSSolverTest::n_t CallStmt,
+                                       IFDSSolverTest::f_t DestFun) {
   return nullptr;
 }
 
@@ -85,21 +85,21 @@ IFDSSolverTest::d_t IFDSSolverTest::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IFDSSolverTest::isZeroValue(IFDSSolverTest::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IFDSSolverTest::isZeroValue(IFDSSolverTest::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
-void IFDSSolverTest::printNode(ostream &os, IFDSSolverTest::n_t n) const {
-  os << llvmIRToString(n);
+void IFDSSolverTest::printNode(ostream &OS, IFDSSolverTest::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IFDSSolverTest::printDataFlowFact(ostream &os,
-                                       IFDSSolverTest::d_t d) const {
-  os << llvmIRToString(d);
+void IFDSSolverTest::printDataFlowFact(ostream &OS,
+                                       IFDSSolverTest::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IFDSSolverTest::printFunction(ostream &os, IFDSSolverTest::f_t m) const {
-  os << m->getName().str();
+void IFDSSolverTest::printFunction(ostream &OS, IFDSSolverTest::f_t M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -90,7 +90,7 @@ IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t Curr,
 shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
 IFDSTaintAnalysis::getCallFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                        IFDSTaintAnalysis::f_t DestFun) {
-  string FunctionName = cxxDemangle(DestFun->getName().str());
+  string FunctionName = cxx_demangle(DestFun->getName().str());
   // Check if a source or sink function is called:
   // We then can kill all data-flow facts not following the called function.
   // The respective taints or leaks are then generated in the corresponding
@@ -132,7 +132,7 @@ IFDSTaintAnalysis::getCallToRetFlowFunction(
   auto &LG = lg::get();
   // Process the effects of source or sink functions that are called
   for (auto *Callee : ICF->getCalleesOfCallAt(CallSite)) {
-    string FunctionName = cxxDemangle(Callee->getName().str());
+    string FunctionName = cxx_demangle(Callee->getName().str());
     LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "F:" << Callee->getName().str());
     LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "demangled F:" << FunctionName);
     if (SourceSinkFunctions.isSource(FunctionName)) {
@@ -225,7 +225,7 @@ IFDSTaintAnalysis::getSummaryFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                           IFDSTaintAnalysis::f_t DestFun) {
   SpecialSummaries<IFDSTaintAnalysis::d_t> &SS =
       SpecialSummaries<IFDSTaintAnalysis::d_t>::getInstance();
-  string FunctionName = cxxDemangle(DestFun->getName().str());
+  string FunctionName = cxx_demangle(DestFun->getName().str());
   // If we have a special summary, which is neither a source function, nor
   // a sink function, then we provide it to the solver.
   if (SS.containsSpecialSummary(FunctionName) &&

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -90,7 +90,7 @@ IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t Curr,
 shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
 IFDSTaintAnalysis::getCallFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                        IFDSTaintAnalysis::f_t DestFun) {
-  string FunctionName = cxx_demangle(DestFun->getName().str());
+  string FunctionName = cxxDemangle(DestFun->getName().str());
   // Check if a source or sink function is called:
   // We then can kill all data-flow facts not following the called function.
   // The respective taints or leaks are then generated in the corresponding
@@ -132,7 +132,7 @@ IFDSTaintAnalysis::getCallToRetFlowFunction(
   auto &LG = lg::get();
   // Process the effects of source or sink functions that are called
   for (auto *Callee : ICF->getCalleesOfCallAt(CallSite)) {
-    string FunctionName = cxx_demangle(Callee->getName().str());
+    string FunctionName = cxxDemangle(Callee->getName().str());
     LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "F:" << Callee->getName().str());
     LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "demangled F:" << FunctionName);
     if (SourceSinkFunctions.isSource(FunctionName)) {
@@ -225,7 +225,7 @@ IFDSTaintAnalysis::getSummaryFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                           IFDSTaintAnalysis::f_t DestFun) {
   SpecialSummaries<IFDSTaintAnalysis::d_t> &SS =
       SpecialSummaries<IFDSTaintAnalysis::d_t>::getInstance();
-  string FunctionName = cxx_demangle(DestFun->getName().str());
+  string FunctionName = cxxDemangle(DestFun->getName().str());
   // If we have a special summary, which is neither a source function, nor
   // a sink function, then we provide it to the solver.
   if (SS.containsSpecialSummary(FunctionName) &&

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -51,15 +51,15 @@ IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t curr,
   // If a tainted value is stored, the store location must be tainted too
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
     struct TAFF : FlowFunction<IFDSTaintAnalysis::d_t> {
-      const llvm::StoreInst *store;
-      TAFF(const llvm::StoreInst *s) : store(s){};
+      const llvm::StoreInst *Store;
+      TAFF(const llvm::StoreInst *s) : Store(s){};
       set<IFDSTaintAnalysis::d_t>
       computeTargets(IFDSTaintAnalysis::d_t source) override {
-        if (store->getValueOperand() == source) {
-          return set<IFDSTaintAnalysis::d_t>{store->getPointerOperand(),
+        if (Store->getValueOperand() == source) {
+          return set<IFDSTaintAnalysis::d_t>{Store->getPointerOperand(),
                                              source};
-        } else if (store->getValueOperand() != source &&
-                   store->getPointerOperand() == source) {
+        } else if (Store->getValueOperand() != source &&
+                   Store->getPointerOperand() == source) {
           return {};
         } else {
           return {source};
@@ -184,27 +184,27 @@ IFDSTaintAnalysis::getCallToRetFlowFunction(
       // process leaks
       LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "Plugin SINK effects");
       struct TAFF : FlowFunction<IFDSTaintAnalysis::d_t> {
-        llvm::ImmutableCallSite callSite;
-        IFDSTaintAnalysis::f_t calledMthd;
+        llvm::ImmutableCallSite CallSite;
+        IFDSTaintAnalysis::f_t CalledMthd;
         TaintConfiguration<IFDSTaintAnalysis::d_t>::SinkFunction Sink;
         map<IFDSTaintAnalysis::n_t, set<IFDSTaintAnalysis::d_t>> &Leaks;
-        const IFDSTaintAnalysis *taintanalysis;
+        const IFDSTaintAnalysis *TaintAnalysis;
         TAFF(llvm::ImmutableCallSite cs, IFDSTaintAnalysis::f_t calledMthd,
              TaintConfiguration<IFDSTaintAnalysis::d_t>::SinkFunction s,
              map<IFDSTaintAnalysis::n_t, set<IFDSTaintAnalysis::d_t>> &leaks,
              const IFDSTaintAnalysis *ta)
-            : callSite(cs), calledMthd(calledMthd), Sink(s), Leaks(leaks),
-              taintanalysis(ta) {}
+            : CallSite(cs), CalledMthd(calledMthd), Sink(s), Leaks(leaks),
+              TaintAnalysis(ta) {}
         set<IFDSTaintAnalysis::d_t>
         computeTargets(IFDSTaintAnalysis::d_t source) override {
           // check if a tainted value flows into a sink
           // if so, add to Leaks and return id
-          if (!taintanalysis->isZeroValue(source)) {
-            for (unsigned Idx = 0; Idx < callSite.getNumArgOperands(); ++Idx) {
-              if (source == callSite.getArgOperand(Idx) &&
+          if (!TaintAnalysis->isZeroValue(source)) {
+            for (unsigned Idx = 0; Idx < CallSite.getNumArgOperands(); ++Idx) {
+              if (source == CallSite.getArgOperand(Idx) &&
                   Sink.isLeakedArg(Idx)) {
                 cout << "FOUND LEAK" << endl;
-                Leaks[callSite.getInstruction()].insert(source);
+                Leaks[CallSite.getInstruction()].insert(source);
               }
             }
           }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.cpp
@@ -32,11 +32,11 @@ IFDSTypeAnalysis::IFDSTypeAnalysis(const ProjectIRDB *IRDB,
 }
 
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t curr,
-                                        IFDSTypeAnalysis::n_t succ) {
+IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t Curr,
+                                        IFDSTypeAnalysis::n_t Succ) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
-    computeTargets(IFDSTypeAnalysis::d_t source) override {
+    computeTargets(IFDSTypeAnalysis::d_t Source) override {
       return set<IFDSTypeAnalysis::d_t>{};
     }
   };
@@ -44,11 +44,11 @@ IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t curr,
 }
 
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t callStmt,
-                                      IFDSTypeAnalysis::f_t destFun) {
+IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t CallStmt,
+                                      IFDSTypeAnalysis::f_t DestFun) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
-    computeTargets(IFDSTypeAnalysis::d_t source) override {
+    computeTargets(IFDSTypeAnalysis::d_t Source) override {
       return set<IFDSTypeAnalysis::d_t>{};
     }
   };
@@ -56,13 +56,13 @@ IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t callStmt,
 }
 
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
-                                     IFDSTypeAnalysis::f_t calleeFun,
-                                     IFDSTypeAnalysis::n_t exitStmt,
-                                     IFDSTypeAnalysis::n_t retSite) {
+IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
+                                     IFDSTypeAnalysis::f_t CalleeFun,
+                                     IFDSTypeAnalysis::n_t ExitStmt,
+                                     IFDSTypeAnalysis::n_t RetSite) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
-    computeTargets(IFDSTypeAnalysis::d_t source) override {
+    computeTargets(IFDSTypeAnalysis::d_t Source) override {
       return set<IFDSTypeAnalysis::d_t>{};
     }
   };
@@ -70,12 +70,12 @@ IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
 }
 
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
-                                           IFDSTypeAnalysis::n_t retSite,
-                                           set<IFDSTypeAnalysis::f_t> callees) {
+IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
+                                           IFDSTypeAnalysis::n_t RetSite,
+                                           set<IFDSTypeAnalysis::f_t> Callees) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
-    computeTargets(IFDSTypeAnalysis::d_t source) override {
+    computeTargets(IFDSTypeAnalysis::d_t Source) override {
       return set<IFDSTypeAnalysis::d_t>{};
     }
   };
@@ -83,8 +83,8 @@ IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t callSite,
 }
 
 shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getSummaryFlowFunction(IFDSTypeAnalysis::n_t curr,
-                                         IFDSTypeAnalysis::f_t destFun) {
+IFDSTypeAnalysis::getSummaryFlowFunction(IFDSTypeAnalysis::n_t Curr,
+                                         IFDSTypeAnalysis::f_t DestFun) {
   return nullptr;
 }
 
@@ -102,22 +102,22 @@ IFDSTypeAnalysis::d_t IFDSTypeAnalysis::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool IFDSTypeAnalysis::isZeroValue(IFDSTypeAnalysis::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool IFDSTypeAnalysis::isZeroValue(IFDSTypeAnalysis::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
-void IFDSTypeAnalysis::printNode(ostream &os, IFDSTypeAnalysis::n_t n) const {
-  os << llvmIRToString(n);
+void IFDSTypeAnalysis::printNode(ostream &OS, IFDSTypeAnalysis::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void IFDSTypeAnalysis::printDataFlowFact(ostream &os,
-                                         IFDSTypeAnalysis::d_t d) const {
-  os << llvmIRToString(d);
+void IFDSTypeAnalysis::printDataFlowFact(ostream &OS,
+                                         IFDSTypeAnalysis::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void IFDSTypeAnalysis::printFunction(ostream &os,
-                                     IFDSTypeAnalysis::f_t m) const {
-  os << m->getName().str();
+void IFDSTypeAnalysis::printFunction(ostream &OS,
+                                     IFDSTypeAnalysis::f_t M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -44,8 +44,8 @@ IFDSUninitializedVariables::IFDSUninitializedVariables(
 
 shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getNormalFlowFunction(
-    IFDSUninitializedVariables::n_t curr,
-    IFDSUninitializedVariables::n_t succ) {
+    IFDSUninitializedVariables::n_t Curr,
+    IFDSUninitializedVariables::n_t Succ) {
   //----------------------------------------------------------------------------------
   // Why do we need this case?
   // Every alloca is reached eventually by this function
@@ -102,7 +102,7 @@ IFDSUninitializedVariables::getNormalFlowFunction(
   */
 
   // check the all store instructions and kill initialized variables
-  if (auto store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
+  if (auto store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
     struct UVFF : FlowFunction<IFDSUninitializedVariables::d_t> {
       // const llvm::Value *valueop;
       // const llvm::Value *pointerop;
@@ -110,13 +110,13 @@ IFDSUninitializedVariables::getNormalFlowFunction(
       const llvm::Value *Zero;
       map<IFDSUninitializedVariables::n_t, set<IFDSUninitializedVariables::d_t>>
           &UndefValueUses;
-      UVFF(const llvm::StoreInst *s,
+      UVFF(const llvm::StoreInst *S,
            map<IFDSUninitializedVariables::n_t,
                set<IFDSUninitializedVariables::d_t>> &UVU,
-           const llvm::Value *zero)
-          : Store(s), Zero(zero), UndefValueUses(UVU) {}
+           const llvm::Value *Zero)
+          : Store(S), Zero(Zero), UndefValueUses(UVU) {}
       set<IFDSUninitializedVariables::d_t>
-      computeTargets(IFDSUninitializedVariables::d_t source) override {
+      computeTargets(IFDSUninitializedVariables::d_t Source) override {
 
         //----------------------------------------------------------------------
         // I don't get the purpose of this for-loop;
@@ -157,27 +157,27 @@ IFDSUninitializedVariables::getNormalFlowFunction(
            return {};
          }
          */
-        if (source == Store->getValueOperand() ||
-            (source == Zero &&
+        if (Source == Store->getValueOperand() ||
+            (Source == Zero &&
              llvm::isa<llvm::UndefValue>(Store->getValueOperand())))
-          return {source, Store->getPointerOperand()};
-        else if (source ==
+          return {Source, Store->getPointerOperand()};
+        else if (Source ==
                  Store->getPointerOperand()) // storing an initialized value
                                              // kills the variable as it is
                                              // now initialized too
           return {};
         // pass all other facts as identity
-        return {source};
+        return {Source};
       }
     };
     return make_shared<UVFF>(store, UndefValueUses, ZeroValue);
   }
-  if (auto alloc = llvm::dyn_cast<llvm::AllocaInst>(curr)) {
+  if (auto alloc = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
 
     return make_shared<LambdaFlow<IFDSUninitializedVariables::d_t>>(
-        [alloc, this](IFDSUninitializedVariables::d_t source)
+        [alloc, this](IFDSUninitializedVariables::d_t Source)
             -> set<IFDSUninitializedVariables::d_t> {
-          if (isZeroValue(source)) {
+          if (isZeroValue(Source)) {
             if (alloc->getAllocatedType()->isIntegerTy() ||
                 alloc->getAllocatedType()->isFloatingPointTy() ||
                 alloc->getAllocatedType()->isPointerTy() ||
@@ -188,11 +188,11 @@ IFDSUninitializedVariables::getNormalFlowFunction(
               //------------------------------------------------------------
 
               // generate the alloca
-              return {source, alloc};
+              return {Source, alloc};
             }
           }
           // otherwise propagate all facts
-          return {source};
+          return {Source};
         });
   }
   // check if some instruction is using an undefined value (in)directly
@@ -200,16 +200,16 @@ IFDSUninitializedVariables::getNormalFlowFunction(
     const llvm::Instruction *Inst;
     map<IFDSUninitializedVariables::n_t, set<IFDSUninitializedVariables::d_t>>
         &UndefValueUses;
-    UVFF(const llvm::Instruction *inst,
+    UVFF(const llvm::Instruction *Inst,
          map<IFDSUninitializedVariables::n_t,
              set<IFDSUninitializedVariables::d_t>> &UVU)
-        : Inst(inst), UndefValueUses(UVU) {}
+        : Inst(Inst), UndefValueUses(UVU) {}
     set<IFDSUninitializedVariables::d_t>
-    computeTargets(IFDSUninitializedVariables::d_t source) override {
+    computeTargets(IFDSUninitializedVariables::d_t Source) override {
       for (auto &operand : Inst->operands()) {
         const llvm::UndefValue *undef =
             llvm::dyn_cast<llvm::UndefValue>(operand);
-        if (operand == source || operand == undef) {
+        if (operand == Source || operand == undef) {
           //----------------------------------------------------------------
           // It is not necessary and (from my point of view) not intended to
           // report a leak on EVERY kind of instruction.
@@ -220,13 +220,13 @@ IFDSUninitializedVariables::getNormalFlowFunction(
               !llvm::isa<llvm::CastInst>(Inst) &&
               !llvm::isa<llvm::PHINode>(Inst))
             UndefValueUses[Inst].insert(operand);
-          return {source, Inst};
+          return {Source, Inst};
         }
       }
-      return {source};
+      return {Source};
     }
   };
-  return make_shared<UVFF>(curr, UndefValueUses);
+  return make_shared<UVFF>(Curr, UndefValueUses);
 
   // otherwise we do not care and nothing changes
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
@@ -234,20 +234,20 @@ IFDSUninitializedVariables::getNormalFlowFunction(
 
 shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getCallFlowFunction(
-    IFDSUninitializedVariables::n_t callStmt,
-    IFDSUninitializedVariables::f_t destFun) {
-  if (llvm::isa<llvm::CallInst>(callStmt) ||
-      llvm::isa<llvm::InvokeInst>(callStmt)) {
-    llvm::ImmutableCallSite callSite(callStmt);
+    IFDSUninitializedVariables::n_t CallStmt,
+    IFDSUninitializedVariables::f_t DestFun) {
+  if (llvm::isa<llvm::CallInst>(CallStmt) ||
+      llvm::isa<llvm::InvokeInst>(CallStmt)) {
+    llvm::ImmutableCallSite callSite(CallStmt);
     struct UVFF : FlowFunction<IFDSUninitializedVariables::d_t> {
       const llvm::Function *DestFun;
       llvm::ImmutableCallSite CallSite;
       const llvm::Value *Zerovalue;
       vector<const llvm::Value *> Actuals;
       vector<const llvm::Value *> Formals;
-      UVFF(const llvm::Function *dm, llvm::ImmutableCallSite cs,
-           const llvm::Value *zv)
-          : DestFun(dm), CallSite(cs), Zerovalue(zv) {
+      UVFF(const llvm::Function *DM, llvm::ImmutableCallSite CS,
+           const llvm::Value *ZV)
+          : DestFun(DM), CallSite(CS), Zerovalue(ZV) {
         // set up the actual parameters
         for (unsigned idx = 0; idx < CallSite.getNumArgOperands(); ++idx) {
           Actuals.push_back(CallSite.getArgOperand(idx));
@@ -262,16 +262,16 @@ IFDSUninitializedVariables::getCallFlowFunction(
       }
 
       set<IFDSUninitializedVariables::d_t>
-      computeTargets(IFDSUninitializedVariables::d_t source) override {
+      computeTargets(IFDSUninitializedVariables::d_t Source) override {
         // perform parameter passing
-        if (source != Zerovalue) {
+        if (Source != Zerovalue) {
           set<const llvm::Value *> res;
           // do the mapping from actual to formal parameters
           // caution: the loop iterates from 0 to formals.size(),
           // rather than actuals.size() as we may have more actual
           // than formal arguments in case of C-style varargs
           for (unsigned idx = 0; idx < Formals.size(); ++idx) {
-            if (source == Actuals[idx]) {
+            if (Source == Actuals[idx]) {
               res.insert(Formals[idx]);
             }
           }
@@ -307,34 +307,34 @@ IFDSUninitializedVariables::getCallFlowFunction(
           return res;*/
 
           // propagate zero
-          return {source};
+          return {Source};
         }
       }
     };
-    return make_shared<UVFF>(destFun, callSite, ZeroValue);
+    return make_shared<UVFF>(DestFun, callSite, ZeroValue);
   }
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getRetFlowFunction(
-    IFDSUninitializedVariables::n_t callSite,
-    IFDSUninitializedVariables::f_t calleeFun,
-    IFDSUninitializedVariables::n_t exitStmt,
-    IFDSUninitializedVariables::n_t retSite) {
-  if (llvm::isa<llvm::CallInst>(callSite) ||
-      llvm::isa<llvm::InvokeInst>(callSite)) {
-    llvm::ImmutableCallSite CS(callSite);
+    IFDSUninitializedVariables::n_t CallSite,
+    IFDSUninitializedVariables::f_t CalleeFun,
+    IFDSUninitializedVariables::n_t ExitStmt,
+    IFDSUninitializedVariables::n_t RetSite) {
+  if (llvm::isa<llvm::CallInst>(CallSite) ||
+      llvm::isa<llvm::InvokeInst>(CallSite)) {
+    llvm::ImmutableCallSite CS(CallSite);
     struct UVFF : FlowFunction<IFDSUninitializedVariables::d_t> {
       llvm::ImmutableCallSite Call;
       const llvm::Instruction *Exit;
-      UVFF(llvm::ImmutableCallSite c, const llvm::Instruction *e)
-          : Call(c), Exit(e) {}
+      UVFF(llvm::ImmutableCallSite C, const llvm::Instruction *E)
+          : Call(C), Exit(E) {}
       set<IFDSUninitializedVariables::d_t>
-      computeTargets(IFDSUninitializedVariables::d_t source) override {
+      computeTargets(IFDSUninitializedVariables::d_t Source) override {
         // check if we return an uninitialized value
         set<IFDSUninitializedVariables::d_t> ret;
-        if (Exit->getNumOperands() > 0 && Exit->getOperand(0) == source) {
+        if (Exit->getNumOperands() > 0 && Exit->getOperand(0) == Source) {
           ret.insert(Call.getInstruction());
         }
         //----------------------------------------------------------------------
@@ -344,7 +344,7 @@ IFDSUninitializedVariables::getRetFlowFunction(
           unsigned i = 0;
           for (auto &arg : Call.getCalledFunction()->args()) {
             // auto arg = getNthFunctionArgument(call.getCalledFunction(), i);
-            if (&arg == source && arg.getType()->isPointerTy()) {
+            if (&arg == Source && arg.getType()->isPointerTy()) {
               ret.insert(Call.getArgument(i));
             }
             i++;
@@ -355,7 +355,7 @@ IFDSUninitializedVariables::getRetFlowFunction(
         return ret;
       }
     };
-    return make_shared<UVFF>(CS, exitStmt);
+    return make_shared<UVFF>(CS, ExitStmt);
   }
   // kill everything else
   return KillAll<IFDSUninitializedVariables::d_t>::getInstance();
@@ -363,28 +363,28 @@ IFDSUninitializedVariables::getRetFlowFunction(
 
 shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getCallToRetFlowFunction(
-    IFDSUninitializedVariables::n_t callSite,
-    IFDSUninitializedVariables::n_t retSite,
-    set<IFDSUninitializedVariables::f_t> callees) {
+    IFDSUninitializedVariables::n_t CallSite,
+    IFDSUninitializedVariables::n_t RetSite,
+    set<IFDSUninitializedVariables::f_t> Callees) {
   //----------------------------------------------------------------------
   // Handle pointer/reference parameters
   //----------------------------------------------------------------------
-  if (llvm::isa<llvm::CallInst>(callSite) ||
-      llvm::isa<llvm::InvokeInst>(callSite)) {
-    llvm::ImmutableCallSite CS(callSite);
+  if (llvm::isa<llvm::CallInst>(CallSite) ||
+      llvm::isa<llvm::InvokeInst>(CallSite)) {
+    llvm::ImmutableCallSite CS(CallSite);
     return make_shared<LambdaFlow<IFDSUninitializedVariables::d_t>>(
-        [CS](IFDSUninitializedVariables::d_t source)
+        [CS](IFDSUninitializedVariables::d_t Source)
             -> set<IFDSUninitializedVariables::d_t> {
-          if (source->getType()->isPointerTy()) {
+          if (Source->getType()->isPointerTy()) {
             for (auto &arg : CS.args()) {
-              if (arg.get() == source)
+              if (arg.get() == Source)
                 // do not propagate pointer arguments, since the function may
                 // initialize them (would be much more precise with
                 // field-sensitivity)
                 return {};
             }
           }
-          return {source};
+          return {Source};
         });
   }
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
@@ -392,8 +392,8 @@ IFDSUninitializedVariables::getCallToRetFlowFunction(
 
 shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
 IFDSUninitializedVariables::getSummaryFlowFunction(
-    IFDSUninitializedVariables::n_t callStmt,
-    IFDSUninitializedVariables::f_t destFun) {
+    IFDSUninitializedVariables::n_t CallStmt,
+    IFDSUninitializedVariables::f_t DestFun) {
   return nullptr;
 }
 
@@ -422,64 +422,64 @@ IFDSUninitializedVariables::createZeroValue() const {
 }
 
 bool IFDSUninitializedVariables::isZeroValue(
-    IFDSUninitializedVariables::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+    IFDSUninitializedVariables::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 void IFDSUninitializedVariables::printNode(
-    ostream &os, IFDSUninitializedVariables::n_t n) const {
-  os << llvmIRToShortString(n);
+    ostream &OS, IFDSUninitializedVariables::n_t N) const {
+  OS << llvmIRToShortString(N);
 }
 
 void IFDSUninitializedVariables::printDataFlowFact(
-    ostream &os, IFDSUninitializedVariables::d_t d) const {
-  os << llvmIRToShortString(d);
+    ostream &OS, IFDSUninitializedVariables::d_t D) const {
+  OS << llvmIRToShortString(D);
 }
 
 void IFDSUninitializedVariables::printFunction(
-    ostream &os, IFDSUninitializedVariables::f_t m) const {
-  os << m->getName().str();
+    ostream &OS, IFDSUninitializedVariables::f_t M) const {
+  OS << M->getName().str();
 }
 
 void IFDSUninitializedVariables::emitTextReport(
     const SolverResults<IFDSUninitializedVariables::n_t,
                         IFDSUninitializedVariables::d_t, BinaryDomain> &SR,
-    ostream &os) {
-  os << "====================== IFDS-Uninitialized-Analysis Report "
+    ostream &OS) {
+  OS << "====================== IFDS-Uninitialized-Analysis Report "
         "======================\n";
   if (UndefValueUses.empty()) {
-    os << "No uses of uninitialized variables found by the analysis!\n";
+    OS << "No uses of uninitialized variables found by the analysis!\n";
   } else {
     if (!IRDB->debugInfoAvailable()) {
       // Emit only IR code, function name and module info
-      os << "\nWARNING: No Debug Info available - emiting results without "
+      OS << "\nWARNING: No Debug Info available - emiting results without "
             "source code mapping!\n";
-      os << "\nTotal uses of uninitialized IR Value's: "
+      OS << "\nTotal uses of uninitialized IR Value's: "
          << UndefValueUses.size() << '\n';
       size_t count = 0;
       for (auto User : UndefValueUses) {
-        os << "\n---------------------------------  " << ++count
+        OS << "\n---------------------------------  " << ++count
            << ". Use  ---------------------------------\n\n";
-        os << "At IR statement: ";
-        printNode(os, User.first);
-        os << "\n    in function: " << getFunctionNameFromIR(User.first);
-        os << "\n    in module  : " << getModuleIDFromIR(User.first) << "\n\n";
+        OS << "At IR statement: ";
+        printNode(OS, User.first);
+        OS << "\n    in function: " << getFunctionNameFromIR(User.first);
+        OS << "\n    in module  : " << getModuleIDFromIR(User.first) << "\n\n";
         for (auto UndefV : User.second) {
-          os << "   Uninit Value: ";
-          printDataFlowFact(os, UndefV);
-          os << '\n';
+          OS << "   Uninit Value: ";
+          printDataFlowFact(OS, UndefV);
+          OS << '\n';
         }
       }
-      os << '\n';
+      OS << '\n';
     } else {
       auto uninit_results = aggregateResults();
-      os << "\nTotal uses of uninitialized variables: " << uninit_results.size()
+      OS << "\nTotal uses of uninitialized variables: " << uninit_results.size()
          << '\n';
       size_t count = 0;
       for (auto res : uninit_results) {
-        os << "\n---------------------------------  " << ++count
+        OS << "\n---------------------------------  " << ++count
            << ". Use  ---------------------------------\n\n";
-        res.print(os);
+        res.print(OS);
       }
     }
   }
@@ -522,26 +522,26 @@ IFDSUninitializedVariables::aggregateResults() {
 
 bool IFDSUninitializedVariables::UninitResult::empty() { return line == 0; }
 
-void IFDSUninitializedVariables::UninitResult::print(std::ostream &os) {
-  os << "Variable(s): ";
+void IFDSUninitializedVariables::UninitResult::print(std::ostream &OS) {
+  OS << "Variable(s): ";
   if (!var_names.empty()) {
     for (size_t i = 0; i < var_names.size(); ++i) {
-      os << var_names[i];
+      OS << var_names[i];
       if (i < var_names.size() - 1)
-        os << ", ";
+        OS << ", ";
     }
-    os << '\n';
+    OS << '\n';
   }
-  os << "Line       : " << line << '\n';
-  os << "Source code: " << src_code << '\n';
-  os << "Function   : " << func_name << '\n';
-  os << "File       : " << file_path << '\n';
-  os << "\nCorresponding IR Statements and uninit. Values\n";
+  OS << "Line       : " << line << '\n';
+  OS << "Source code: " << src_code << '\n';
+  OS << "Function   : " << func_name << '\n';
+  OS << "File       : " << file_path << '\n';
+  OS << "\nCorresponding IR Statements and uninit. Values\n";
   if (!ir_trace.empty()) {
     for (auto trace : ir_trace) {
-      os << "At IR Statement: " << llvmIRToString(trace.first) << '\n';
+      OS << "At IR Statement: " << llvmIRToString(trace.first) << '\n';
       for (auto IRVal : trace.second) {
-        os << "   Uninit Value: " << llvmIRToString(IRVal) << '\n';
+        OS << "   Uninit Value: " << llvmIRToString(IRVal) << '\n';
       }
       // os << '\n';
     }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
@@ -37,7 +37,7 @@ const std::map<std::string, std::set<int>>
 // Token: FOPEN = 0, FCLOSE = 1, STAR = 2
 // States: UNINIT = 0, OPENED = 1, CLOSED = 2, ERROR = 3, BOT = 4
 const CSTDFILEIOTypeStateDescription::CSTDFILEIOState
-    CSTDFILEIOTypeStateDescription::delta[3][5] = {
+    CSTDFILEIOTypeStateDescription::Delta[3][5] = {
         /* FOPEN */
         {CSTDFILEIOState::OPENED, CSTDFILEIOState::OPENED,
          CSTDFILEIOState::ERROR, CSTDFILEIOState::ERROR, CSTDFILEIOState::BOT},
@@ -72,15 +72,15 @@ bool CSTDFILEIOTypeStateDescription::isAPIFunction(const std::string &F) const {
 TypeStateDescription::State CSTDFILEIOTypeStateDescription::getNextState(
     std::string Tok, TypeStateDescription::State S) const {
   if (isAPIFunction(Tok)) {
-    auto x = static_cast<std::underlying_type_t<CSTDFILEIOToken>>(
+    auto X = static_cast<std::underlying_type_t<CSTDFILEIOToken>>(
         funcNameToToken(Tok));
 
-    auto ret = delta[x][S];
+    auto Ret = Delta[X][S];
     // if (ret == error()) {
     //  std::cerr << "getNextState(" << Tok << ", " << stateToString(S)
     //            << ") = ERROR" << std::endl;
     // }
-    return ret;
+    return Ret;
   } else {
     return CSTDFILEIOState::BOT;
   }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKeyDerivationTypeStateDescription.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKeyDerivationTypeStateDescription.cpp
@@ -37,7 +37,7 @@ const std::map<std::string, std::set<int>>
 // DERIVE = 3, EVP_KDF_CTX_FREE = 4, STAR = 5 States: UNINIT = 0, KDF_FETCHED =
 // 1, CTX_ATTACHED = 2, PARAM_INIT = 3, DERIVED = 4, ERROR = 5, BOT = 6
 const OpenSSLEVPKeyDerivationTypeStateDescription::OpenSSLEVPKeyDerivationState
-    OpenSSLEVPKeyDerivationTypeStateDescription::delta[6][7] = {
+    OpenSSLEVPKeyDerivationTypeStateDescription::Delta[6][7] = {
         /* EVP_KDF_FETCH */
         {OpenSSLEVPKeyDerivationState::KDF_FETCHED,
          OpenSSLEVPKeyDerivationState::KDF_FETCHED,
@@ -115,7 +115,7 @@ TypeStateDescription::State
 OpenSSLEVPKeyDerivationTypeStateDescription::getNextState(
     std::string Tok, TypeStateDescription::State S) const {
   if (isAPIFunction(Tok)) {
-    return delta
+    return Delta
         [static_cast<std::underlying_type_t<OpenSSLEVPKeyDerivationToken>>(
             funcNameToToken(Tok))][S];
   } else {

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 namespace psr {
 
-const shared_ptr<AllBottom<BinaryDomain>> ALL_BOTTOM =
+const shared_ptr<AllBottom<BinaryDomain>> ALLBOTTOM =
     make_shared<AllBottom<BinaryDomain>>(BinaryDomain::BOTTOM);
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ZeroFlowFact.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/ZeroFlowFact.cpp
@@ -16,7 +16,7 @@ using namespace psr;
 
 namespace psr {
 
-void ZeroFlowFact::print(ostream &os) const { os << "ZeroFlowFact"; }
+void ZeroFlowFact::print(ostream &OS) const { OS << "ZeroFlowFact"; }
 
 bool ZeroFlowFact::equal_to(const FlowFact &FF) const { return false; }
 

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoFullConstantPropagation.cpp
@@ -123,29 +123,29 @@ InterMonoFullConstantPropagation::callToRetFlow(
 }
 
 void InterMonoFullConstantPropagation::printNode(
-    std::ostream &os, InterMonoFullConstantPropagation::n_t n) const {
-  os << llvmIRToString(n);
+    std::ostream &OS, InterMonoFullConstantPropagation::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
 void InterMonoFullConstantPropagation::printDataFlowFact(
-    std::ostream &os, InterMonoFullConstantPropagation::d_t d) const {
-  os << "< " + llvmIRToString(d.first) << ", ";
-  if (std::holds_alternative<Top>(d.second)) {
-    os << std::get<Top>(d.second);
+    std::ostream &OS, InterMonoFullConstantPropagation::d_t D) const {
+  OS << "< " + llvmIRToString(D.first) << ", ";
+  if (std::holds_alternative<Top>(D.second)) {
+    OS << std::get<Top>(D.second);
   }
-  if (std::holds_alternative<Bottom>(d.second)) {
-    os << std::get<Bottom>(d.second);
+  if (std::holds_alternative<Bottom>(D.second)) {
+    OS << std::get<Bottom>(D.second);
   }
   if (std::holds_alternative<InterMonoFullConstantPropagation::plain_d_t>(
-          d.second)) {
-    os << std::get<InterMonoFullConstantPropagation::plain_d_t>(d.second);
+          D.second)) {
+    OS << std::get<InterMonoFullConstantPropagation::plain_d_t>(D.second);
   }
-  os << " >";
+  OS << " >";
 }
 
 void InterMonoFullConstantPropagation::printFunction(
-    std::ostream &os, InterMonoFullConstantPropagation::f_t f) const {
-  os << f->getName().str();
+    std::ostream &OS, InterMonoFullConstantPropagation::f_t F) const {
+  OS << F->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
@@ -102,19 +102,19 @@ InterMonoSolverTest::initialSeeds() {
   return Seeds;
 }
 
-void InterMonoSolverTest::printNode(ostream &os,
-                                    const llvm::Instruction *n) const {
-  os << llvmIRToString(n);
+void InterMonoSolverTest::printNode(ostream &OS,
+                                    const llvm::Instruction *N) const {
+  OS << llvmIRToString(N);
 }
 
-void InterMonoSolverTest::printDataFlowFact(ostream &os,
-                                            const llvm::Value *d) const {
-  os << llvmIRToString(d) << '\n';
+void InterMonoSolverTest::printDataFlowFact(ostream &OS,
+                                            const llvm::Value *D) const {
+  OS << llvmIRToString(D) << '\n';
 }
 
-void InterMonoSolverTest::printFunction(ostream &os,
-                                        const llvm::Function *m) const {
-  os << m->getName().str();
+void InterMonoSolverTest::printFunction(ostream &OS,
+                                        const llvm::Function *M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
@@ -94,11 +94,11 @@ BitVectorSet<const llvm::Value *> InterMonoSolverTest::callToRetFlow(
 unordered_map<const llvm::Instruction *, BitVectorSet<const llvm::Value *>>
 InterMonoSolverTest::initialSeeds() {
   cout << "InterMonoSolverTest::initialSeeds()\n";
-  const llvm::Function *main = ICF->getFunction("main");
+  const llvm::Function *Main = ICF->getFunction("main");
   unordered_map<const llvm::Instruction *, BitVectorSet<const llvm::Value *>>
       Seeds;
   Seeds.insert(
-      make_pair(&main->front().front(), BitVectorSet<const llvm::Value *>()));
+      make_pair(&Main->front().front(), BitVectorSet<const llvm::Value *>()));
   return Seeds;
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
@@ -44,8 +44,8 @@ InterMonoTaintAnalysis::InterMonoTaintAnalysis(
 BitVectorSet<const llvm::Value *>
 InterMonoTaintAnalysis::join(const BitVectorSet<const llvm::Value *> &Lhs,
                              const BitVectorSet<const llvm::Value *> &Rhs) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG) << "InterMonoTaintAnalysis::join()");
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG) << "InterMonoTaintAnalysis::join()");
   // cout << "InterMonoTaintAnalysis::join()\n";
   return Lhs.setUnion(Rhs);
 }
@@ -53,8 +53,8 @@ InterMonoTaintAnalysis::join(const BitVectorSet<const llvm::Value *> &Lhs,
 bool InterMonoTaintAnalysis::sqSubSetEqual(
     const BitVectorSet<const llvm::Value *> &Lhs,
     const BitVectorSet<const llvm::Value *> &Rhs) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::sqSubSetEqual()");
   return Rhs.includes(Lhs);
 }
@@ -62,8 +62,8 @@ bool InterMonoTaintAnalysis::sqSubSetEqual(
 BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::normalFlow(
     const llvm::Instruction *Stmt,
     const BitVectorSet<const llvm::Value *> &In) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::normalFlow()");
   BitVectorSet<const llvm::Value *> Out(In);
   if (auto Store = llvm::dyn_cast<llvm::StoreInst>(Stmt)) {
@@ -90,27 +90,27 @@ BitVectorSet<const llvm::Value *>
 InterMonoTaintAnalysis::callFlow(const llvm::Instruction *CallSite,
                                  const llvm::Function *Callee,
                                  const BitVectorSet<const llvm::Value *> &In) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::callFlow()");
   BitVectorSet<const llvm::Value *> Out;
   llvm::ImmutableCallSite CS(CallSite);
   vector<const llvm::Value *> Actuals;
   vector<const llvm::Value *> Formals;
   // set up the actual parameters
-  for (unsigned idx = 0; idx < CS.getNumArgOperands(); ++idx) {
-    Actuals.push_back(CS.getArgOperand(idx));
+  for (unsigned Idx = 0; Idx < CS.getNumArgOperands(); ++Idx) {
+    Actuals.push_back(CS.getArgOperand(Idx));
   }
   // set up the formal parameters
   /* for (unsigned idx = 0; idx < Callee->arg_size(); ++idx) {
     Formals.push_back(getNthFunctionArgument(Callee, idx));
   }*/
-  for (auto &arg : Callee->args()) {
-    Formals.push_back(&arg);
+  for (auto &Arg : Callee->args()) {
+    Formals.push_back(&Arg);
   }
-  for (unsigned idx = 0; idx < Actuals.size(); ++idx) {
-    if (In.count(Actuals[idx])) {
-      Out.insert(Formals[idx]);
+  for (unsigned Idx = 0; Idx < Actuals.size(); ++Idx) {
+    if (In.count(Actuals[Idx])) {
+      Out.insert(Formals[Idx]);
     }
   }
   return Out;
@@ -120,8 +120,8 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::returnFlow(
     const llvm::Instruction *CallSite, const llvm::Function *Callee,
     const llvm::Instruction *ExitStmt, const llvm::Instruction *RetSite,
     const BitVectorSet<const llvm::Value *> &In) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::returnFlow()");
   BitVectorSet<const llvm::Value *> Out;
   if (auto Ret = llvm::dyn_cast<llvm::ReturnInst>(ExitStmt)) {
@@ -132,12 +132,12 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::returnFlow(
   // propagate pointer arguments to the caller, since this callee may modify
   // them
   llvm::ImmutableCallSite CS(CallSite);
-  unsigned index = 0;
-  for (auto &arg : Callee->args()) {
-    if (arg.getType()->isPointerTy() && In.count(&arg)) {
-      Out.insert(CS.getArgOperand(index));
+  unsigned Index = 0;
+  for (auto &Arg : Callee->args()) {
+    if (Arg.getType()->isPointerTy() && In.count(&Arg)) {
+      Out.insert(CS.getArgOperand(Index));
     }
-    index++;
+    Index++;
   }
   return Out;
 }
@@ -146,8 +146,8 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::callToRetFlow(
     const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
     set<const llvm::Function *> Callees,
     const BitVectorSet<const llvm::Value *> &In) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::callToRetFlow()");
   BitVectorSet<const llvm::Value *> Out(In);
   llvm::ImmutableCallSite CS(CallSite);
@@ -155,26 +155,26 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::callToRetFlow(
   // Handle virtual calls in the loop
   //-----------------------------------------------------------------------------
   for (auto Callee : Callees) {
-    LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+    LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                   << "InterMonoTaintAnalysis::callToRetFlow()::"
                   << Callee->getName().str());
 
     if (TSF.isSink(Callee->getName().str())) {
-      for (unsigned idx = 0; idx < CS.getNumArgOperands(); ++idx) {
-        if (TSF.getSink(Callee->getName().str()).isLeakedArg(idx) &&
-            In.count(CS.getArgOperand(idx))) {
+      for (unsigned Idx = 0; Idx < CS.getNumArgOperands(); ++Idx) {
+        if (TSF.getSink(Callee->getName().str()).isLeakedArg(Idx) &&
+            In.count(CS.getArgOperand(Idx))) {
           cout << "FOUND LEAK AT: " << llvmIRToString(CallSite) << '\n';
-          cout << "LEAKED VALUE: " << llvmIRToString(CS.getArgOperand(idx))
+          cout << "LEAKED VALUE: " << llvmIRToString(CS.getArgOperand(Idx))
                << '\n'
                << endl;
-          Leaks[CallSite].insert(CS.getArgOperand(idx));
+          Leaks[CallSite].insert(CS.getArgOperand(Idx));
         }
       }
     }
     if (TSF.isSource(Callee->getName().str())) {
-      for (unsigned idx = 0; idx < CS.getNumArgOperands(); ++idx) {
-        if (TSF.getSource(Callee->getName().str()).isTaintedArg(idx)) {
-          Out.insert(CS.getArgOperand(idx));
+      for (unsigned Idx = 0; Idx < CS.getNumArgOperands(); ++Idx) {
+        if (TSF.getSource(Callee->getName().str()).isTaintedArg(Idx)) {
+          Out.insert(CS.getArgOperand(Idx));
         }
       }
       if (TSF.getSource(Callee->getName().str()).TaintsReturn) {
@@ -184,9 +184,9 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::callToRetFlow(
   }
 
   // erase pointer arguments, since they are now propagated in the retFF
-  for (unsigned i = 0; i < CS.getNumArgOperands(); ++i) {
-    if (CS.getArgOperand(i)->getType()->isPointerTy()) {
-      Out.erase(CS.getArgOperand(i));
+  for (unsigned Idx = 0; Idx < CS.getNumArgOperands(); ++Idx) {
+    if (CS.getArgOperand(Idx)->getType()->isPointerTy()) {
+      Out.erase(CS.getArgOperand(Idx));
     }
   }
   return Out;
@@ -194,17 +194,17 @@ BitVectorSet<const llvm::Value *> InterMonoTaintAnalysis::callToRetFlow(
 
 unordered_map<const llvm::Instruction *, BitVectorSet<const llvm::Value *>>
 InterMonoTaintAnalysis::initialSeeds() {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "InterMonoTaintAnalysis::initialSeeds()");
-  const llvm::Function *main = ICF->getFunction("main");
+  const llvm::Function *Main = ICF->getFunction("main");
   unordered_map<const llvm::Instruction *, BitVectorSet<const llvm::Value *>>
       Seeds;
   BitVectorSet<const llvm::Value *> Facts;
-  for (unsigned idx = 0; idx < main->arg_size(); ++idx) {
-    Facts.insert(getNthFunctionArgument(main, idx));
+  for (unsigned Idx = 0; Idx < Main->arg_size(); ++Idx) {
+    Facts.insert(getNthFunctionArgument(Main, Idx));
   }
-  Seeds.insert(make_pair(&main->front().front(), Facts));
+  Seeds.insert(make_pair(&Main->front().front(), Facts));
   return Seeds;
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
@@ -208,19 +208,19 @@ InterMonoTaintAnalysis::initialSeeds() {
   return Seeds;
 }
 
-void InterMonoTaintAnalysis::printNode(ostream &os,
-                                       const llvm::Instruction *n) const {
-  os << llvmIRToString(n);
+void InterMonoTaintAnalysis::printNode(ostream &OS,
+                                       const llvm::Instruction *N) const {
+  OS << llvmIRToString(N);
 }
 
-void InterMonoTaintAnalysis::printDataFlowFact(ostream &os,
-                                               const llvm::Value *d) const {
-  os << llvmIRToString(d) << '\n';
+void InterMonoTaintAnalysis::printDataFlowFact(ostream &OS,
+                                               const llvm::Value *D) const {
+  OS << llvmIRToString(D) << '\n';
 }
 
-void InterMonoTaintAnalysis::printFunction(ostream &os,
-                                           const llvm::Function *m) const {
-  os << m->getName().str();
+void InterMonoTaintAnalysis::printFunction(ostream &OS,
+                                           const llvm::Function *M) const {
+  OS << M->getName().str();
 }
 const std::map<const llvm::Instruction *, std::set<const llvm::Value *>> &
 InterMonoTaintAnalysis::getAllLeaks() const {

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
@@ -24,11 +24,11 @@
 namespace std {
 template <> struct hash<pair<const llvm::Value *, unsigned>> {
   size_t operator()(const pair<const llvm::Value *, unsigned> &P) const {
-    std::hash<const llvm::Value *> hash_ptr;
-    std::hash<unsigned> hash_unsigned;
-    size_t hp = hash_ptr(P.first);
-    size_t hu = hash_unsigned(P.second);
-    return hp ^ (hu << 1);
+    std::hash<const llvm::Value *> HashPtr;
+    std::hash<unsigned> HashUnsigned;
+    size_t HP = HashPtr(P.first);
+    size_t HU = HashUnsigned(P.second);
+    return HP ^ (HU << 1);
   }
 };
 } // namespace std

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
@@ -23,11 +23,11 @@
 
 namespace std {
 template <> struct hash<pair<const llvm::Value *, unsigned>> {
-  size_t operator()(const pair<const llvm::Value *, unsigned> &p) const {
+  size_t operator()(const pair<const llvm::Value *, unsigned> &P) const {
     std::hash<const llvm::Value *> hash_ptr;
     std::hash<unsigned> hash_unsigned;
-    size_t hp = hash_ptr(p.first);
-    size_t hu = hash_unsigned(p.second);
+    size_t hp = hash_ptr(P.first);
+    size_t hu = hash_unsigned(P.second);
     return hp ^ (hu << 1);
   }
 };
@@ -77,19 +77,19 @@ IntraMonoFullConstantPropagation::initialSeeds() {
 }
 
 void IntraMonoFullConstantPropagation::printNode(
-    std::ostream &os, const llvm::Instruction *n) const {
-  os << llvmIRToString(n);
+    std::ostream &OS, const llvm::Instruction *N) const {
+  OS << llvmIRToString(N);
 }
 
 void IntraMonoFullConstantPropagation::printDataFlowFact(
-    std::ostream &os, std::pair<const llvm::Value *, unsigned> d) const {
-  os << "< " + llvmIRToString(d.first)
-     << ", " + std::to_string(d.second) + " >";
+    std::ostream &OS, std::pair<const llvm::Value *, unsigned> D) const {
+  OS << "< " + llvmIRToString(D.first)
+     << ", " + std::to_string(D.second) + " >";
 }
 
 void IntraMonoFullConstantPropagation::printFunction(
-    std::ostream &os, const llvm::Function *m) const {
-  os << m->getName().str();
+    std::ostream &OS, const llvm::Function *M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.cpp
@@ -74,19 +74,19 @@ IntraMonoSolverTest::initialSeeds() {
   return {};
 }
 
-void IntraMonoSolverTest::printNode(ostream &os,
-                                    const llvm::Instruction *n) const {
-  os << llvmIRToString(n);
+void IntraMonoSolverTest::printNode(ostream &OS,
+                                    const llvm::Instruction *N) const {
+  OS << llvmIRToString(N);
 }
 
-void IntraMonoSolverTest::printDataFlowFact(ostream &os,
-                                            const llvm::Value *d) const {
-  os << llvmIRToString(d);
+void IntraMonoSolverTest::printDataFlowFact(ostream &OS,
+                                            const llvm::Value *D) const {
+  OS << llvmIRToString(D);
 }
 
-void IntraMonoSolverTest::printFunction(ostream &os,
-                                        const llvm::Function *m) const {
-  os << m->getName().str();
+void IntraMonoSolverTest::printFunction(ostream &OS,
+                                        const llvm::Function *M) const {
+  OS << M->getName().str();
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
@@ -34,75 +34,75 @@ WPDSAliasCollector::WPDSAliasCollector(const ProjectIRDB *IRDB,
                   WPDSAliasCollector::i_t>(IRDB, TH, ICF, PT, EntryPoints) {}
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
-WPDSAliasCollector::getNormalFlowFunction(WPDSAliasCollector::n_t curr,
-                                          WPDSAliasCollector::n_t succ) {
+WPDSAliasCollector::getNormalFlowFunction(WPDSAliasCollector::n_t Curr,
+                                          WPDSAliasCollector::n_t Succ) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
-WPDSAliasCollector::getCallFlowFunction(WPDSAliasCollector::n_t callStmt,
-                                        WPDSAliasCollector::f_t destFun) {
+WPDSAliasCollector::getCallFlowFunction(WPDSAliasCollector::n_t CallStmt,
+                                        WPDSAliasCollector::f_t DestFun) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
-WPDSAliasCollector::getRetFlowFunction(WPDSAliasCollector::n_t callSite,
-                                       WPDSAliasCollector::f_t calleeFun,
-                                       WPDSAliasCollector::n_t exitStmt,
-                                       WPDSAliasCollector::n_t retSite) {
+WPDSAliasCollector::getRetFlowFunction(WPDSAliasCollector::n_t CallSite,
+                                       WPDSAliasCollector::f_t CalleeFun,
+                                       WPDSAliasCollector::n_t ExitStmt,
+                                       WPDSAliasCollector::n_t RetSite) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
 WPDSAliasCollector::getCallToRetFlowFunction(
-    WPDSAliasCollector::n_t callSite, WPDSAliasCollector::n_t retSite,
-    set<WPDSAliasCollector::f_t> callees) {
+    WPDSAliasCollector::n_t CallSite, WPDSAliasCollector::n_t RetSite,
+    set<WPDSAliasCollector::f_t> Callees) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
-WPDSAliasCollector::getSummaryFlowFunction(WPDSAliasCollector::n_t curr,
-                                           WPDSAliasCollector::f_t destFun) {
+WPDSAliasCollector::getSummaryFlowFunction(WPDSAliasCollector::n_t Curr,
+                                           WPDSAliasCollector::f_t DestFun) {
   return nullptr;
 }
 
 shared_ptr<EdgeFunction<WPDSAliasCollector::l_t>>
-WPDSAliasCollector::getNormalEdgeFunction(WPDSAliasCollector::n_t curr,
-                                          WPDSAliasCollector::d_t currNode,
-                                          WPDSAliasCollector::n_t succ,
-                                          WPDSAliasCollector::d_t succNode) {
+WPDSAliasCollector::getNormalEdgeFunction(WPDSAliasCollector::n_t Curr,
+                                          WPDSAliasCollector::d_t CurrNode,
+                                          WPDSAliasCollector::n_t Succ,
+                                          WPDSAliasCollector::d_t SuccNode) {
   return EdgeIdentity<WPDSAliasCollector::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSAliasCollector::l_t>>
 WPDSAliasCollector::getCallEdgeFunction(
-    WPDSAliasCollector::n_t callStmt, WPDSAliasCollector::d_t srcNode,
-    WPDSAliasCollector::f_t destinationFunction,
-    WPDSAliasCollector::d_t destNode) {
+    WPDSAliasCollector::n_t CallStmt, WPDSAliasCollector::d_t SrcNode,
+    WPDSAliasCollector::f_t DestinationFunction,
+    WPDSAliasCollector::d_t DestNode) {
   return EdgeIdentity<WPDSAliasCollector::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSAliasCollector::l_t>>
 WPDSAliasCollector::getReturnEdgeFunction(
-    WPDSAliasCollector::n_t callSite, WPDSAliasCollector::f_t calleeFunction,
-    WPDSAliasCollector::n_t exitStmt, WPDSAliasCollector::d_t exitNode,
-    WPDSAliasCollector::n_t reSite, WPDSAliasCollector::d_t retNode) {
+    WPDSAliasCollector::n_t CallSite, WPDSAliasCollector::f_t CalleeFunction,
+    WPDSAliasCollector::n_t ExitStmt, WPDSAliasCollector::d_t ExitNode,
+    WPDSAliasCollector::n_t ReSite, WPDSAliasCollector::d_t RetNode) {
   return EdgeIdentity<WPDSAliasCollector::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSAliasCollector::l_t>>
 WPDSAliasCollector::getCallToRetEdgeFunction(
-    WPDSAliasCollector::n_t callSite, WPDSAliasCollector::d_t callNode,
-    WPDSAliasCollector::n_t retSite, WPDSAliasCollector::d_t retSiteNode,
-    set<WPDSAliasCollector::f_t> callees) {
+    WPDSAliasCollector::n_t CallSite, WPDSAliasCollector::d_t CallNode,
+    WPDSAliasCollector::n_t RetSite, WPDSAliasCollector::d_t RetSiteNode,
+    set<WPDSAliasCollector::f_t> Callees) {
   return EdgeIdentity<WPDSAliasCollector::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSAliasCollector::l_t>>
-WPDSAliasCollector::getSummaryEdgeFunction(WPDSAliasCollector::n_t curr,
-                                           WPDSAliasCollector::d_t currNode,
-                                           WPDSAliasCollector::n_t succ,
-                                           WPDSAliasCollector::d_t succNode) {
+WPDSAliasCollector::getSummaryEdgeFunction(WPDSAliasCollector::n_t Curr,
+                                           WPDSAliasCollector::d_t CurrNode,
+                                           WPDSAliasCollector::n_t Succ,
+                                           WPDSAliasCollector::d_t SuccNode) {
   return nullptr;
 }
 
@@ -112,15 +112,15 @@ WPDSAliasCollector::l_t WPDSAliasCollector::topElement() {
 WPDSAliasCollector::l_t WPDSAliasCollector::bottomElement() {
   return BinaryDomain::BOTTOM;
 }
-WPDSAliasCollector::l_t WPDSAliasCollector::join(WPDSAliasCollector::l_t lhs,
-                                                 WPDSAliasCollector::l_t rhs) {
-  return (lhs == BinaryDomain::BOTTOM || rhs == BinaryDomain::BOTTOM)
+WPDSAliasCollector::l_t WPDSAliasCollector::join(WPDSAliasCollector::l_t Lhs,
+                                                 WPDSAliasCollector::l_t Rhs) {
+  return (Lhs == BinaryDomain::BOTTOM || Rhs == BinaryDomain::BOTTOM)
              ? BinaryDomain::BOTTOM
              : BinaryDomain::TOP;
 }
 
-bool WPDSAliasCollector::isZeroValue(WPDSAliasCollector::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool WPDSAliasCollector::isZeroValue(WPDSAliasCollector::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 std::map<WPDSAliasCollector::n_t, std::set<WPDSAliasCollector::d_t>>
 WPDSAliasCollector::initialSeeds() {
@@ -132,27 +132,27 @@ WPDSAliasCollector::allTopFunction() {
   return make_shared<AllTop<WPDSAliasCollector::l_t>>(BinaryDomain::TOP);
 }
 
-void WPDSAliasCollector::printNode(std::ostream &os,
-                                   WPDSAliasCollector::n_t n) const {
-  os << llvmIRToString(n);
+void WPDSAliasCollector::printNode(std::ostream &OS,
+                                   WPDSAliasCollector::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void WPDSAliasCollector::printDataFlowFact(std::ostream &os,
-                                           WPDSAliasCollector::d_t d) const {
-  os << llvmIRToString(d);
+void WPDSAliasCollector::printDataFlowFact(std::ostream &OS,
+                                           WPDSAliasCollector::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void WPDSAliasCollector::printFunction(std::ostream &os,
-                                       WPDSAliasCollector::f_t m) const {
-  os << m->getName().str();
+void WPDSAliasCollector::printFunction(std::ostream &OS,
+                                       WPDSAliasCollector::f_t M) const {
+  OS << M->getName().str();
 }
 
-void WPDSAliasCollector::printEdgeFact(std::ostream &os,
-                                       WPDSAliasCollector::l_t v) const {
-  if (v == BinaryDomain::TOP) {
-    os << "TOP";
+void WPDSAliasCollector::printEdgeFact(std::ostream &OS,
+                                       WPDSAliasCollector::l_t V) const {
+  if (V == BinaryDomain::TOP) {
+    OS << "TOP";
   } else {
-    os << "BOTTOM";
+    OS << "BOTTOM";
   }
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
@@ -32,78 +32,78 @@ WPDSSolverTest::WPDSSolverTest(const ProjectIRDB *IRDB,
                   WPDSSolverTest::i_t>(IRDB, TH, ICF, PT, EntryPoints) {}
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getNormalFlowFunction(WPDSSolverTest::n_t curr,
-                                      WPDSSolverTest::n_t succ) {
+WPDSSolverTest::getNormalFlowFunction(WPDSSolverTest::n_t Curr,
+                                      WPDSSolverTest::n_t Succ) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getCallFlowFunction(WPDSSolverTest::n_t callStmt,
-                                    WPDSSolverTest::f_t destFun) {
+WPDSSolverTest::getCallFlowFunction(WPDSSolverTest::n_t CallStmt,
+                                    WPDSSolverTest::f_t DestFun) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getRetFlowFunction(WPDSSolverTest::n_t callSite,
-                                   WPDSSolverTest::f_t calleeFun,
-                                   WPDSSolverTest::n_t exitStmt,
-                                   WPDSSolverTest::n_t retSite) {
+WPDSSolverTest::getRetFlowFunction(WPDSSolverTest::n_t CallSite,
+                                   WPDSSolverTest::f_t CalleeFun,
+                                   WPDSSolverTest::n_t ExitStmt,
+                                   WPDSSolverTest::n_t RetSite) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getCallToRetFlowFunction(WPDSSolverTest::n_t callSite,
-                                         WPDSSolverTest::n_t retSite,
-                                         set<WPDSSolverTest::f_t> callees) {
+WPDSSolverTest::getCallToRetFlowFunction(WPDSSolverTest::n_t CallSite,
+                                         WPDSSolverTest::n_t RetSite,
+                                         set<WPDSSolverTest::f_t> Callees) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getSummaryFlowFunction(WPDSSolverTest::n_t curr,
-                                       WPDSSolverTest::f_t destFun) {
+WPDSSolverTest::getSummaryFlowFunction(WPDSSolverTest::n_t Curr,
+                                       WPDSSolverTest::f_t DestFun) {
   return nullptr;
 }
 
 shared_ptr<EdgeFunction<WPDSSolverTest::l_t>>
-WPDSSolverTest::getNormalEdgeFunction(WPDSSolverTest::n_t curr,
-                                      WPDSSolverTest::d_t currNode,
-                                      WPDSSolverTest::n_t succ,
-                                      WPDSSolverTest::d_t succNode) {
+WPDSSolverTest::getNormalEdgeFunction(WPDSSolverTest::n_t Curr,
+                                      WPDSSolverTest::d_t CurrNode,
+                                      WPDSSolverTest::n_t Succ,
+                                      WPDSSolverTest::d_t SuccNode) {
   return EdgeIdentity<WPDSSolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSSolverTest::l_t>>
-WPDSSolverTest::getCallEdgeFunction(WPDSSolverTest::n_t callStmt,
-                                    WPDSSolverTest::d_t srcNode,
-                                    WPDSSolverTest::f_t destinationFunction,
-                                    WPDSSolverTest::d_t destNode) {
+WPDSSolverTest::getCallEdgeFunction(WPDSSolverTest::n_t CallStmt,
+                                    WPDSSolverTest::d_t SrcNode,
+                                    WPDSSolverTest::f_t DestinationFunction,
+                                    WPDSSolverTest::d_t DestNode) {
   return EdgeIdentity<WPDSSolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSSolverTest::l_t>>
-WPDSSolverTest::getReturnEdgeFunction(WPDSSolverTest::n_t callSite,
-                                      WPDSSolverTest::f_t calleeFunction,
-                                      WPDSSolverTest::n_t exitStmt,
-                                      WPDSSolverTest::d_t exitNode,
-                                      WPDSSolverTest::n_t reSite,
-                                      WPDSSolverTest::d_t retNode) {
+WPDSSolverTest::getReturnEdgeFunction(WPDSSolverTest::n_t CallSite,
+                                      WPDSSolverTest::f_t CalleeFunction,
+                                      WPDSSolverTest::n_t ExitStmt,
+                                      WPDSSolverTest::d_t ExitNode,
+                                      WPDSSolverTest::n_t ReSite,
+                                      WPDSSolverTest::d_t RetNode) {
   return EdgeIdentity<WPDSSolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSSolverTest::l_t>>
-WPDSSolverTest::getCallToRetEdgeFunction(WPDSSolverTest::n_t callSite,
-                                         WPDSSolverTest::d_t callNode,
-                                         WPDSSolverTest::n_t retSite,
-                                         WPDSSolverTest::d_t retSiteNode,
-                                         set<WPDSSolverTest::f_t> callees) {
+WPDSSolverTest::getCallToRetEdgeFunction(WPDSSolverTest::n_t CallSite,
+                                         WPDSSolverTest::d_t CallNode,
+                                         WPDSSolverTest::n_t RetSite,
+                                         WPDSSolverTest::d_t RetSiteNode,
+                                         set<WPDSSolverTest::f_t> Callees) {
   return EdgeIdentity<WPDSSolverTest::l_t>::getInstance();
 }
 
 shared_ptr<EdgeFunction<WPDSSolverTest::l_t>>
-WPDSSolverTest::getSummaryEdgeFunction(WPDSSolverTest::n_t curr,
-                                       WPDSSolverTest::d_t currNode,
-                                       WPDSSolverTest::n_t succ,
-                                       WPDSSolverTest::d_t succNode) {
+WPDSSolverTest::getSummaryEdgeFunction(WPDSSolverTest::n_t Curr,
+                                       WPDSSolverTest::d_t CurrNode,
+                                       WPDSSolverTest::n_t Succ,
+                                       WPDSSolverTest::d_t SuccNode) {
   return nullptr;
 }
 
@@ -113,9 +113,9 @@ WPDSSolverTest::l_t WPDSSolverTest::bottomElement() {
   return BinaryDomain::BOTTOM;
 }
 
-WPDSSolverTest::l_t WPDSSolverTest::join(WPDSSolverTest::l_t lhs,
-                                         WPDSSolverTest::l_t rhs) {
-  return (lhs == BinaryDomain::BOTTOM || rhs == BinaryDomain::BOTTOM)
+WPDSSolverTest::l_t WPDSSolverTest::join(WPDSSolverTest::l_t Lhs,
+                                         WPDSSolverTest::l_t Rhs) {
+  return (Lhs == BinaryDomain::BOTTOM || Rhs == BinaryDomain::BOTTOM)
              ? BinaryDomain::BOTTOM
              : BinaryDomain::TOP;
 }
@@ -124,8 +124,8 @@ WPDSSolverTest::d_t WPDSSolverTest::createZeroValue() const {
   return LLVMZeroValue::getInstance();
 }
 
-bool WPDSSolverTest::isZeroValue(WPDSSolverTest::d_t d) const {
-  return LLVMZeroValue::getInstance()->isLLVMZeroValue(d);
+bool WPDSSolverTest::isZeroValue(WPDSSolverTest::d_t D) const {
+  return LLVMZeroValue::getInstance()->isLLVMZeroValue(D);
 }
 
 std::map<WPDSSolverTest::n_t, std::set<WPDSSolverTest::d_t>>
@@ -138,26 +138,26 @@ WPDSSolverTest::allTopFunction() {
   return make_shared<AllTop<WPDSSolverTest::l_t>>(BinaryDomain::TOP);
 }
 
-void WPDSSolverTest::printNode(std::ostream &os, WPDSSolverTest::n_t n) const {
-  os << llvmIRToString(n);
+void WPDSSolverTest::printNode(std::ostream &OS, WPDSSolverTest::n_t N) const {
+  OS << llvmIRToString(N);
 }
 
-void WPDSSolverTest::printDataFlowFact(std::ostream &os,
-                                       WPDSSolverTest::d_t d) const {
-  os << llvmIRToString(d);
+void WPDSSolverTest::printDataFlowFact(std::ostream &OS,
+                                       WPDSSolverTest::d_t D) const {
+  OS << llvmIRToString(D);
 }
 
-void WPDSSolverTest::printFunction(std::ostream &os,
-                                   WPDSSolverTest::f_t m) const {
-  os << m->getName().str();
+void WPDSSolverTest::printFunction(std::ostream &OS,
+                                   WPDSSolverTest::f_t M) const {
+  OS << M->getName().str();
 }
 
-void WPDSSolverTest::printEdgeFact(std::ostream &os,
-                                   WPDSSolverTest::l_t v) const {
-  if (v == BinaryDomain::TOP) {
-    os << "TOP";
+void WPDSSolverTest::printEdgeFact(std::ostream &OS,
+                                   WPDSSolverTest::l_t V) const {
+  if (V == BinaryDomain::TOP) {
+    OS << "TOP";
   } else {
-    os << "BOTTOM";
+    OS << "BOTTOM";
   }
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
@@ -16,7 +16,7 @@
 
 namespace psr {
 
-WPDSType to_WPDSType(const std::string &S) {
+WPDSType toWPDSType(const std::string &S) {
   WPDSType Type = llvm::StringSwitch<WPDSType>(S)
 #define WPDS_TYPES(NAME, TYPE) .Case(NAME, WPDSType::TYPE)
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
@@ -24,7 +24,7 @@ WPDSType to_WPDSType(const std::string &S) {
   return Type;
 }
 
-std::string to_string(const WPDSType &T) {
+std::string toString(const WPDSType &T) {
   switch (T) {
   default:
 #define WPDS_TYPES(NAME, TYPE)                                                 \
@@ -36,10 +36,10 @@ std::string to_string(const WPDSType &T) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T) {
-  return OS << to_string(T);
+  return OS << toString(T);
 }
 
-WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
+WPDSSearchDirection toWPDSSearchDirection(const std::string &S) {
   if (S == "FORWARD") {
     return WPDSSearchDirection::FORWARD;
   } else {
@@ -47,7 +47,7 @@ WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
   }
 }
 
-std::string to_string(const WPDSSearchDirection &S) {
+std::string toString(const WPDSSearchDirection &S) {
   switch (S) {
   default:
   case WPDSSearchDirection::FORWARD:
@@ -60,7 +60,7 @@ std::string to_string(const WPDSSearchDirection &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S) {
-  return OS << to_string(S);
+  return OS << toString(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
@@ -24,7 +24,7 @@ WPDSType to_WPDSType(const std::string &S) {
   return Type;
 }
 
-std::string to_string(const WPDSType &T) {
+std::string toString(const WPDSType &T) {
   switch (T) {
   default:
 #define WPDS_TYPES(NAME, TYPE)                                                 \
@@ -36,7 +36,7 @@ std::string to_string(const WPDSType &T) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T) {
-  return OS << to_string(T);
+  return OS << toString(T);
 }
 
 WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
@@ -47,7 +47,7 @@ WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
   }
 }
 
-std::string to_string(const WPDSSearchDirection &S) {
+std::string toString(const WPDSSearchDirection &S) {
   switch (S) {
   default:
   case WPDSSearchDirection::FORWARD:
@@ -60,7 +60,7 @@ std::string to_string(const WPDSSearchDirection &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S) {
-  return OS << to_string(S);
+  return OS << toString(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
@@ -16,7 +16,7 @@
 
 namespace psr {
 
-WPDSType to_WPDSType(const std::string &S) {
+WPDSType toWPDSType(const std::string &S) {
   WPDSType Type = llvm::StringSwitch<WPDSType>(S)
 #define WPDS_TYPES(NAME, TYPE) .Case(NAME, WPDSType::TYPE)
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
@@ -39,7 +39,7 @@ std::ostream &operator<<(std::ostream &OS, const WPDSType &T) {
   return OS << toString(T);
 }
 
-WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
+WPDSSearchDirection toWPDSSearchDirection(const std::string &S) {
   if (S == "FORWARD") {
     return WPDSSearchDirection::FORWARD;
   } else {

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSOptions.cpp
@@ -16,7 +16,7 @@
 
 namespace psr {
 
-WPDSType toWPDSType(const std::string &S) {
+WPDSType to_WPDSType(const std::string &S) {
   WPDSType Type = llvm::StringSwitch<WPDSType>(S)
 #define WPDS_TYPES(NAME, TYPE) .Case(NAME, WPDSType::TYPE)
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSType.def"
@@ -24,7 +24,7 @@ WPDSType toWPDSType(const std::string &S) {
   return Type;
 }
 
-std::string toString(const WPDSType &T) {
+std::string to_string(const WPDSType &T) {
   switch (T) {
   default:
 #define WPDS_TYPES(NAME, TYPE)                                                 \
@@ -36,10 +36,10 @@ std::string toString(const WPDSType &T) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSType &T) {
-  return OS << toString(T);
+  return OS << to_string(T);
 }
 
-WPDSSearchDirection toWPDSSearchDirection(const std::string &S) {
+WPDSSearchDirection to_WPDSSearchDirection(const std::string &S) {
   if (S == "FORWARD") {
     return WPDSSearchDirection::FORWARD;
   } else {
@@ -47,7 +47,7 @@ WPDSSearchDirection toWPDSSearchDirection(const std::string &S) {
   }
 }
 
-std::string toString(const WPDSSearchDirection &S) {
+std::string to_string(const WPDSSearchDirection &S) {
   switch (S) {
   default:
   case WPDSSearchDirection::FORWARD:
@@ -60,7 +60,7 @@ std::string toString(const WPDSSearchDirection &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const WPDSSearchDirection &S) {
-  return OS << toString(S);
+  return OS << to_string(S);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSSolverConfig.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/WPDSSolverConfig.cpp
@@ -16,11 +16,11 @@ using namespace psr;
 
 namespace psr {
 
-WPDSSolverConfig::WPDSSolverConfig(bool recordWitnesses,
-                                   WPDSSearchDirection searchDirection,
-                                   WPDSType wpdsty)
-    : recordWitnesses(recordWitnesses), searchDirection(searchDirection),
-      wpdsty(wpdsty) {}
+WPDSSolverConfig::WPDSSolverConfig(bool RecordWitnesses,
+                                   WPDSSearchDirection SearchDirection,
+                                   WPDSType Wpdsty)
+    : recordWitnesses(RecordWitnesses), searchDirection(SearchDirection),
+      wpdsty(Wpdsty) {}
 
 ostream &operator<<(ostream &OS, const WPDSSolverConfig &SC) {
   return OS << "WPDSSolverConfig:\n"

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
@@ -91,7 +91,7 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
           llvm::ImmutableCallSite CS(&I);
           if (CS.getCalledFunction()) {
             if (MemAllocatingFunctions.count(
-                    cxx_demangle(CS.getCalledFunction()->getName().str()))) {
+                    cxxDemangle(CS.getCalledFunction()->getName().str()))) {
               // do not add allocas from llvm internal functions
               Stats.allocaInstructions.insert(&I);
               ++Stats.allocationsites;

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
@@ -91,7 +91,7 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
           llvm::ImmutableCallSite CS(&I);
           if (CS.getCalledFunction()) {
             if (MemAllocatingFunctions.count(
-                    cxxDemangle(CS.getCalledFunction()->getName().str()))) {
+                    cxx_demangle(CS.getCalledFunction()->getName().str()))) {
               // do not add allocas from llvm internal functions
               Stats.allocaInstructions.insert(&I);
               ++Stats.allocationsites;

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
@@ -41,9 +41,9 @@ GeneralStatisticsAnalysis::GeneralStatisticsAnalysis() {}
 GeneralStatistics
 GeneralStatisticsAnalysis::run(llvm::Module &M,
                                llvm::ModuleAnalysisManager &AM) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << "Running GeneralStatisticsAnalysis");
-  static const std::set<std::string> mem_allocating_functions = {
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO) << "Running GeneralStatisticsAnalysis");
+  static const std::set<std::string> MemAllocatingFunctions = {
       "operator new(unsigned long)", "operator new[](unsigned long)", "malloc",
       "calloc", "realloc"};
   for (auto &F : M) {
@@ -54,17 +54,17 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
         // found one more instruction
         ++Stats.instructions;
         // check for alloca instruction for possible types
-        if (const llvm::AllocaInst *alloc =
+        if (const llvm::AllocaInst *Alloc =
                 llvm::dyn_cast<llvm::AllocaInst>(&I)) {
-          Stats.allocatedTypes.insert(alloc->getAllocatedType());
+          Stats.allocatedTypes.insert(Alloc->getAllocatedType());
           // do not add allocas from llvm internal functions
           Stats.allocaInstructions.insert(&I);
           ++Stats.allocationsites;
         } // check bitcast instructions for possible types
         else {
-          for (auto user : I.users()) {
-            if (const llvm::BitCastInst *cast =
-                    llvm::dyn_cast<llvm::BitCastInst>(user)) {
+          for (auto User : I.users()) {
+            if (const llvm::BitCastInst *Cast =
+                    llvm::dyn_cast<llvm::BitCastInst>(User)) {
               // types.insert(cast->getDestTy());
             }
           }
@@ -90,7 +90,7 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
           ++Stats.callsites;
           llvm::ImmutableCallSite CS(&I);
           if (CS.getCalledFunction()) {
-            if (mem_allocating_functions.count(
+            if (MemAllocatingFunctions.count(
                     cxx_demangle(CS.getCalledFunction()->getName().str()))) {
               // do not add allocas from llvm internal functions
               Stats.allocaInstructions.insert(&I);
@@ -126,8 +126,8 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
     }
   }
   // check for global pointers
-  for (auto &global : M.globals()) {
-    if (global.getType()->isPointerTy()) {
+  for (auto &Global : M.globals()) {
+    if (Global.getType()->isPointerTy()) {
       ++Stats.globalPointers;
     }
     ++Stats.globals;
@@ -155,27 +155,27 @@ GeneralStatisticsAnalysis::run(llvm::Module &M,
   // Using the logging guard explicitly since we are printing allocated types
   // manually
   if (boost::log::core::get()->get_logging_enabled()) {
-    auto &lg = lg::get();
-    BOOST_LOG_SEV(lg, INFO) << "GeneralStatisticsAnalysis summary for module: '"
+    auto &LG = lg::get();
+    BOOST_LOG_SEV(LG, INFO) << "GeneralStatisticsAnalysis summary for module: '"
                             << M.getName().str() << "'";
-    BOOST_LOG_SEV(lg, INFO) << "Instructions       : " << Stats.instructions;
-    BOOST_LOG_SEV(lg, INFO)
+    BOOST_LOG_SEV(LG, INFO) << "Instructions       : " << Stats.instructions;
+    BOOST_LOG_SEV(LG, INFO)
         << "Allocated Types    : " << Stats.allocatedTypes.size();
-    BOOST_LOG_SEV(lg, INFO) << "Allocation Sites   : " << Stats.allocationsites;
-    BOOST_LOG_SEV(lg, INFO) << "Basic Blocks       : " << Stats.basicblocks;
-    BOOST_LOG_SEV(lg, INFO) << "Calls Sites        : " << Stats.callsites;
-    BOOST_LOG_SEV(lg, INFO) << "Functions          : " << Stats.functions;
-    BOOST_LOG_SEV(lg, INFO) << "Globals            : " << Stats.globals;
-    BOOST_LOG_SEV(lg, INFO) << "Global Pointer     : " << Stats.globalPointers;
-    BOOST_LOG_SEV(lg, INFO) << "Memory Intrinsics  : " << Stats.memIntrinsic;
-    BOOST_LOG_SEV(lg, INFO)
+    BOOST_LOG_SEV(LG, INFO) << "Allocation Sites   : " << Stats.allocationsites;
+    BOOST_LOG_SEV(LG, INFO) << "Basic Blocks       : " << Stats.basicblocks;
+    BOOST_LOG_SEV(LG, INFO) << "Calls Sites        : " << Stats.callsites;
+    BOOST_LOG_SEV(LG, INFO) << "Functions          : " << Stats.functions;
+    BOOST_LOG_SEV(LG, INFO) << "Globals            : " << Stats.globals;
+    BOOST_LOG_SEV(LG, INFO) << "Global Pointer     : " << Stats.globalPointers;
+    BOOST_LOG_SEV(LG, INFO) << "Memory Intrinsics  : " << Stats.memIntrinsic;
+    BOOST_LOG_SEV(LG, INFO)
         << "Store Instructions : " << Stats.storeInstructions;
-    BOOST_LOG_SEV(lg, INFO) << ' ';
-    for (auto type : Stats.allocatedTypes) {
-      std::string type_str;
-      llvm::raw_string_ostream rso(type_str);
-      type->print(rso);
-      BOOST_LOG_SEV(lg, INFO) << "  " << rso.str();
+    BOOST_LOG_SEV(LG, INFO) << ' ';
+    for (auto Type : Stats.allocatedTypes) {
+      std::string TypeStr;
+      llvm::raw_string_ostream Rso(TypeStr);
+      Type->print(Rso);
+      BOOST_LOG_SEV(LG, INFO) << "  " << Rso.str();
     }
   }
   // now we are done and can return the results

--- a/lib/PhasarLLVM/Passes/ValueAnnotationPass.cpp
+++ b/lib/PhasarLLVM/Passes/ValueAnnotationPass.cpp
@@ -37,35 +37,35 @@ namespace psr {
 
 llvm::AnalysisKey ValueAnnotationPass::Key;
 
-size_t ValueAnnotationPass::unique_value_id = 0;
+size_t ValueAnnotationPass::UniqueValueId = 0;
 
 ValueAnnotationPass::ValueAnnotationPass() {}
 
 llvm::PreservedAnalyses
 ValueAnnotationPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << "Running ValueAnnotationPass");
-  auto &context = M.getContext();
-  for (auto &global : M.globals()) {
-    llvm::MDNode *node = llvm::MDNode::get(
-        context, llvm::MDString::get(context, std::to_string(unique_value_id)));
-    global.setMetadata(PhasarConfig::MetaDataKind(), node);
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO) << "Running ValueAnnotationPass");
+  auto &Context = M.getContext();
+  for (auto &Global : M.globals()) {
+    llvm::MDNode *Node = llvm::MDNode::get(
+        Context, llvm::MDString::get(Context, std::to_string(UniqueValueId)));
+    Global.setMetadata(PhasarConfig::MetaDataKind(), Node);
     //		std::cout <<
     // llvm::cast<llvm::MDString>(global.getMetadata(MetaDataKind)->getOperand(0))->getString().str()
     //<< std::endl;
-    ++unique_value_id;
+    ++UniqueValueId;
   }
   for (auto &F : M) {
     for (auto &BB : F) {
       for (auto &I : BB) {
-        llvm::MDNode *node = llvm::MDNode::get(
-            context,
-            llvm::MDString::get(context, std::to_string(unique_value_id)));
-        I.setMetadata(PhasarConfig::MetaDataKind(), node);
+        llvm::MDNode *Node = llvm::MDNode::get(
+            Context,
+            llvm::MDString::get(Context, std::to_string(UniqueValueId)));
+        I.setMetadata(PhasarConfig::MetaDataKind(), Node);
         //		    	std::cout <<
         // llvm::cast<llvm::MDString>(I.getMetadata(MetaDataKind)->getOperand(0))->getString().str()
         //<< std::endl;
-        ++unique_value_id;
+        ++UniqueValueId;
       }
     }
   }
@@ -74,7 +74,7 @@ ValueAnnotationPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
 
 void ValueAnnotationPass::resetValueID() {
   cout << "Reset ID" << endl;
-  unique_value_id = 0;
+  UniqueValueId = 0;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
+++ b/lib/PhasarLLVM/Plugins/AnalysisPluginController.cpp
@@ -35,7 +35,7 @@ AnalysisPluginController::AnalysisPluginController(
     std::vector<std::string> AnalysisPlygins, const ProjectIRDB *IRDB,
     const LLVMTypeHierarchy *TH, const LLVMBasedICFG *ICF,
     const LLVMPointsToInfo *PT, std::set<std::string> EntryPoints) {
-  auto &lg = lg::get();
+  auto &LG = lg::get();
   for (const auto &AnalysisPlugin : AnalysisPlygins) {
     boost::filesystem::path LibPath(AnalysisPlugin);
     boost::system::error_code Err;

--- a/lib/PhasarLLVM/Plugins/ICFGTestPlugin.cxx
+++ b/lib/PhasarLLVM/Plugins/ICFGTestPlugin.cxx
@@ -39,61 +39,61 @@ ICFGTestPlugin::ICFGTestPlugin(ProjectIRDB &IRDB,
     : ICFGPlugin(IRDB, EntryPoints) {}
 
 ICFGTestPlugin::f_t
-ICFGTestPlugin::getFunctionOf(ICFGTestPlugin::n_t stmt) const {
+ICFGTestPlugin::getFunctionOf(ICFGTestPlugin::n_t Stmt) const {
   return nullptr;
 }
 
 std::vector<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getPredsOf(ICFGTestPlugin::n_t stmt) const {
+ICFGTestPlugin::getPredsOf(ICFGTestPlugin::n_t Stmt) const {
   return {};
 }
 
 std::vector<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getSuccsOf(ICFGTestPlugin::n_t stmt) const {
+ICFGTestPlugin::getSuccsOf(ICFGTestPlugin::n_t Stmt) const {
   return {};
 }
 
 std::vector<std::pair<ICFGTestPlugin::n_t, ICFGTestPlugin::n_t>>
-ICFGTestPlugin::getAllControlFlowEdges(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getAllControlFlowEdges(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
 std::vector<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getAllInstructionsOf(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getAllInstructionsOf(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
-bool ICFGTestPlugin::isExitStmt(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isExitStmt(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isStartPoint(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isStartPoint(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isFieldLoad(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isFieldLoad(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isFieldStore(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isFieldStore(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isFallThroughSuccessor(ICFGTestPlugin::n_t stmt,
-                                            ICFGTestPlugin::n_t succ) const {
+bool ICFGTestPlugin::isFallThroughSuccessor(ICFGTestPlugin::n_t Stmt,
+                                            ICFGTestPlugin::n_t Succ) const {
   return false;
 }
 
-bool ICFGTestPlugin::isBranchTarget(ICFGTestPlugin::n_t stmt,
-                                    ICFGTestPlugin::n_t succ) const {
+bool ICFGTestPlugin::isBranchTarget(ICFGTestPlugin::n_t Stmt,
+                                    ICFGTestPlugin::n_t Succ) const {
   return false;
 }
 
-std::string ICFGTestPlugin::getStatementId(ICFGTestPlugin::n_t stmt) const {
+std::string ICFGTestPlugin::getStatementId(ICFGTestPlugin::n_t Stmt) const {
   return "";
 }
 
-std::string ICFGTestPlugin::getFunctionName(ICFGTestPlugin::f_t fun) const {
+std::string ICFGTestPlugin::getFunctionName(ICFGTestPlugin::f_t Fun) const {
   return "";
 }
 
@@ -109,19 +109,19 @@ std::set<ICFGTestPlugin::f_t> ICFGTestPlugin::getAllFunctions() const {
   return {};
 }
 
-ICFGTestPlugin::f_t ICFGTestPlugin::getFunction(const std::string &fun) const {
+ICFGTestPlugin::f_t ICFGTestPlugin::getFunction(const std::string &Fun) const {
   return nullptr;
 }
 
-bool ICFGTestPlugin::isCallStmt(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isCallStmt(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isIndirectFunctionCall(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isIndirectFunctionCall(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
-bool ICFGTestPlugin::isVirtualFunctionCall(ICFGTestPlugin::n_t stmt) const {
+bool ICFGTestPlugin::isVirtualFunctionCall(ICFGTestPlugin::n_t Stmt) const {
   return false;
 }
 
@@ -130,32 +130,32 @@ std::set<ICFGTestPlugin::n_t> ICFGTestPlugin::allNonCallStartNodes() const {
 }
 
 std::set<ICFGTestPlugin::f_t>
-ICFGTestPlugin::getCalleesOfCallAt(ICFGTestPlugin::n_t stmt) const {
+ICFGTestPlugin::getCalleesOfCallAt(ICFGTestPlugin::n_t Stmt) const {
   return {};
 }
 
 std::set<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getCallersOf(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getCallersOf(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
 std::set<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getCallsFromWithin(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getCallsFromWithin(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
 std::set<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getStartPointsOf(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getStartPointsOf(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
 std::set<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getExitPointsOf(ICFGTestPlugin::f_t fun) const {
+ICFGTestPlugin::getExitPointsOf(ICFGTestPlugin::f_t Fun) const {
   return {};
 }
 
 std::set<ICFGTestPlugin::n_t>
-ICFGTestPlugin::getReturnSitesOfCallAt(ICFGTestPlugin::n_t stmt) const {
+ICFGTestPlugin::getReturnSitesOfCallAt(ICFGTestPlugin::n_t Stmt) const {
   return {};
 }
 

--- a/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
@@ -51,35 +51,35 @@ IFDSSFB901TaintAnalysis::IFDSSFB901TaintAnalysis(
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, EntryPoints) {}
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSFB901TaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
-                                               const llvm::Instruction *succ) {
+IFDSSFB901TaintAnalysis::getNormalFlowFunction(const llvm::Instruction *Curr,
+                                               const llvm::Instruction *Succ) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSFB901TaintAnalysis::getCallFlowFunction(const llvm::Instruction *callStmt,
-                                             const llvm::Function *destFun) {
+IFDSSFB901TaintAnalysis::getCallFlowFunction(const llvm::Instruction *CallStmt,
+                                             const llvm::Function *DestFun) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSFB901TaintAnalysis::getRetFlowFunction(const llvm::Instruction *callSite,
-                                            const llvm::Function *calleeFun,
-                                            const llvm::Instruction *exitStmt,
-                                            const llvm::Instruction *retSite) {
+IFDSSFB901TaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
+                                            const llvm::Function *CalleeFun,
+                                            const llvm::Instruction *ExitStmt,
+                                            const llvm::Instruction *RetSite) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getCallToRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Instruction *retSite,
-    set<const llvm::Function *> callees) {
+    const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
+    set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSFB901TaintAnalysis::getSummaryFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
@@ -62,7 +62,7 @@ IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
     struct STA : FlowFunction<const llvm::Value *> {
       const llvm::StoreInst *Store;
       STA(const llvm::StoreInst *S) : Store(S) {}
-      set<const llvm::Value *> computeTargets(const llvm::Value *src) {
+      set<const llvm::Value *> computeTargets(const llvm::Value *src) override {
         if (Store->getValueOperand() == src) {
           return {Store->getValueOperand(), Store->getPointerOperand()};
         } else {

--- a/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
@@ -56,14 +56,14 @@ IFDSSimpleTaintAnalysis::IFDSSimpleTaintAnalysis(
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, EntryPoints) {}
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
-                                               const llvm::Instruction *succ) {
-  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(curr)) {
+IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *Curr,
+                                               const llvm::Instruction *Succ) {
+  if (auto Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
     struct STA : FlowFunction<const llvm::Value *> {
       const llvm::StoreInst *Store;
       STA(const llvm::StoreInst *S) : Store(S) {}
-      set<const llvm::Value *> computeTargets(const llvm::Value *src) override {
-        if (Store->getValueOperand() == src) {
+      set<const llvm::Value *> computeTargets(const llvm::Value *Src) override {
+        if (Store->getValueOperand() == Src) {
           return {Store->getValueOperand(), Store->getPointerOperand()};
         } else {
           return {Store->getValueOperand()};
@@ -76,12 +76,12 @@ IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *curr,
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *callStmt,
-                                             const llvm::Function *destFun) {
-  if (auto Call = llvm::dyn_cast<llvm::CallInst>(callStmt)) {
-    if (destFun->getName().str() == "taint") {
+IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *CallStmt,
+                                             const llvm::Function *DestFun) {
+  if (auto Call = llvm::dyn_cast<llvm::CallInst>(CallStmt)) {
+    if (DestFun->getName().str() == "taint") {
       return make_shared<Gen<const llvm::Value *>>(Call, getZeroValue());
-    } else if (destFun->getName().str() == "leak") {
+    } else if (DestFun->getName().str() == "leak") {
     } else {
     }
   }
@@ -89,23 +89,23 @@ IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *callStmt,
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
-IFDSSimpleTaintAnalysis::getRetFlowFunction(const llvm::Instruction *callSite,
-                                            const llvm::Function *calleeFun,
-                                            const llvm::Instruction *exitStmt,
-                                            const llvm::Instruction *retSite) {
+IFDSSimpleTaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
+                                            const llvm::Function *CalleeFun,
+                                            const llvm::Instruction *ExitStmt,
+                                            const llvm::Instruction *RetSite) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getCallToRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Instruction *retSite,
-    set<const llvm::Function *> callees) {
+    const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
+    set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSSimpleTaintAnalysis::getSummaryFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
@@ -53,33 +53,33 @@ IFDSTabulationProblemTestPlugin::IFDSTabulationProblemTestPlugin(
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getNormalFlowFunction(
-    const llvm::Instruction *curr, const llvm::Instruction *succ) {
+    const llvm::Instruction *Curr, const llvm::Instruction *Succ) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getCallFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Function *calleeFun,
-    const llvm::Instruction *exitStmt, const llvm::Instruction *retSite) {
+    const llvm::Instruction *CallSite, const llvm::Function *CalleeFun,
+    const llvm::Instruction *ExitStmt, const llvm::Instruction *RetSite) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getCallToRetFlowFunction(
-    const llvm::Instruction *callSite, const llvm::Instruction *retSite,
-    set<const llvm::Function *> callees) {
+    const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
+    set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
 shared_ptr<FlowFunction<const llvm::Value *>>
 IFDSTabulationProblemTestPlugin::getSummaryFlowFunction(
-    const llvm::Instruction *callStmt, const llvm::Function *destFun) {
+    const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;
 }
 

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
@@ -52,18 +52,18 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
       : AllocationSites(AllocationSizes), CallStack(CallStack) {}
 
   template <typename Vertex, typename Graph>
-  void discover_vertex(Vertex U, const Graph &G) {
+  void discoverVertex(Vertex U, const Graph &G) {
     VisitorStack.push_back(U);
   }
 
   template <typename Vertex, typename Graph>
-  void finish_vertex(Vertex U, const Graph &G) {
+  void finishVertex(Vertex U, const Graph &G) {
     auto &LG = lg::get();
     // check for stack allocation
     if (const llvm::AllocaInst *Alloc =
             llvm::dyn_cast<llvm::AllocaInst>(G[U].V)) {
       // If the call stack is empty, we completely ignore the calling context
-      if (matches_stack(G) || CallStack.empty()) {
+      if (matchesStack(G) || CallStack.empty()) {
         LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                       << "Found stack allocation: " << llvmIRToString(Alloc));
         AllocationSites.insert(G[U].V);
@@ -78,7 +78,7 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
               CS.getCalledFunction()->getName().str())) {
         // If the call stack is empty, we completely ignore the calling
         // context
-        if (matches_stack(G) || CallStack.empty()) {
+        if (matchesStack(G) || CallStack.empty()) {
           LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                         << "Found heap allocation: "
                         << llvmIRToString(CS.getInstruction()));
@@ -89,7 +89,7 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
     VisitorStack.pop_back();
   }
 
-  template <typename Graph> bool matches_stack(const Graph &G) {
+  template <typename Graph> bool matchesStack(const Graph &G) {
     size_t CallStackIdx = 0;
     for (size_t I = 0, J = 1;
          I < VisitorStack.size() && J < VisitorStack.size(); ++I, ++J) {
@@ -109,7 +109,7 @@ struct PointsToGraph::ReachabilityDFSVisitor : boost::default_dfs_visitor {
   std::set<vertex_t> &PointsToSet;
   ReachabilityDFSVisitor(set<vertex_t> &Result) : PointsToSet(Result) {}
   template <typename Vertex, typename Graph>
-  void finish_vertex(Vertex U, const Graph &G) {
+  void finishVertex(Vertex U, const Graph &G) {
     PointsToSet.insert(U);
   }
 };

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
@@ -58,13 +58,13 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
 
   template <typename Vertex, typename Graph>
   void finish_vertex(Vertex U, const Graph &G) {
-    auto &lg = lg::get();
+    auto &LG = lg::get();
     // check for stack allocation
     if (const llvm::AllocaInst *Alloc =
             llvm::dyn_cast<llvm::AllocaInst>(G[U].V)) {
       // If the call stack is empty, we completely ignore the calling context
       if (matches_stack(G) || CallStack.empty()) {
-        LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+        LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                       << "Found stack allocation: " << llvmIRToString(Alloc));
         AllocationSites.insert(G[U].V);
       }
@@ -79,7 +79,7 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
         // If the call stack is empty, we completely ignore the calling
         // context
         if (matches_stack(G) || CallStack.empty()) {
-          LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+          LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                         << "Found heap allocation: "
                         << llvmIRToString(CS.getInstruction()));
           AllocationSites.insert(G[U].V);
@@ -90,16 +90,16 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
   }
 
   template <typename Graph> bool matches_stack(const Graph &G) {
-    size_t call_stack_idx = 0;
-    for (size_t i = 0, j = 1;
-         i < VisitorStack.size() && j < VisitorStack.size(); ++i, ++j) {
-      auto e = boost::edge(VisitorStack[i], VisitorStack[j], G);
-      if (G[e.first].V == nullptr)
+    size_t CallStackIdx = 0;
+    for (size_t I = 0, J = 1;
+         I < VisitorStack.size() && J < VisitorStack.size(); ++I, ++J) {
+      auto E = boost::edge(VisitorStack[I], VisitorStack[J], G);
+      if (G[E.first].V == nullptr)
         continue;
-      if (G[e.first].V != CallStack[CallStack.size() - call_stack_idx - 1]) {
+      if (G[E.first].V != CallStack[CallStack.size() - CallStackIdx - 1]) {
         return false;
       }
-      call_stack_idx++;
+      CallStackIdx++;
     }
     return true;
   }
@@ -128,8 +128,8 @@ PointsToGraph::VertexProperties::getUsers() const {
   if (!users.empty() || V == nullptr) {
     return users;
   }
-  auto allUsers = V->users();
-  users.insert(users.end(), allUsers.begin(), allUsers.end());
+  auto AllUsers = V->users();
+  users.insert(users.end(), AllUsers.begin(), AllUsers.end());
   return users;
 }
 
@@ -143,8 +143,8 @@ std::string PointsToGraph::EdgeProperties::getValueAsString() const {
 
 PointsToGraph::PointsToGraph(llvm::Function *F, llvm::AAResults &AA) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Analyzing function: " << F->getName().str());
   ContainedFunctions.insert(F);
   bool PrintAll, PrintNoAlias, PrintMayAlias, PrintPartialAlias, PrintMustAlias,
@@ -203,14 +203,14 @@ PointsToGraph::PointsToGraph(llvm::Function *F, llvm::AAResults &AA) {
     ValueVertexMap[P] = boost::add_vertex(VertexProperties(P), PAG);
   }
   // iterate over the worklist, and run the full (n^2)/2 disambiguations
-  const auto mapEnd = ValueVertexMap.end();
-  for (auto I1 = ValueVertexMap.begin(); I1 != mapEnd; ++I1) {
+  const auto MapEnd = ValueVertexMap.end();
+  for (auto I1 = ValueVertexMap.begin(); I1 != MapEnd; ++I1) {
     llvm::Type *I1ElTy =
         llvm::cast<llvm::PointerType>(I1->first->getType())->getElementType();
     const uint64_t I1Size = I1ElTy->isSized()
                                 ? DL.getTypeStoreSize(I1ElTy)
                                 : llvm::MemoryLocation::UnknownSize;
-    for (auto I2 = std::next(I1); I2 != mapEnd; ++I2) {
+    for (auto I2 = std::next(I1); I2 != MapEnd; ++I2) {
       llvm::Type *I2ElTy =
           llvm::cast<llvm::PointerType>(I2->first->getType())->getElementType();
       const uint64_t I2Size = I2ElTy->isSized()
@@ -234,88 +234,87 @@ PointsToGraph::PointsToGraph(llvm::Function *F, llvm::AAResults &AA) {
 
 vector<pair<unsigned, const llvm::Value *>>
 PointsToGraph::getPointersEscapingThroughParams() {
-  vector<pair<unsigned, const llvm::Value *>> escaping_pointers;
-  for (auto vertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
-    if (const llvm::Argument *arg =
-            llvm::dyn_cast<llvm::Argument>(PAG[vertexIter].V)) {
-      escaping_pointers.push_back(make_pair(arg->getArgNo(), arg));
+  vector<pair<unsigned, const llvm::Value *>> EscapingPointers;
+  for (auto VertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
+    if (const llvm::Argument *Arg =
+            llvm::dyn_cast<llvm::Argument>(PAG[VertexIter].V)) {
+      EscapingPointers.push_back(make_pair(Arg->getArgNo(), Arg));
     }
   }
-  return escaping_pointers;
+  return EscapingPointers;
 }
 
 vector<const llvm::Value *>
 PointsToGraph::getPointersEscapingThroughReturns() const {
-  vector<const llvm::Value *> escaping_pointers;
-  for (auto vertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
-    auto &vertex = PAG[vertexIter];
-    for (const auto user : vertex.getUsers()) {
-      if (llvm::isa<llvm::ReturnInst>(user)) {
-        escaping_pointers.push_back(vertex.V);
+  vector<const llvm::Value *> EscapingPointers;
+  for (auto VertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
+    auto &Vertex = PAG[VertexIter];
+    for (const auto User : Vertex.getUsers()) {
+      if (llvm::isa<llvm::ReturnInst>(User)) {
+        EscapingPointers.push_back(Vertex.V);
       }
     }
   }
-  return escaping_pointers;
+  return EscapingPointers;
 }
 
 vector<const llvm::Value *>
 PointsToGraph::getPointersEscapingThroughReturnsForFunction(
     const llvm::Function *F) const {
-  vector<const llvm::Value *> escaping_pointers;
-  for (auto vertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
-    auto &vertex = PAG[vertexIter];
-    for (const auto user : vertex.getUsers()) {
-      if (auto R = llvm::dyn_cast<llvm::ReturnInst>(user)) {
+  vector<const llvm::Value *> EscapingPointers;
+  for (auto VertexIter : boost::make_iterator_range(boost::vertices(PAG))) {
+    auto &Vertex = PAG[VertexIter];
+    for (const auto User : Vertex.getUsers()) {
+      if (auto R = llvm::dyn_cast<llvm::ReturnInst>(User)) {
         if (R->getFunction() == F)
-          escaping_pointers.push_back(vertex.V);
+          EscapingPointers.push_back(Vertex.V);
       }
     }
   }
-  return escaping_pointers;
+  return EscapingPointers;
 }
 
 set<const llvm::Value *> PointsToGraph::getReachableAllocationSites(
     const llvm::Value *V, vector<const llvm::Instruction *> CallStack) {
-  set<const llvm::Value *> alloc_sites;
-  AllocationSiteDFSVisitor alloc_vis(alloc_sites, CallStack);
-  vector<boost::default_color_type> color_map(boost::num_vertices(PAG));
+  set<const llvm::Value *> AllocSites;
+  AllocationSiteDFSVisitor AllocVis(AllocSites, CallStack);
+  vector<boost::default_color_type> ColorMap(boost::num_vertices(PAG));
   boost::depth_first_visit(
-      PAG, ValueVertexMap[V], alloc_vis,
-      boost::make_iterator_property_map(color_map.begin(),
-                                        boost::get(boost::vertex_index, PAG),
-                                        color_map[0]));
-  return alloc_sites;
+      PAG, ValueVertexMap[V], AllocVis,
+      boost::make_iterator_property_map(
+          ColorMap.begin(), boost::get(boost::vertex_index, PAG), ColorMap[0]));
+  return AllocSites;
 }
 
 bool PointsToGraph::containsValue(llvm::Value *V) {
-  for (auto vertexIter : boost::make_iterator_range(boost::vertices(PAG)))
-    if (PAG[vertexIter].V == V)
+  for (auto VertexIter : boost::make_iterator_range(boost::vertices(PAG)))
+    if (PAG[VertexIter].V == V)
       return true;
   return false;
 }
 
 set<const llvm::Type *>
 PointsToGraph::computeTypesFromAllocationSites(set<const llvm::Value *> AS) {
-  set<const llvm::Type *> types;
+  set<const llvm::Type *> Types;
   // an allocation site can either be an AllocaInst or a call to an allocating
   // function
   for (auto V : AS) {
-    if (const llvm::AllocaInst *alloc = llvm::dyn_cast<llvm::AllocaInst>(V)) {
-      types.insert(alloc->getAllocatedType());
+    if (const llvm::AllocaInst *Alloc = llvm::dyn_cast<llvm::AllocaInst>(V)) {
+      Types.insert(Alloc->getAllocatedType());
     } else {
       // usually if an allocating function is called, it is immediately
       // bit-casted
       // to the desired allocated value and hence we can determine it from the
       // destination type of that cast instruction.
-      for (auto user : V->users()) {
-        if (const llvm::BitCastInst *cast =
-                llvm::dyn_cast<llvm::BitCastInst>(user)) {
-          types.insert(cast->getDestTy());
+      for (auto User : V->users()) {
+        if (const llvm::BitCastInst *Cast =
+                llvm::dyn_cast<llvm::BitCastInst>(User)) {
+          Types.insert(Cast->getDestTy());
         }
       }
     }
   }
-  return types;
+  return Types;
 }
 
 set<const llvm::Value *>
@@ -327,21 +326,20 @@ PointsToGraph::getPointsToSet(const llvm::Value *V) const {
   if (!ValueVertexMap.count(V)) {
     return {};
   }
-  set<vertex_t> reachable_vertices;
-  ReachabilityDFSVisitor vis(reachable_vertices);
-  vector<boost::default_color_type> color_map(boost::num_vertices(PAG));
+  set<vertex_t> ReachableVertices;
+  ReachabilityDFSVisitor Vis(ReachableVertices);
+  vector<boost::default_color_type> ColorMap(boost::num_vertices(PAG));
   boost::depth_first_visit(
-      PAG, ValueVertexMap.at(V), vis,
-      boost::make_iterator_property_map(color_map.begin(),
-                                        boost::get(boost::vertex_index, PAG),
-                                        color_map[0]));
-  set<const llvm::Value *> result;
-  for (auto vertex : reachable_vertices) {
-    result.insert(PAG[vertex].V);
+      PAG, ValueVertexMap.at(V), Vis,
+      boost::make_iterator_property_map(
+          ColorMap.begin(), boost::get(boost::vertex_index, PAG), ColorMap[0]));
+  set<const llvm::Value *> Result;
+  for (auto Vertex : ReachableVertices) {
+    Result.insert(PAG[Vertex].V);
   }
   PAUSE_TIMER("PointsTo-Set Computation", PAMM_SEVERITY_LEVEL::Full);
-  ADD_TO_HISTOGRAM("Points-to", result.size(), 1, PAMM_SEVERITY_LEVEL::Full);
-  return result;
+  ADD_TO_HISTOGRAM("Points-to", Result.size(), 1, PAMM_SEVERITY_LEVEL::Full);
+  return Result;
 }
 
 bool PointsToGraph::representsSingleFunction() {
@@ -351,13 +349,13 @@ bool PointsToGraph::representsSingleFunction() {
 void PointsToGraph::print(std::ostream &OS) const {
   for (const auto &Fn : ContainedFunctions) {
     cout << "PointsToGraph for " << Fn->getName().str() << ":\n";
-    vertex_iterator ui, ui_end;
-    for (boost::tie(ui, ui_end) = boost::vertices(PAG); ui != ui_end; ++ui) {
-      OS << PAG[*ui].getValueAsString() << " <--> ";
-      out_edge_iterator ei, ei_end;
-      for (boost::tie(ei, ei_end) = boost::out_edges(*ui, PAG); ei != ei_end;
-           ++ei) {
-        OS << PAG[target(*ei, PAG)].getValueAsString() << " ";
+    vertex_iterator UI, UIEnd;
+    for (boost::tie(UI, UIEnd) = boost::vertices(PAG); UI != UIEnd; ++UI) {
+      OS << PAG[*UI].getValueAsString() << " <--> ";
+      out_edge_iterator EI, EIEnd;
+      for (boost::tie(EI, EIEnd) = boost::out_edges(*UI, PAG); EI != EIEnd;
+           ++EI) {
+        OS << PAG[target(*EI, PAG)].getValueAsString() << " ";
       }
       OS << '\n';
     }
@@ -371,66 +369,65 @@ void PointsToGraph::printAsDot(std::ostream &OS) const {
 
 nlohmann::json PointsToGraph::getAsJson() {
   nlohmann::json J;
-  vertex_iterator vi_v, vi_v_end;
-  out_edge_iterator ei, ei_end;
+  vertex_iterator VIv, VIvEnd;
+  out_edge_iterator EI, EIEnd;
   // iterate all graph vertices
-  for (boost::tie(vi_v, vi_v_end) = boost::vertices(PAG); vi_v != vi_v_end;
-       ++vi_v) {
-    J[PhasarConfig::JsonPointToGraphID()][PAG[*vi_v].getValueAsString()];
+  for (boost::tie(VIv, VIvEnd) = boost::vertices(PAG); VIv != VIvEnd; ++VIv) {
+    J[PhasarConfig::JsonPointToGraphID()][PAG[*VIv].getValueAsString()];
     // iterate all out edges of vertex vi_v
-    for (boost::tie(ei, ei_end) = boost::out_edges(*vi_v, PAG); ei != ei_end;
-         ++ei) {
-      J[PhasarConfig::JsonPointToGraphID()][PAG[*vi_v].getValueAsString()] +=
-          PAG[boost::target(*ei, PAG)].getValueAsString();
+    for (boost::tie(EI, EIEnd) = boost::out_edges(*VIv, PAG); EI != EIEnd;
+         ++EI) {
+      J[PhasarConfig::JsonPointToGraphID()][PAG[*VIv].getValueAsString()] +=
+          PAG[boost::target(*EI, PAG)].getValueAsString();
     }
   }
   return J;
 }
 
 void PointsToGraph::printValueVertexMap() {
-  for (const auto &entry : ValueVertexMap) {
-    cout << entry.first << " <---> " << entry.second << endl;
+  for (const auto &Entry : ValueVertexMap) {
+    cout << Entry.first << " <---> " << Entry.second << endl;
   }
 }
 
 void PointsToGraph::mergeGraph(const PointsToGraph &Other) {
   typedef graph_t::vertex_descriptor vertex_t;
   typedef std::map<vertex_t, vertex_t> vertex_map_t;
-  vertex_map_t oldToNewVertexMapping;
-  boost::associative_property_map<vertex_map_t> vertexMapWrapper(
-      oldToNewVertexMapping);
-  boost::copy_graph(Other.PAG, PAG, boost::orig_to_copy(vertexMapWrapper));
+  vertex_map_t OldToNewVertexMapping;
+  boost::associative_property_map<vertex_map_t> VertexMapWrapper(
+      OldToNewVertexMapping);
+  boost::copy_graph(Other.PAG, PAG, boost::orig_to_copy(VertexMapWrapper));
 
-  for (const auto &otherValues : Other.ValueVertexMap) {
-    auto mappingIter = oldToNewVertexMapping.find(otherValues.second);
-    if (mappingIter != oldToNewVertexMapping.end()) {
-      ValueVertexMap.insert(make_pair(otherValues.first, mappingIter->second));
+  for (const auto &OtherValues : Other.ValueVertexMap) {
+    auto MappingIter = OldToNewVertexMapping.find(OtherValues.second);
+    if (MappingIter != OldToNewVertexMapping.end()) {
+      ValueVertexMap.insert(make_pair(OtherValues.first, MappingIter->second));
     }
   }
 }
 
 void PointsToGraph::mergeCallSite(const llvm::ImmutableCallSite &CS,
                                   const llvm::Function *F) {
-  auto formalArgRange = F->args();
-  auto formalIter = formalArgRange.begin();
-  auto mapEnd = ValueVertexMap.end();
-  for (const auto &arg : CS.args()) {
-    const llvm::Argument *Formal = &*formalIter++;
-    auto argMapIter = ValueVertexMap.find(arg);
-    auto formalMapIter = ValueVertexMap.find(Formal);
-    if (argMapIter != mapEnd && formalMapIter != mapEnd) {
-      boost::add_edge(argMapIter->second, formalMapIter->second,
+  auto FormalArgRange = F->args();
+  auto FormalIter = FormalArgRange.begin();
+  auto MapEnd = ValueVertexMap.end();
+  for (const auto &Arg : CS.args()) {
+    const llvm::Argument *Formal = &*FormalIter++;
+    auto ArgMapIter = ValueVertexMap.find(Arg);
+    auto FormalMapIter = ValueVertexMap.find(Formal);
+    if (ArgMapIter != MapEnd && FormalMapIter != MapEnd) {
+      boost::add_edge(ArgMapIter->second, FormalMapIter->second,
                       CS.getInstruction(), PAG);
     }
-    if (formalIter == formalArgRange.end())
+    if (FormalIter == FormalArgRange.end())
       break;
   }
 
   for (auto Formal : getPointersEscapingThroughReturnsForFunction(F)) {
-    auto instrMapIter = ValueVertexMap.find(CS.getInstruction());
-    auto formalMapIter = ValueVertexMap.find(Formal);
-    if (instrMapIter != mapEnd && formalMapIter != mapEnd) {
-      boost::add_edge(instrMapIter->second, formalMapIter->second,
+    auto InstrMapIter = ValueVertexMap.find(CS.getInstruction());
+    auto FormalMapIter = ValueVertexMap.find(Formal);
+    if (InstrMapIter != MapEnd && FormalMapIter != MapEnd) {
+      boost::add_edge(InstrMapIter->second, FormalMapIter->second,
                       CS.getInstruction(), PAG);
     }
   }
@@ -450,8 +447,8 @@ void PointsToGraph::mergeWith(
   ContainedFunctions.insert(Other.ContainedFunctions.begin(),
                             Other.ContainedFunctions.end());
   mergeGraph(Other);
-  for (const auto &call : Calls) {
-    mergeCallSite(call.first, call.second);
+  for (const auto &Call : Calls) {
+    mergeCallSite(Call.first, Call.second);
   }
 }
 

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
@@ -52,18 +52,18 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
       : AllocationSites(AllocationSizes), CallStack(CallStack) {}
 
   template <typename Vertex, typename Graph>
-  void discoverVertex(Vertex U, const Graph &G) {
+  void discover_vertex(Vertex U, const Graph &G) {
     VisitorStack.push_back(U);
   }
 
   template <typename Vertex, typename Graph>
-  void finishVertex(Vertex U, const Graph &G) {
+  void finish_vertex(Vertex U, const Graph &G) {
     auto &LG = lg::get();
     // check for stack allocation
     if (const llvm::AllocaInst *Alloc =
             llvm::dyn_cast<llvm::AllocaInst>(G[U].V)) {
       // If the call stack is empty, we completely ignore the calling context
-      if (matchesStack(G) || CallStack.empty()) {
+      if (matches_stack(G) || CallStack.empty()) {
         LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                       << "Found stack allocation: " << llvmIRToString(Alloc));
         AllocationSites.insert(G[U].V);
@@ -78,7 +78,7 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
               CS.getCalledFunction()->getName().str())) {
         // If the call stack is empty, we completely ignore the calling
         // context
-        if (matchesStack(G) || CallStack.empty()) {
+        if (matches_stack(G) || CallStack.empty()) {
           LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                         << "Found heap allocation: "
                         << llvmIRToString(CS.getInstruction()));
@@ -89,7 +89,7 @@ struct PointsToGraph::AllocationSiteDFSVisitor : boost::default_dfs_visitor {
     VisitorStack.pop_back();
   }
 
-  template <typename Graph> bool matchesStack(const Graph &G) {
+  template <typename Graph> bool matches_stack(const Graph &G) {
     size_t CallStackIdx = 0;
     for (size_t I = 0, J = 1;
          I < VisitorStack.size() && J < VisitorStack.size(); ++I, ++J) {
@@ -109,7 +109,7 @@ struct PointsToGraph::ReachabilityDFSVisitor : boost::default_dfs_visitor {
   std::set<vertex_t> &PointsToSet;
   ReachabilityDFSVisitor(set<vertex_t> &Result) : PointsToSet(Result) {}
   template <typename Vertex, typename Graph>
-  void finishVertex(Vertex U, const Graph &G) {
+  void finish_vertex(Vertex U, const Graph &G) {
     PointsToSet.insert(U);
   }
 };

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -31,7 +31,7 @@ using namespace psr;
 
 namespace psr {
 
-static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
+static void printResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
                          const llvm::Value *V2, const llvm::Module *M) {
   if (P) {
     std::string O1, O2;
@@ -48,7 +48,7 @@ static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
   }
 }
 
-static inline void PrintModRefResults(const char *Msg, bool P,
+static inline void printModRefResults(const char *Msg, bool P,
                                       llvm::Instruction *I, llvm::Value *Ptr,
                                       llvm::Module *M) {
   if (P) {
@@ -58,7 +58,7 @@ static inline void PrintModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void PrintModRefResults(const char *Msg, bool P,
+static inline void printModRefResults(const char *Msg, bool P,
                                       llvm::CallBase *CallA,
                                       llvm::CallBase *CallB, llvm::Module *M) {
   if (P) {
@@ -66,7 +66,7 @@ static inline void PrintModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void PrintLoadStoreResults(llvm::AliasResult AR, bool P,
+static inline void printLoadStoreResults(llvm::AliasResult AR, bool P,
                                          const llvm::Value *V1,
                                          const llvm::Value *V2,
                                          const llvm::Module *M) {
@@ -75,7 +75,7 @@ static inline void PrintLoadStoreResults(llvm::AliasResult AR, bool P,
   }
 }
 
-std::string to_string(const PointerAnalysisType &PA) {
+std::string toString(const PointerAnalysisType &PA) {
   switch (PA) {
   default:
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
@@ -86,7 +86,7 @@ std::string to_string(const PointerAnalysisType &PA) {
   }
 }
 
-PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
+PointerAnalysisType toPointerAnalysisType(const std::string &S) {
   PointerAnalysisType Type = llvm::StringSwitch<PointerAnalysisType>(S)
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
   .Case(NAME, PointerAnalysisType::TYPE)
@@ -103,7 +103,7 @@ PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const PointerAnalysisType &PA) {
-  return OS << to_string(PA);
+  return OS << toString(PA);
 }
 
 LLVMPointsToInfo::LLVMPointsToInfo(ProjectIRDB &IRDB, PointerAnalysisType PAT) {
@@ -284,16 +284,16 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
         llvm::AliasResult AR = AA->alias(*I1, I1Size, *I2, I2Size);
         switch (AR) {
         case llvm::NoAlias:
-          PrintResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MayAlias:
-          PrintResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
           break;
         case llvm::PartialAlias:
-          PrintResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MustAlias:
-          PrintResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
           break;
         }
       }
@@ -308,19 +308,19 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(Store)));
           switch (AR) {
           case llvm::NoAlias:
-            PrintLoadStoreResults(AR, PrintNoAlias, Load, Store,
+            printLoadStoreResults(AR, PrintNoAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MayAlias:
-            PrintLoadStoreResults(AR, PrintMayAlias, Load, Store,
+            printLoadStoreResults(AR, PrintMayAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::PartialAlias:
-            PrintLoadStoreResults(AR, PrintPartialAlias, Load, Store,
+            printLoadStoreResults(AR, PrintPartialAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            PrintLoadStoreResults(AR, PrintMustAlias, Load, Store,
+            printLoadStoreResults(AR, PrintMustAlias, Load, Store,
                                   F->getParent());
             break;
           }
@@ -338,17 +338,17 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(*I2)));
           switch (AR) {
           case llvm::NoAlias:
-            PrintLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
             break;
           case llvm::MayAlias:
-            PrintLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
             break;
           case llvm::PartialAlias:
-            PrintLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
+            printLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            PrintLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
             break;
           }
         }
@@ -366,34 +366,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
 
         switch (AA->getModRefInfo(Call, Pointer, Size)) {
         case llvm::ModRefInfo::NoModRef:
-          PrintModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
+          printModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          PrintModRefResults("Just Mod", PrintMod, Call, Pointer,
+          printModRefResults("Just Mod", PrintMod, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          PrintModRefResults("Just Ref", PrintRef, Call, Pointer,
+          printModRefResults("Just Ref", PrintRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          PrintModRefResults("Both ModRef", PrintModRef, Call, Pointer,
+          printModRefResults("Both ModRef", PrintModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          PrintModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
+          printModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
+          printModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
+          printModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
+          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
                              Pointer, F->getParent());
           break;
         }
@@ -407,34 +407,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
           continue;
         switch (AA->getModRefInfo(CallA, CallB)) {
         case llvm::ModRefInfo::NoModRef:
-          PrintModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
+          printModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          PrintModRefResults("Just Mod", PrintMod, CallA, CallB,
+          printModRefResults("Just Mod", PrintMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          PrintModRefResults("Just Ref", PrintRef, CallA, CallB,
+          printModRefResults("Just Ref", PrintRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          PrintModRefResults("Both ModRef", PrintModRef, CallA, CallB,
+          printModRefResults("Both ModRef", PrintModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          PrintModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
+          printModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
+          printModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
+          printModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
+          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
                              CallB, F->getParent());
           break;
         }

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -102,8 +102,8 @@ PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
   return Type;
 }
 
-std::ostream &operator<<(std::ostream &os, const PointerAnalysisType &PA) {
-  return os << to_string(PA);
+std::ostream &operator<<(std::ostream &OS, const PointerAnalysisType &PA) {
+  return OS << to_string(PA);
 }
 
 LLVMPointsToInfo::LLVMPointsToInfo(ProjectIRDB &IRDB, PointerAnalysisType PAT) {

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -86,7 +86,7 @@ std::string toString(const PointerAnalysisType &PA) {
   }
 }
 
-PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
+PointerAnalysisType toPointerAnalysisType(const std::string &S) {
   PointerAnalysisType Type = llvm::StringSwitch<PointerAnalysisType>(S)
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
   .Case(NAME, PointerAnalysisType::TYPE)

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -75,7 +75,7 @@ static inline void PrintLoadStoreResults(llvm::AliasResult AR, bool P,
   }
 }
 
-std::string to_string(const PointerAnalysisType &PA) {
+std::string toString(const PointerAnalysisType &PA) {
   switch (PA) {
   default:
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
@@ -103,7 +103,7 @@ PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const PointerAnalysisType &PA) {
-  return OS << to_string(PA);
+  return OS << toString(PA);
 }
 
 LLVMPointsToInfo::LLVMPointsToInfo(ProjectIRDB &IRDB, PointerAnalysisType PAT) {

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -31,7 +31,7 @@ using namespace psr;
 
 namespace psr {
 
-static void printResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
+static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
                          const llvm::Value *V2, const llvm::Module *M) {
   if (P) {
     std::string O1, O2;
@@ -48,7 +48,7 @@ static void printResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
   }
 }
 
-static inline void printModRefResults(const char *Msg, bool P,
+static inline void PrintModRefResults(const char *Msg, bool P,
                                       llvm::Instruction *I, llvm::Value *Ptr,
                                       llvm::Module *M) {
   if (P) {
@@ -58,7 +58,7 @@ static inline void printModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void printModRefResults(const char *Msg, bool P,
+static inline void PrintModRefResults(const char *Msg, bool P,
                                       llvm::CallBase *CallA,
                                       llvm::CallBase *CallB, llvm::Module *M) {
   if (P) {
@@ -66,7 +66,7 @@ static inline void printModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void printLoadStoreResults(llvm::AliasResult AR, bool P,
+static inline void PrintLoadStoreResults(llvm::AliasResult AR, bool P,
                                          const llvm::Value *V1,
                                          const llvm::Value *V2,
                                          const llvm::Module *M) {
@@ -75,7 +75,7 @@ static inline void printLoadStoreResults(llvm::AliasResult AR, bool P,
   }
 }
 
-std::string toString(const PointerAnalysisType &PA) {
+std::string to_string(const PointerAnalysisType &PA) {
   switch (PA) {
   default:
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
@@ -86,7 +86,7 @@ std::string toString(const PointerAnalysisType &PA) {
   }
 }
 
-PointerAnalysisType toPointerAnalysisType(const std::string &S) {
+PointerAnalysisType to_PointerAnalysisType(const std::string &S) {
   PointerAnalysisType Type = llvm::StringSwitch<PointerAnalysisType>(S)
 #define ANALYSIS_SETUP_POINTER_TYPE(NAME, CMDFLAG, TYPE)                       \
   .Case(NAME, PointerAnalysisType::TYPE)
@@ -103,7 +103,7 @@ PointerAnalysisType toPointerAnalysisType(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const PointerAnalysisType &PA) {
-  return OS << toString(PA);
+  return OS << to_string(PA);
 }
 
 LLVMPointsToInfo::LLVMPointsToInfo(ProjectIRDB &IRDB, PointerAnalysisType PAT) {
@@ -284,16 +284,16 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
         llvm::AliasResult AR = AA->alias(*I1, I1Size, *I2, I2Size);
         switch (AR) {
         case llvm::NoAlias:
-          printResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+          PrintResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MayAlias:
-          printResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+          PrintResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
           break;
         case llvm::PartialAlias:
-          printResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
+          PrintResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MustAlias:
-          printResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+          PrintResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
           break;
         }
       }
@@ -308,19 +308,19 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(Store)));
           switch (AR) {
           case llvm::NoAlias:
-            printLoadStoreResults(AR, PrintNoAlias, Load, Store,
+            PrintLoadStoreResults(AR, PrintNoAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MayAlias:
-            printLoadStoreResults(AR, PrintMayAlias, Load, Store,
+            PrintLoadStoreResults(AR, PrintMayAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::PartialAlias:
-            printLoadStoreResults(AR, PrintPartialAlias, Load, Store,
+            PrintLoadStoreResults(AR, PrintPartialAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            printLoadStoreResults(AR, PrintMustAlias, Load, Store,
+            PrintLoadStoreResults(AR, PrintMustAlias, Load, Store,
                                   F->getParent());
             break;
           }
@@ -338,17 +338,17 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(*I2)));
           switch (AR) {
           case llvm::NoAlias:
-            printLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+            PrintLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
             break;
           case llvm::MayAlias:
-            printLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+            PrintLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
             break;
           case llvm::PartialAlias:
-            printLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
+            PrintLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            printLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+            PrintLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
             break;
           }
         }
@@ -366,34 +366,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
 
         switch (AA->getModRefInfo(Call, Pointer, Size)) {
         case llvm::ModRefInfo::NoModRef:
-          printModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
+          PrintModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          printModRefResults("Just Mod", PrintMod, Call, Pointer,
+          PrintModRefResults("Just Mod", PrintMod, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          printModRefResults("Just Ref", PrintRef, Call, Pointer,
+          PrintModRefResults("Just Ref", PrintRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          printModRefResults("Both ModRef", PrintModRef, Call, Pointer,
+          PrintModRefResults("Both ModRef", PrintModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          printModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
+          PrintModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          printModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
+          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          printModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
+          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
+          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
                              Pointer, F->getParent());
           break;
         }
@@ -407,34 +407,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
           continue;
         switch (AA->getModRefInfo(CallA, CallB)) {
         case llvm::ModRefInfo::NoModRef:
-          printModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
+          PrintModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          printModRefResults("Just Mod", PrintMod, CallA, CallB,
+          PrintModRefResults("Just Mod", PrintMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          printModRefResults("Just Ref", PrintRef, CallA, CallB,
+          PrintModRefResults("Just Ref", PrintRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          printModRefResults("Both ModRef", PrintModRef, CallA, CallB,
+          PrintModRefResults("Both ModRef", PrintModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          printModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
+          PrintModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          printModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
+          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          printModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
+          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
+          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
                              CallB, F->getParent());
           break;
         }

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -31,7 +31,7 @@ using namespace psr;
 
 namespace psr {
 
-static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
+static void printResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
                          const llvm::Value *V2, const llvm::Module *M) {
   if (P) {
     std::string O1, O2;
@@ -48,7 +48,7 @@ static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
   }
 }
 
-static inline void PrintModRefResults(const char *Msg, bool P,
+static inline void printModRefResults(const char *Msg, bool P,
                                       llvm::Instruction *I, llvm::Value *Ptr,
                                       llvm::Module *M) {
   if (P) {
@@ -58,7 +58,7 @@ static inline void PrintModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void PrintModRefResults(const char *Msg, bool P,
+static inline void printModRefResults(const char *Msg, bool P,
                                       llvm::CallBase *CallA,
                                       llvm::CallBase *CallB, llvm::Module *M) {
   if (P) {
@@ -66,7 +66,7 @@ static inline void PrintModRefResults(const char *Msg, bool P,
   }
 }
 
-static inline void PrintLoadStoreResults(llvm::AliasResult AR, bool P,
+static inline void printLoadStoreResults(llvm::AliasResult AR, bool P,
                                          const llvm::Value *V1,
                                          const llvm::Value *V2,
                                          const llvm::Module *M) {
@@ -284,16 +284,16 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
         llvm::AliasResult AR = AA->alias(*I1, I1Size, *I2, I2Size);
         switch (AR) {
         case llvm::NoAlias:
-          PrintResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MayAlias:
-          PrintResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
           break;
         case llvm::PartialAlias:
-          PrintResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintPartialAlias, *I1, *I2, F->getParent());
           break;
         case llvm::MustAlias:
-          PrintResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+          printResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
           break;
         }
       }
@@ -308,19 +308,19 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(Store)));
           switch (AR) {
           case llvm::NoAlias:
-            PrintLoadStoreResults(AR, PrintNoAlias, Load, Store,
+            printLoadStoreResults(AR, PrintNoAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MayAlias:
-            PrintLoadStoreResults(AR, PrintMayAlias, Load, Store,
+            printLoadStoreResults(AR, PrintMayAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::PartialAlias:
-            PrintLoadStoreResults(AR, PrintPartialAlias, Load, Store,
+            printLoadStoreResults(AR, PrintPartialAlias, Load, Store,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            PrintLoadStoreResults(AR, PrintMustAlias, Load, Store,
+            printLoadStoreResults(AR, PrintMustAlias, Load, Store,
                                   F->getParent());
             break;
           }
@@ -338,17 +338,17 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
               llvm::MemoryLocation::get(llvm::cast<llvm::StoreInst>(*I2)));
           switch (AR) {
           case llvm::NoAlias:
-            PrintLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintNoAlias, *I1, *I2, F->getParent());
             break;
           case llvm::MayAlias:
-            PrintLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintMayAlias, *I1, *I2, F->getParent());
             break;
           case llvm::PartialAlias:
-            PrintLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
+            printLoadStoreResults(AR, PrintPartialAlias, *I1, *I2,
                                   F->getParent());
             break;
           case llvm::MustAlias:
-            PrintLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
+            printLoadStoreResults(AR, PrintMustAlias, *I1, *I2, F->getParent());
             break;
           }
         }
@@ -366,34 +366,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
 
         switch (AA->getModRefInfo(Call, Pointer, Size)) {
         case llvm::ModRefInfo::NoModRef:
-          PrintModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
+          printModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          PrintModRefResults("Just Mod", PrintMod, Call, Pointer,
+          printModRefResults("Just Mod", PrintMod, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          PrintModRefResults("Just Ref", PrintRef, Call, Pointer,
+          printModRefResults("Just Ref", PrintRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          PrintModRefResults("Both ModRef", PrintModRef, Call, Pointer,
+          printModRefResults("Both ModRef", PrintModRef, Call, Pointer,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          PrintModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
+          printModRefResults("Must", PrintMust, Call, Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
+          printModRefResults("Just Mod (MustAlias)", PrintMustMod, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
+          printModRefResults("Just Ref (MustAlias)", PrintMustRef, Call,
                              Pointer, F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
+          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, Call,
                              Pointer, F->getParent());
           break;
         }
@@ -407,34 +407,34 @@ void LLVMPointsToInfo::print(std::ostream &OS) const {
           continue;
         switch (AA->getModRefInfo(CallA, CallB)) {
         case llvm::ModRefInfo::NoModRef:
-          PrintModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
+          printModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Mod:
-          PrintModRefResults("Just Mod", PrintMod, CallA, CallB,
+          printModRefResults("Just Mod", PrintMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Ref:
-          PrintModRefResults("Just Ref", PrintRef, CallA, CallB,
+          printModRefResults("Just Ref", PrintRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::ModRef:
-          PrintModRefResults("Both ModRef", PrintModRef, CallA, CallB,
+          printModRefResults("Both ModRef", PrintModRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::Must:
-          PrintModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
+          printModRefResults("Must", PrintMust, CallA, CallB, F->getParent());
           break;
         case llvm::ModRefInfo::MustMod:
-          PrintModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
+          printModRefResults("Just Mod (MustAlias)", PrintMustMod, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustRef:
-          PrintModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
+          printModRefResults("Just Ref (MustAlias)", PrintMustRef, CallA, CallB,
                              F->getParent());
           break;
         case llvm::ModRefInfo::MustModRef:
-          PrintModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
+          printModRefResults("Both ModRef (MustAlias)", PrintMustModRef, CallA,
                              CallB, F->getParent());
           break;
         }

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -34,17 +34,17 @@ namespace psr {
 static void PrintResults(llvm::AliasResult AR, bool P, const llvm::Value *V1,
                          const llvm::Value *V2, const llvm::Module *M) {
   if (P) {
-    std::string o1, o2;
+    std::string O1, O2;
     {
-      llvm::raw_string_ostream os1(o1), os2(o2);
-      V1->printAsOperand(os1, true, M);
-      V2->printAsOperand(os2, true, M);
+      llvm::raw_string_ostream OS1(O1), OS2(O2);
+      V1->printAsOperand(OS1, true, M);
+      V2->printAsOperand(OS2, true, M);
     }
 
-    if (o2 < o1) {
-      std::swap(o1, o2);
+    if (O2 < O1) {
+      std::swap(O1, O2);
     }
-    llvm::errs() << "  " << AR << ":\t" << o1 << ", " << o2 << "\n";
+    llvm::errs() << "  " << AR << ":\t" << O1 << ", " << O2 << "\n";
   }
 }
 

--- a/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
@@ -13,7 +13,7 @@
 
 namespace psr {
 
-std::string toString(AliasResult AR) {
+std::string to_string(AliasResult AR) {
   switch (AR) {
   case AliasResult::NoAlias:
     return "NoAlias";
@@ -30,7 +30,7 @@ std::string toString(AliasResult AR) {
   }
 }
 
-AliasResult toAliasResult(const std::string &S) {
+AliasResult to_AliasResult(const std::string &S) {
   if (S == "NoAlias") {
     return AliasResult::NoAlias;
   } else if (S == "MayAlias") {
@@ -43,7 +43,7 @@ AliasResult toAliasResult(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR) {
-  return OS << toString(AR);
+  return OS << to_string(AR);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
@@ -13,7 +13,7 @@
 
 namespace psr {
 
-std::string to_string(AliasResult AR) {
+std::string toString(AliasResult AR) {
   switch (AR) {
   case AliasResult::NoAlias:
     return "NoAlias";
@@ -30,7 +30,7 @@ std::string to_string(AliasResult AR) {
   }
 }
 
-AliasResult to_AliasResult(const std::string &S) {
+AliasResult toAliasResult(const std::string &S) {
   if (S == "NoAlias") {
     return AliasResult::NoAlias;
   } else if (S == "MayAlias") {
@@ -43,7 +43,7 @@ AliasResult to_AliasResult(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR) {
-  return OS << to_string(AR);
+  return OS << toString(AR);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
@@ -30,7 +30,7 @@ std::string toString(AliasResult AR) {
   }
 }
 
-AliasResult to_AliasResult(const std::string &S) {
+AliasResult toAliasResult(const std::string &S) {
   if (S == "NoAlias") {
     return AliasResult::NoAlias;
   } else if (S == "MayAlias") {

--- a/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/PointsToInfo.cpp
@@ -13,7 +13,7 @@
 
 namespace psr {
 
-std::string to_string(AliasResult AR) {
+std::string toString(AliasResult AR) {
   switch (AR) {
   case AliasResult::NoAlias:
     return "NoAlias";
@@ -43,7 +43,7 @@ AliasResult to_AliasResult(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const AliasResult &AR) {
-  return OS << to_string(AR);
+  return OS << toString(AR);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
@@ -34,7 +34,7 @@ namespace psr {
 struct CachedTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
   dfs_visitor(graph_t *G) : g(G) {}
 
-  void finishEdge(edge_t E, graph_t const &U) {
+  void finish_edge(edge_t E, graph_t const &U) {
     CachedTypeGraph::vertex_t Src = boost::source(E, U);
     CachedTypeGraph::vertex_t Target = boost::target(E, U);
 
@@ -50,7 +50,7 @@ struct CachedTypeGraph::reverse_type_propagation_dfs_visitor
     : public boost::default_dfs_visitor {
   reverse_type_propagation_dfs_visitor(rev_graph_t *G) : g(G) {}
 
-  void examineEdge(rev_edge_t E, rev_graph_t const &U) {
+  void examine_edge(rev_edge_t E, rev_graph_t const &U) {
     auto Src = boost::source(E, U);
     auto Target = boost::target(E, U);
 

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
@@ -32,33 +32,33 @@ using namespace psr;
 namespace psr {
 
 struct CachedTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
-  dfs_visitor(graph_t *_g) : g(_g) {}
+  dfs_visitor(graph_t *g) : G(g) {}
 
   void finish_edge(edge_t e, graph_t const &u) {
     CachedTypeGraph::vertex_t src = boost::source(e, u);
     CachedTypeGraph::vertex_t target = boost::target(e, u);
 
     for (auto target_type : u[target].types) {
-      (*g)[src].types.insert(target_type);
+      (*G)[src].types.insert(target_type);
     }
   }
 
-  graph_t *g;
+  graph_t *G;
 };
 
 struct CachedTypeGraph::reverse_type_propagation_dfs_visitor
     : public boost::default_dfs_visitor {
-  reverse_type_propagation_dfs_visitor(rev_graph_t *_g) : g(_g) {}
+  reverse_type_propagation_dfs_visitor(rev_graph_t *g) : G(g) {}
 
   void examine_edge(rev_edge_t e, rev_graph_t const &u) {
     auto src = boost::source(e, u);
     auto target = boost::target(e, u);
 
     for (auto src_type : u[src].types)
-      (*g)[target].types.insert(src_type);
+      (*G)[target].types.insert(src_type);
   }
 
-  rev_graph_t *g;
+  rev_graph_t *G;
 };
 
 CachedTypeGraph::vertex_t

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
@@ -34,7 +34,7 @@ namespace psr {
 struct CachedTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
   dfs_visitor(graph_t *G) : g(G) {}
 
-  void finish_edge(edge_t E, graph_t const &U) {
+  void finishEdge(edge_t E, graph_t const &U) {
     CachedTypeGraph::vertex_t Src = boost::source(E, U);
     CachedTypeGraph::vertex_t Target = boost::target(E, U);
 
@@ -50,7 +50,7 @@ struct CachedTypeGraph::reverse_type_propagation_dfs_visitor
     : public boost::default_dfs_visitor {
   reverse_type_propagation_dfs_visitor(rev_graph_t *G) : g(G) {}
 
-  void examine_edge(rev_edge_t E, rev_graph_t const &U) {
+  void examineEdge(rev_edge_t E, rev_graph_t const &U) {
     auto Src = boost::source(E, U);
     auto Target = boost::target(E, U);
 

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -35,10 +35,10 @@ struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
   dfs_visitor(std::set<const llvm::StructType *> &Result) : Result(Result) {}
 
   void finish_edge(edge_t E, graph_t const &U) {
-    LazyTypeGraph::vertex_t src = boost::source(E, U);
-    LazyTypeGraph::vertex_t target = boost::target(E, U);
+    LazyTypeGraph::vertex_t Src = boost::source(E, U);
+    LazyTypeGraph::vertex_t Target = boost::target(E, U);
 
-    Result.insert(U[target].type);
+    Result.insert(U[Target].type);
   }
 
   std::set<const llvm::StructType *> &Result;
@@ -46,16 +46,16 @@ struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
 
 LazyTypeGraph::vertex_t
 LazyTypeGraph::addType(const llvm::StructType *NewType) {
-  auto name = NewType->getName().str();
+  auto Name = NewType->getName().str();
 
-  if (type_vertex_map.find(name) == type_vertex_map.end()) {
-    auto vertex = boost::add_vertex(g);
-    type_vertex_map[name] = vertex;
-    g[vertex].name = name;
-    g[vertex].type = NewType;
+  if (type_vertex_map.find(Name) == type_vertex_map.end()) {
+    auto Vertex = boost::add_vertex(g);
+    type_vertex_map[Name] = Vertex;
+    g[Vertex].name = Name;
+    g[Vertex].type = NewType;
   }
 
-  return type_vertex_map[name];
+  return type_vertex_map[Name];
 }
 
 bool LazyTypeGraph::addLink(const llvm::StructType *From,
@@ -65,39 +65,39 @@ bool LazyTypeGraph::addLink(const llvm::StructType *From,
 
   already_visited = true;
 
-  auto from_vertex = addType(From);
-  auto to_vertex = addType(To);
+  auto FromVertex = addType(From);
+  auto ToVertex = addType(To);
 
-  auto result_edge = boost::add_edge(from_vertex, to_vertex, g);
+  auto ResultEdge = boost::add_edge(FromVertex, ToVertex, g);
 
   already_visited = false;
-  return result_edge.second;
+  return ResultEdge.second;
 }
 
 void LazyTypeGraph::printAsDot(const std::string &Path) const {
-  std::ofstream ofs(Path);
-  boost::write_graphviz(ofs, g,
+  std::ofstream Ofs(Path);
+  boost::write_graphviz(Ofs, g,
                         boost::make_label_writer(boost::get(
                             &LazyTypeGraph::VertexProperties::name, g)));
 }
 
 std::set<const llvm::StructType *>
 LazyTypeGraph::getTypes(const llvm::StructType *StructType) {
-  auto struct_ty_vertex = addType(StructType);
+  auto StructTyVertex = addType(StructType);
 
-  std::vector<boost::default_color_type> color_map(boost::num_vertices(g));
+  std::vector<boost::default_color_type> ColorMap(boost::num_vertices(g));
 
-  std::set<const llvm::StructType *> results;
-  results.insert(StructType);
+  std::set<const llvm::StructType *> Results;
+  Results.insert(StructType);
 
-  dfs_visitor vis(results);
+  dfs_visitor Vis(Results);
 
   boost::depth_first_visit(
-      g, struct_ty_vertex, vis,
+      g, StructTyVertex, Vis,
       boost::make_iterator_property_map(
-          color_map.begin(), boost::get(boost::vertex_index, g), color_map[0]));
+          ColorMap.begin(), boost::get(boost::vertex_index, g), ColorMap[0]));
 
-  return results;
+  return Results;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -34,7 +34,7 @@ namespace psr {
 struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
   dfs_visitor(std::set<const llvm::StructType *> &Result) : Result(Result) {}
 
-  void finish_edge(edge_t E, graph_t const &U) {
+  void finishEdge(edge_t E, graph_t const &U) {
     LazyTypeGraph::vertex_t Src = boost::source(E, U);
     LazyTypeGraph::vertex_t Target = boost::target(E, U);
 

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -34,7 +34,7 @@ namespace psr {
 struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
   dfs_visitor(std::set<const llvm::StructType *> &Result) : Result(Result) {}
 
-  void finishEdge(edge_t E, graph_t const &U) {
+  void finish_edge(edge_t E, graph_t const &U) {
     LazyTypeGraph::vertex_t Src = boost::source(E, U);
     LazyTypeGraph::vertex_t Target = boost::target(E, U);
 

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -32,16 +32,16 @@ using namespace psr;
 namespace psr {
 
 struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
-  dfs_visitor(std::set<const llvm::StructType *> &_result) : result(_result) {}
+  dfs_visitor(std::set<const llvm::StructType *> &result) : Result(result) {}
 
   void finish_edge(edge_t e, graph_t const &u) {
     LazyTypeGraph::vertex_t src = boost::source(e, u);
     LazyTypeGraph::vertex_t target = boost::target(e, u);
 
-    result.insert(u[target].type);
+    Result.insert(u[target].type);
   }
 
-  std::set<const llvm::StructType *> &result;
+  std::set<const llvm::StructType *> &Result;
 };
 
 LazyTypeGraph::vertex_t

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -32,41 +32,41 @@ using namespace psr;
 namespace psr {
 
 struct LazyTypeGraph::dfs_visitor : public boost::default_dfs_visitor {
-  dfs_visitor(std::set<const llvm::StructType *> &result) : Result(result) {}
+  dfs_visitor(std::set<const llvm::StructType *> &Result) : Result(Result) {}
 
-  void finish_edge(edge_t e, graph_t const &u) {
-    LazyTypeGraph::vertex_t src = boost::source(e, u);
-    LazyTypeGraph::vertex_t target = boost::target(e, u);
+  void finish_edge(edge_t E, graph_t const &U) {
+    LazyTypeGraph::vertex_t src = boost::source(E, U);
+    LazyTypeGraph::vertex_t target = boost::target(E, U);
 
-    Result.insert(u[target].type);
+    Result.insert(U[target].type);
   }
 
   std::set<const llvm::StructType *> &Result;
 };
 
 LazyTypeGraph::vertex_t
-LazyTypeGraph::addType(const llvm::StructType *new_type) {
-  auto name = new_type->getName().str();
+LazyTypeGraph::addType(const llvm::StructType *NewType) {
+  auto name = NewType->getName().str();
 
   if (type_vertex_map.find(name) == type_vertex_map.end()) {
     auto vertex = boost::add_vertex(g);
     type_vertex_map[name] = vertex;
     g[vertex].name = name;
-    g[vertex].type = new_type;
+    g[vertex].type = NewType;
   }
 
   return type_vertex_map[name];
 }
 
-bool LazyTypeGraph::addLink(const llvm::StructType *from,
-                            const llvm::StructType *to) {
+bool LazyTypeGraph::addLink(const llvm::StructType *From,
+                            const llvm::StructType *To) {
   if (already_visited)
     return false;
 
   already_visited = true;
 
-  auto from_vertex = addType(from);
-  auto to_vertex = addType(to);
+  auto from_vertex = addType(From);
+  auto to_vertex = addType(To);
 
   auto result_edge = boost::add_edge(from_vertex, to_vertex, g);
 
@@ -74,21 +74,21 @@ bool LazyTypeGraph::addLink(const llvm::StructType *from,
   return result_edge.second;
 }
 
-void LazyTypeGraph::printAsDot(const std::string &path) const {
-  std::ofstream ofs(path);
+void LazyTypeGraph::printAsDot(const std::string &Path) const {
+  std::ofstream ofs(Path);
   boost::write_graphviz(ofs, g,
                         boost::make_label_writer(boost::get(
                             &LazyTypeGraph::VertexProperties::name, g)));
 }
 
 std::set<const llvm::StructType *>
-LazyTypeGraph::getTypes(const llvm::StructType *struct_type) {
-  auto struct_ty_vertex = addType(struct_type);
+LazyTypeGraph::getTypes(const llvm::StructType *StructType) {
+  auto struct_ty_vertex = addType(StructType);
 
   std::vector<boost::default_color_type> color_map(boost::num_vertices(g));
 
   std::set<const llvm::StructType *> results;
-  results.insert(struct_type);
+  results.insert(StructType);
 
   dfs_visitor vis(results);
 

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -71,8 +71,8 @@ std::string LLVMTypeHierarchy::VertexProperties::getTypeName() const {
 
 LLVMTypeHierarchy::LLVMTypeHierarchy(ProjectIRDB &IRDB) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << "Construct type hierarchy");
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO) << "Construct type hierarchy");
   for (auto M : IRDB.getAllModules()) {
     buildLLVMTypeHierarchy(*M);
   }
@@ -82,8 +82,8 @@ LLVMTypeHierarchy::LLVMTypeHierarchy(ProjectIRDB &IRDB) {
 
 LLVMTypeHierarchy::LLVMTypeHierarchy(const llvm::Module &M) {
   PAMM_GET_INSTANCE;
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, INFO) << "Construct type hierarchy");
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, INFO) << "Construct type hierarchy");
   buildLLVMTypeHierarchy(M);
   REG_COUNTER("CH Vertices", getNumOfVertices(), PAMM_SEVERITY_LEVEL::Full);
   REG_COUNTER("CH Edges", getNumOfEdges(), PAMM_SEVERITY_LEVEL::Full);
@@ -225,8 +225,8 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
 }
 
 void LLVMTypeHierarchy::constructHierarchy(const llvm::Module &M) {
-  auto &lg = lg::get();
-  LOG_IF_ENABLE(BOOST_LOG_SEV(lg, DEBUG)
+  auto &LG = lg::get();
+  LOG_IF_ENABLE(BOOST_LOG_SEV(LG, DEBUG)
                 << "Analyze types in module: " << M.getModuleIdentifier());
   // store analyzed module
   VisitedModules.insert(&M);
@@ -342,14 +342,13 @@ bool LLVMTypeHierarchy::empty() const { return size() == 0; }
 
 void LLVMTypeHierarchy::print(std::ostream &OS) const {
   OS << "Type Hierarchy:\n";
-  vertex_iterator ui, ui_end;
-  for (boost::tie(ui, ui_end) = boost::vertices(TypeGraph); ui != ui_end;
-       ++ui) {
-    OS << TypeGraph[*ui].getTypeName() << " --> ";
-    out_edge_iterator ei, ei_end;
-    for (boost::tie(ei, ei_end) = boost::out_edges(*ui, TypeGraph);
-         ei != ei_end; ++ei)
-      OS << TypeGraph[target(*ei, TypeGraph)].getTypeName() << " ";
+  vertex_iterator UI, UIEnd;
+  for (boost::tie(UI, UIEnd) = boost::vertices(TypeGraph); UI != UIEnd; ++UI) {
+    OS << TypeGraph[*UI].getTypeName() << " --> ";
+    out_edge_iterator EI, EIEnd;
+    for (boost::tie(EI, EIEnd) = boost::out_edges(*UI, TypeGraph); EI != EIEnd;
+         ++EI)
+      OS << TypeGraph[target(*EI, TypeGraph)].getTypeName() << " ";
     OS << '\n';
   }
   OS << "VFTables:\n";
@@ -363,17 +362,17 @@ void LLVMTypeHierarchy::print(std::ostream &OS) const {
 
 nlohmann::json LLVMTypeHierarchy::getAsJson() const {
   nlohmann::json J;
-  vertex_iterator vi_v, vi_v_end;
-  out_edge_iterator ei, ei_end;
+  vertex_iterator VIv, VIvEnd;
+  out_edge_iterator EI, EIEnd;
   // iterate all graph vertices
-  for (boost::tie(vi_v, vi_v_end) = boost::vertices(TypeGraph);
-       vi_v != vi_v_end; ++vi_v) {
-    J[PhasarConfig::JsonTypeHierarchyID()][TypeGraph[*vi_v].getTypeName()];
+  for (boost::tie(VIv, VIvEnd) = boost::vertices(TypeGraph); VIv != VIvEnd;
+       ++VIv) {
+    J[PhasarConfig::JsonTypeHierarchyID()][TypeGraph[*VIv].getTypeName()];
     // iterate all out edges of vertex vi_v
-    for (boost::tie(ei, ei_end) = boost::out_edges(*vi_v, TypeGraph);
-         ei != ei_end; ++ei) {
-      J[PhasarConfig::JsonTypeHierarchyID()][TypeGraph[*vi_v].getTypeName()] +=
-          TypeGraph[boost::target(*ei, TypeGraph)].getTypeName();
+    for (boost::tie(EI, EIEnd) = boost::out_edges(*VIv, TypeGraph); EI != EIEnd;
+         ++EI) {
+      J[PhasarConfig::JsonTypeHierarchyID()][TypeGraph[*VIv].getTypeName()] +=
+          TypeGraph[boost::target(*EI, TypeGraph)].getTypeName();
     }
   }
   return J;

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMVFTable.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMVFTable.cpp
@@ -53,8 +53,8 @@ void LLVMVFTable::print(std::ostream &OS) const {
 }
 
 nlohmann::json LLVMVFTable::getAsJson() const {
-  nlohmann::json j = "{}"_json;
-  return j;
+  nlohmann::json J = "{}"_json;
+  return J;
 }
 
 std::vector<const ::llvm::Function *>::iterator LLVMVFTable::begin() {

--- a/lib/PhasarLLVM/Utils/BinaryDomain.cpp
+++ b/lib/PhasarLLVM/Utils/BinaryDomain.cpp
@@ -28,7 +28,7 @@ const map<string, BinaryDomain> StringToBinaryDomain = {
 const map<BinaryDomain, string> BinaryDomainToString = {
     {BinaryDomain::BOTTOM, "BOTTOM"}, {BinaryDomain::TOP, "TOP"}};
 
-ostream &operator<<(ostream &os, const BinaryDomain &b) {
-  return os << BinaryDomainToString.at(b);
+ostream &operator<<(ostream &OS, const BinaryDomain &B) {
+  return OS << BinaryDomainToString.at(B);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -38,15 +38,15 @@ DOTNode::DOTNode(std::string FName, std::string L, std::string SId,
 }
 
 std::string DOTNode::str(std::string Indent) const {
-  std::string str = Indent + id + " [label=\"" + label;
+  std::string Str = Indent + id + " [label=\"" + label;
   if (factId) {
-    str += " | SID: " + stmtId;
+    Str += " | SID: " + stmtId;
   }
-  str += "\"";
+  Str += "\"";
   if (!isVisible) {
-    str += ", style=invis";
+    Str += ", style=invis";
   }
-  return str + ']';
+  return Str + ']';
 }
 
 DOTEdge::DOTEdge(DOTNode Src, DOTNode Tar, bool IsV, std::string Efl,
@@ -55,75 +55,75 @@ DOTEdge::DOTEdge(DOTNode Src, DOTNode Tar, bool IsV, std::string Efl,
       valueLabel(Vl) {}
 
 std::string DOTEdge::str(std::string Indent) const {
-  std::string str = Indent + source.id + " -> " + target.id;
+  std::string Str = Indent + source.id + " -> " + target.id;
   if (isVisible) {
     if (!edgeFnLabel.empty() && !valueLabel.empty()) {
-      str += " [headlabel=\"\\r" + edgeFnLabel + "\", taillabel=\"" +
+      Str += " [headlabel=\"\\r" + edgeFnLabel + "\", taillabel=\"" +
              valueLabel + "\"]";
     } else if (!edgeFnLabel.empty()) {
-      str += " [headlabel=\"\\r" + edgeFnLabel + "\"]";
+      Str += " [headlabel=\"\\r" + edgeFnLabel + "\"]";
     } else if (!valueLabel.empty()) {
-      str += " [taillabel=\"" + valueLabel + "\"]";
+      Str += " [taillabel=\"" + valueLabel + "\"]";
     }
   } else if (!isVisible) {
-    str += " [style=invis]";
+    Str += " [style=invis]";
   }
-  return str;
+  return Str;
 }
 
 std::string DOTFactSubGraph::str(std::string Indent) const {
-  std::string innerIndent = Indent + "  ";
-  std::string str = Indent + "subgraph cluster_" + id + " {\n" + innerIndent +
-                    "style=invis\n" + innerIndent + "label=\"" + label +
-                    "\"\n\n" + innerIndent + "// Fact nodes in the ESG\n" +
-                    innerIndent + DOTConfig::FactNodeAttr() + '\n';
+  std::string InnerIndent = Indent + "  ";
+  std::string Str = Indent + "subgraph cluster_" + id + " {\n" + InnerIndent +
+                    "style=invis\n" + InnerIndent + "label=\"" + label +
+                    "\"\n\n" + InnerIndent + "// Fact nodes in the ESG\n" +
+                    InnerIndent + DOTConfig::FactNodeAttr() + '\n';
   // Print fact nodes
-  for (auto n : nodes) {
-    str += n.second.str(innerIndent) + '\n';
+  for (auto N : nodes) {
+    Str += N.second.str(InnerIndent) + '\n';
   }
   // Print id edges
-  str += '\n' + innerIndent + "// Identity edges for this fact\n" +
-         innerIndent + DOTConfig::FactIDEdgeAttr() + '\n';
-  for (DOTEdge e : edges) {
-    str += e.str(innerIndent) + '\n';
+  Str += '\n' + InnerIndent + "// Identity edges for this fact\n" +
+         InnerIndent + DOTConfig::FactIDEdgeAttr() + '\n';
+  for (DOTEdge E : edges) {
+    Str += E.str(InnerIndent) + '\n';
   }
-  return str + Indent + '}';
+  return Str + Indent + '}';
 }
 
 std::string DOTFunctionSubGraph::str(std::string Indent) const {
-  std::string innerIndent = Indent + "  ";
-  std::string str = Indent + "subgraph cluster_" + id + " {\n" + innerIndent +
+  std::string InnerIndent = Indent + "  ";
+  std::string Str = Indent + "subgraph cluster_" + id + " {\n" + InnerIndent +
                     "label=\"" + id + "\"";
   // Print control flow nodes
-  str += "\n\n" + innerIndent + "// Control flow nodes\n" + innerIndent +
+  Str += "\n\n" + InnerIndent + "// Control flow nodes\n" + InnerIndent +
          DOTConfig::CFNodeAttr() + '\n';
-  for (DOTNode stmt : stmts) {
-    str += stmt.str(innerIndent) + '\n';
+  for (DOTNode Stmt : stmts) {
+    Str += Stmt.str(InnerIndent) + '\n';
   }
 
   // Print fact subgraphs
-  str += '\n' + innerIndent + "// Fact subgraphs\n";
-  for (auto factSG : facts) {
-    str += factSG.second.str(innerIndent) + "\n\n";
+  Str += '\n' + InnerIndent + "// Fact subgraphs\n";
+  for (auto FactSG : facts) {
+    Str += FactSG.second.str(InnerIndent) + "\n\n";
   }
 
   // Print lambda subgraph
-  str += generateLambdaSG(innerIndent);
+  Str += generateLambdaSG(InnerIndent);
 
   // Print intra control flow edges
-  str += "\n\n" + innerIndent + "// Intra-procedural control flow edges\n" +
-         innerIndent + DOTConfig::CFIntraEdgeAttr() + '\n';
-  for (DOTEdge e : intraCFEdges) {
-    str += e.str(innerIndent) + '\n';
+  Str += "\n\n" + InnerIndent + "// Intra-procedural control flow edges\n" +
+         InnerIndent + DOTConfig::CFIntraEdgeAttr() + '\n';
+  for (DOTEdge E : intraCFEdges) {
+    Str += E.str(InnerIndent) + '\n';
   }
 
   // Print intra cross fact edges
-  str += '\n' + innerIndent + "// Intra-procedural cross fact edges\n" +
-         innerIndent + DOTConfig::FactCrossEdgeAttr() + '\n';
-  for (DOTEdge e : crossFactEdges) {
-    str += e.str(innerIndent) + '\n';
+  Str += '\n' + InnerIndent + "// Intra-procedural cross fact edges\n" +
+         InnerIndent + DOTConfig::FactCrossEdgeAttr() + '\n';
+  for (DOTEdge E : crossFactEdges) {
+    Str += E.str(InnerIndent) + '\n';
   }
-  return str + Indent + '}';
+  return Str + Indent + '}';
 }
 
 DOTFactSubGraph *DOTFunctionSubGraph::getOrCreateFactSG(unsigned FactID,
@@ -138,73 +138,73 @@ DOTFactSubGraph *DOTFunctionSubGraph::getOrCreateFactSG(unsigned FactID,
 }
 
 std::string DOTFunctionSubGraph::generateLambdaSG(std::string Indent) const {
-  std::string innerIndent = Indent + "  ";
-  std::string str = Indent + "// Auto-generated lambda nodes and edges\n" +
+  std::string InnerIndent = Indent + "  ";
+  std::string Str = Indent + "// Auto-generated lambda nodes and edges\n" +
                     Indent + "subgraph cluster_" + id + "_lambda {\n" +
-                    innerIndent + "style=invis\n" + innerIndent +
-                    "label=\"Λ\"\n" + innerIndent +
+                    InnerIndent + "style=invis\n" + InnerIndent +
+                    "label=\"Λ\"\n" + InnerIndent +
                     DOTConfig::LambdaNodeAttr() + '\n';
   // Print lambda nodes
-  for (DOTNode stmt : stmts) {
-    str += innerIndent + id + "_0_" + stmt.stmtId +
-           " [label=\"Λ|SID: " + stmt.stmtId + "\"]\n";
+  for (DOTNode Stmt : stmts) {
+    Str += InnerIndent + id + "_0_" + Stmt.stmtId +
+           " [label=\"Λ|SID: " + Stmt.stmtId + "\"]\n";
   }
   // Print lambda edges
-  str += '\n' + innerIndent + DOTConfig::LambdaIDEdgeAttr() + '\n';
-  for (DOTEdge e : intraCFEdges) {
-    str += innerIndent + id + "_0_" + e.source.stmtId + " -> " + id + "_0_" +
-           e.target.stmtId;
-    if (e.isVisible) {
-      str += " [headlabel=\"\\rAllBottom\", taillabel=\"BOT\"]\n";
+  Str += '\n' + InnerIndent + DOTConfig::LambdaIDEdgeAttr() + '\n';
+  for (DOTEdge E : intraCFEdges) {
+    Str += InnerIndent + id + "_0_" + E.source.stmtId + " -> " + id + "_0_" +
+           E.target.stmtId;
+    if (E.isVisible) {
+      Str += " [headlabel=\"\\rAllBottom\", taillabel=\"BOT\"]\n";
     } else {
-      str += " [style=invis]\n";
+      Str += " [style=invis]\n";
     }
   }
-  return str + Indent + '}';
+  return Str + Indent + '}';
 }
 
 void DOTFunctionSubGraph::createLayoutCFNodes() {
-  auto last = stmts.empty() ? stmts.end() : std::prev(stmts.end());
-  for (auto firstIt = stmts.begin(); firstIt != last; ++firstIt) {
-    auto secondIt = std::next(firstIt);
-    DOTNode n1 = *firstIt;
-    DOTNode n2 = *secondIt;
-    intraCFEdges.emplace(n1, n2, false);
+  auto Last = stmts.empty() ? stmts.end() : std::prev(stmts.end());
+  for (auto FirstIt = stmts.begin(); FirstIt != Last; ++FirstIt) {
+    auto SecondIt = std::next(FirstIt);
+    DOTNode N1 = *FirstIt;
+    DOTNode N2 = *SecondIt;
+    intraCFEdges.emplace(N1, N2, false);
   }
 }
 
 void DOTFunctionSubGraph::createLayoutFactNodes() {
-  for (auto &[key, factSG] : facts) {
-    for (auto stmt : stmts) {
-      if (factSG.nodes.find(stmt.stmtId) == factSG.nodes.end()) {
-        DOTNode factNode(stmt.funcName, factSG.label, stmt.stmtId,
-                         factSG.factId, false, false);
-        factSG.nodes[stmt.stmtId] = factNode;
+  for (auto &[Key, FactSG] : facts) {
+    for (auto Stmt : stmts) {
+      if (FactSG.nodes.find(Stmt.stmtId) == FactSG.nodes.end()) {
+        DOTNode FactNode(Stmt.funcName, FactSG.label, Stmt.stmtId,
+                         FactSG.factId, false, false);
+        FactSG.nodes[Stmt.stmtId] = FactNode;
       }
     }
   }
 }
 
 void DOTFunctionSubGraph::createLayoutFactEdges() {
-  for (auto &[key, factSG] : facts) {
-    for (auto iCFE : intraCFEdges) {
-      DOTNode d1 = {iCFE.source.funcName, factSG.label, iCFE.source.stmtId,
-                    factSG.factId, false};
-      DOTNode d2 = {iCFE.target.funcName, factSG.label, iCFE.target.stmtId,
-                    factSG.factId, false};
-      factSG.edges.emplace(d1, d2, false);
+  for (auto &[Key, FactSG] : facts) {
+    for (auto ICFE : intraCFEdges) {
+      DOTNode D1 = {ICFE.source.funcName, FactSG.label, ICFE.source.stmtId,
+                    FactSG.factId, false};
+      DOTNode D2 = {ICFE.target.funcName, FactSG.label, ICFE.target.stmtId,
+                    FactSG.factId, false};
+      FactSG.edges.emplace(D1, D2, false);
     }
   }
 }
 
 bool operator<(const DOTNode &Lhs, const DOTNode &Rhs) {
-  stringIDLess strLess;
+  stringIDLess StrLess;
   // comparing control flow nodes
   if (Lhs.factId == 0 && Rhs.factId == 0) {
-    return strLess(Lhs.stmtId, Rhs.stmtId);
+    return StrLess(Lhs.stmtId, Rhs.stmtId);
   } else { // comparing fact nodes
     if (Lhs.factId == Rhs.factId) {
-      return strLess(Lhs.stmtId, Rhs.stmtId);
+      return StrLess(Lhs.stmtId, Rhs.stmtId);
     } else {
       return Lhs.factId < Rhs.factId;
     }
@@ -249,51 +249,51 @@ void DOTConfig::importDOTConfig() {
   FilePath /= boost::filesystem::path("config/DOTGraphConfig.json");
   if (boost::filesystem::exists(FilePath) &&
       !boost::filesystem::is_directory(FilePath)) {
-    std::ifstream ifs(FilePath.string());
-    if (ifs.is_open()) {
-      std::stringstream iss;
-      iss << ifs.rdbuf();
-      ifs.close();
-      nlohmann::json jDOTConfig;
-      iss >> jDOTConfig;
-      for (auto &el : jDOTConfig.items()) {
-        std::stringstream attr_str;
-        if (el.key().find("Node") != std::string::npos) {
-          attr_str << "node [";
+    std::ifstream Ifs(FilePath.string());
+    if (Ifs.is_open()) {
+      std::stringstream Iss;
+      Iss << Ifs.rdbuf();
+      Ifs.close();
+      nlohmann::json JDOTConfig;
+      Iss >> JDOTConfig;
+      for (auto &El : JDOTConfig.items()) {
+        std::stringstream AttrStr;
+        if (El.key().find("Node") != std::string::npos) {
+          AttrStr << "node [";
         } else {
-          attr_str << "edge [";
+          AttrStr << "edge [";
         }
-        for (nlohmann::json::iterator it = el.value().begin();
-             it != el.value().end(); ++it) {
+        for (nlohmann::json::iterator It = El.value().begin();
+             It != El.value().end(); ++It) {
           // using it.value() directly with the << operator adds unnecessary
           // quotes
-          std::string val = it.value();
-          attr_str << it.key() << "=" << val;
-          if (std::next(it) != el.value().end()) {
-            attr_str << ", ";
+          std::string Val = It.value();
+          AttrStr << It.key() << "=" << Val;
+          if (std::next(It) != El.value().end()) {
+            AttrStr << ", ";
           }
         }
-        attr_str << ']';
-        if (el.key() == "CFNode") {
-          DOTConfig::CFNode = attr_str.str();
-        } else if (el.key() == "CFIntraEdge") {
-          DOTConfig::CFIntraEdge = attr_str.str();
-        } else if (el.key() == "CFInterEdge") {
-          DOTConfig::CFInterEdge = attr_str.str();
-        } else if (el.key() == "FactNode") {
-          DOTConfig::FactNode = attr_str.str();
-        } else if (el.key() == "FactIDEdge") {
-          DOTConfig::FactIDEdge = attr_str.str();
-        } else if (el.key() == "FactCrossEdge") {
-          DOTConfig::FactCrossEdge = attr_str.str();
-        } else if (el.key() == "FactInterEdge") {
-          DOTConfig::FactInterEdge = attr_str.str();
-        } else if (el.key() == "LambdaNode") {
-          DOTConfig::LambdaNode = attr_str.str();
-        } else if (el.key() == "LambdaIDEdge") {
-          DOTConfig::LambdaIDEdge = attr_str.str();
-        } else if (el.key() == "LambdaInterEdge") {
-          DOTConfig::LambdaInterEdge = attr_str.str();
+        AttrStr << ']';
+        if (El.key() == "CFNode") {
+          DOTConfig::CFNode = AttrStr.str();
+        } else if (El.key() == "CFIntraEdge") {
+          DOTConfig::CFIntraEdge = AttrStr.str();
+        } else if (El.key() == "CFInterEdge") {
+          DOTConfig::CFInterEdge = AttrStr.str();
+        } else if (El.key() == "FactNode") {
+          DOTConfig::FactNode = AttrStr.str();
+        } else if (El.key() == "FactIDEdge") {
+          DOTConfig::FactIDEdge = AttrStr.str();
+        } else if (El.key() == "FactCrossEdge") {
+          DOTConfig::FactCrossEdge = AttrStr.str();
+        } else if (El.key() == "FactInterEdge") {
+          DOTConfig::FactInterEdge = AttrStr.str();
+        } else if (El.key() == "LambdaNode") {
+          DOTConfig::LambdaNode = AttrStr.str();
+        } else if (El.key() == "LambdaIDEdge") {
+          DOTConfig::LambdaIDEdge = AttrStr.str();
+        } else if (El.key() == "LambdaInterEdge") {
+          DOTConfig::LambdaInterEdge = AttrStr.str();
         }
       }
     } else {

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -27,18 +27,18 @@
 
 namespace psr {
 
-DOTNode::DOTNode(std::string fName, std::string l, std::string sId,
-                 unsigned fId, bool isStmt, bool isv)
-    : funcName(fName), label(l), stmtId(sId), factId(fId), isVisible(isv) {
-  if (isStmt) {
+DOTNode::DOTNode(std::string FName, std::string L, std::string SId,
+                 unsigned FId, bool IsStmt, bool IsV)
+    : funcName(FName), label(L), stmtId(SId), factId(FId), isVisible(IsV) {
+  if (IsStmt) {
     id = funcName + '_' + stmtId;
   } else {
     id = funcName + '_' + std::to_string(factId) + '_' + stmtId;
   }
 }
 
-std::string DOTNode::str(std::string indent) const {
-  std::string str = indent + id + " [label=\"" + label;
+std::string DOTNode::str(std::string Indent) const {
+  std::string str = Indent + id + " [label=\"" + label;
   if (factId) {
     str += " | SID: " + stmtId;
   }
@@ -49,13 +49,13 @@ std::string DOTNode::str(std::string indent) const {
   return str + ']';
 }
 
-DOTEdge::DOTEdge(DOTNode src, DOTNode tar, bool isv, std::string efl,
-                 std::string vl)
-    : source(src), target(tar), isVisible(isv), edgeFnLabel(efl),
-      valueLabel(vl) {}
+DOTEdge::DOTEdge(DOTNode Src, DOTNode Tar, bool IsV, std::string Efl,
+                 std::string Vl)
+    : source(Src), target(Tar), isVisible(IsV), edgeFnLabel(Efl),
+      valueLabel(Vl) {}
 
-std::string DOTEdge::str(std::string indent) const {
-  std::string str = indent + source.id + " -> " + target.id;
+std::string DOTEdge::str(std::string Indent) const {
+  std::string str = Indent + source.id + " -> " + target.id;
   if (isVisible) {
     if (!edgeFnLabel.empty() && !valueLabel.empty()) {
       str += " [headlabel=\"\\r" + edgeFnLabel + "\", taillabel=\"" +
@@ -71,9 +71,9 @@ std::string DOTEdge::str(std::string indent) const {
   return str;
 }
 
-std::string DOTFactSubGraph::str(std::string indent) const {
-  std::string innerIndent = indent + "  ";
-  std::string str = indent + "subgraph cluster_" + id + " {\n" + innerIndent +
+std::string DOTFactSubGraph::str(std::string Indent) const {
+  std::string innerIndent = Indent + "  ";
+  std::string str = Indent + "subgraph cluster_" + id + " {\n" + innerIndent +
                     "style=invis\n" + innerIndent + "label=\"" + label +
                     "\"\n\n" + innerIndent + "// Fact nodes in the ESG\n" +
                     innerIndent + DOTConfig::FactNodeAttr() + '\n';
@@ -87,12 +87,12 @@ std::string DOTFactSubGraph::str(std::string indent) const {
   for (DOTEdge e : edges) {
     str += e.str(innerIndent) + '\n';
   }
-  return str + indent + '}';
+  return str + Indent + '}';
 }
 
-std::string DOTFunctionSubGraph::str(std::string indent) const {
-  std::string innerIndent = indent + "  ";
-  std::string str = indent + "subgraph cluster_" + id + " {\n" + innerIndent +
+std::string DOTFunctionSubGraph::str(std::string Indent) const {
+  std::string innerIndent = Indent + "  ";
+  std::string str = Indent + "subgraph cluster_" + id + " {\n" + innerIndent +
                     "label=\"" + id + "\"";
   // Print control flow nodes
   str += "\n\n" + innerIndent + "// Control flow nodes\n" + innerIndent +
@@ -123,24 +123,24 @@ std::string DOTFunctionSubGraph::str(std::string indent) const {
   for (DOTEdge e : crossFactEdges) {
     str += e.str(innerIndent) + '\n';
   }
-  return str + indent + '}';
+  return str + Indent + '}';
 }
 
-DOTFactSubGraph *DOTFunctionSubGraph::getOrCreateFactSG(unsigned factID,
-                                                        std::string &label) {
-  DOTFactSubGraph *FuncSG = &facts[factID];
+DOTFactSubGraph *DOTFunctionSubGraph::getOrCreateFactSG(unsigned FactID,
+                                                        std::string &Label) {
+  DOTFactSubGraph *FuncSG = &facts[FactID];
   if (FuncSG->id.empty()) {
-    FuncSG->id = id + '_' + std::to_string(factID);
-    FuncSG->factId = factID;
-    FuncSG->label = label;
+    FuncSG->id = id + '_' + std::to_string(FactID);
+    FuncSG->factId = FactID;
+    FuncSG->label = Label;
   }
   return FuncSG;
 }
 
-std::string DOTFunctionSubGraph::generateLambdaSG(std::string indent) const {
-  std::string innerIndent = indent + "  ";
-  std::string str = indent + "// Auto-generated lambda nodes and edges\n" +
-                    indent + "subgraph cluster_" + id + "_lambda {\n" +
+std::string DOTFunctionSubGraph::generateLambdaSG(std::string Indent) const {
+  std::string innerIndent = Indent + "  ";
+  std::string str = Indent + "// Auto-generated lambda nodes and edges\n" +
+                    Indent + "subgraph cluster_" + id + "_lambda {\n" +
                     innerIndent + "style=invis\n" + innerIndent +
                     "label=\"Λ\"\n" + innerIndent +
                     DOTConfig::LambdaNodeAttr() + '\n';
@@ -160,7 +160,7 @@ std::string DOTFunctionSubGraph::generateLambdaSG(std::string indent) const {
       str += " [style=invis]\n";
     }
   }
-  return str + indent + '}';
+  return str + Indent + '}';
 }
 
 void DOTFunctionSubGraph::createLayoutCFNodes() {
@@ -197,46 +197,46 @@ void DOTFunctionSubGraph::createLayoutFactEdges() {
   }
 }
 
-bool operator<(const DOTNode &lhs, const DOTNode &rhs) {
+bool operator<(const DOTNode &Lhs, const DOTNode &Rhs) {
   stringIDLess strLess;
   // comparing control flow nodes
-  if (lhs.factId == 0 && rhs.factId == 0) {
-    return strLess(lhs.stmtId, rhs.stmtId);
+  if (Lhs.factId == 0 && Rhs.factId == 0) {
+    return strLess(Lhs.stmtId, Rhs.stmtId);
   } else { // comparing fact nodes
-    if (lhs.factId == rhs.factId) {
-      return strLess(lhs.stmtId, rhs.stmtId);
+    if (Lhs.factId == Rhs.factId) {
+      return strLess(Lhs.stmtId, Rhs.stmtId);
     } else {
-      return lhs.factId < rhs.factId;
+      return Lhs.factId < Rhs.factId;
     }
   }
 }
 
-bool operator==(const DOTNode &lhs, const DOTNode &rhs) {
-  return !(lhs < rhs) && !(rhs < lhs);
+bool operator==(const DOTNode &Lhs, const DOTNode &Rhs) {
+  return !(Lhs < Rhs) && !(Rhs < Lhs);
 }
 
-std::ostream &operator<<(std::ostream &os, const DOTNode &node) {
-  return os << node.str();
+std::ostream &operator<<(std::ostream &OS, const DOTNode &Node) {
+  return OS << Node.str();
 }
 
-bool operator<(const DOTEdge &lhs, const DOTEdge &rhs) {
-  if (lhs.source == rhs.source) {
-    return lhs.target < rhs.target;
+bool operator<(const DOTEdge &Lhs, const DOTEdge &Rhs) {
+  if (Lhs.source == Rhs.source) {
+    return Lhs.target < Rhs.target;
   }
-  return lhs.source < rhs.source;
+  return Lhs.source < Rhs.source;
 }
 
-std::ostream &operator<<(std::ostream &os, const DOTEdge &edge) {
-  return os << edge.str();
+std::ostream &operator<<(std::ostream &OS, const DOTEdge &Edge) {
+  return OS << Edge.str();
 }
 
-std::ostream &operator<<(std::ostream &os, const DOTFactSubGraph &factSG) {
-  return os << factSG.str();
+std::ostream &operator<<(std::ostream &OS, const DOTFactSubGraph &FactSG) {
+  return OS << FactSG.str();
 }
 
-std::ostream &operator<<(std::ostream &os,
-                         const DOTFunctionSubGraph &functionSG) {
-  return os << functionSG.str();
+std::ostream &operator<<(std::ostream &OS,
+                         const DOTFunctionSubGraph &FunctionSG) {
+  return OS << FunctionSG.str();
 }
 
 DOTConfig &DOTConfig::getDOTConfig() {

--- a/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
+++ b/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const DataFlowAnalysisType &D) {
+std::string toString(const DataFlowAnalysisType &D) {
   switch (D) {
   default:
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
@@ -47,6 +47,6 @@ DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const DataFlowAnalysisType &D) {
-  return OS << to_string(D);
+  return OS << toString(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
+++ b/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const DataFlowAnalysisType &D) {
+std::string toString(const DataFlowAnalysisType &D) {
   switch (D) {
   default:
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
@@ -30,7 +30,7 @@ std::string to_string(const DataFlowAnalysisType &D) {
   }
 }
 
-DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
+DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S) {
   DataFlowAnalysisType Type = llvm::StringSwitch<DataFlowAnalysisType>(S)
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
   .Case(NAME, DataFlowAnalysisType::TYPE)
@@ -47,6 +47,6 @@ DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const DataFlowAnalysisType &D) {
-  return OS << to_string(D);
+  return OS << toString(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
+++ b/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string toString(const DataFlowAnalysisType &D) {
+std::string to_string(const DataFlowAnalysisType &D) {
   switch (D) {
   default:
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
@@ -30,7 +30,7 @@ std::string toString(const DataFlowAnalysisType &D) {
   }
 }
 
-DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S) {
+DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
   DataFlowAnalysisType Type = llvm::StringSwitch<DataFlowAnalysisType>(S)
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
   .Case(NAME, DataFlowAnalysisType::TYPE)
@@ -47,6 +47,6 @@ DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const DataFlowAnalysisType &D) {
-  return OS << toString(D);
+  return OS << to_string(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
+++ b/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
@@ -30,7 +30,7 @@ std::string toString(const DataFlowAnalysisType &D) {
   }
 }
 
-DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
+DataFlowAnalysisType toDataFlowAnalysisType(const std::string &S) {
   DataFlowAnalysisType Type = llvm::StringSwitch<DataFlowAnalysisType>(S)
 #define DATA_FLOW_ANALYSIS_TYPES(NAME, CMDFLAG, TYPE)                          \
   .Case(NAME, DataFlowAnalysisType::TYPE)

--- a/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
+++ b/lib/PhasarLLVM/Utils/DataFlowAnalysisType.cpp
@@ -46,7 +46,7 @@ DataFlowAnalysisType to_DataFlowAnalysisType(const std::string &S) {
   return Type;
 }
 
-ostream &operator<<(ostream &os, const DataFlowAnalysisType &D) {
-  return os << to_string(D);
+ostream &operator<<(ostream &OS, const DataFlowAnalysisType &D) {
+  return OS << to_string(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/IOFormat.cpp
+++ b/lib/PhasarLLVM/Utils/IOFormat.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string toString(const IOFormat &D) {
+std::string to_string(const IOFormat &D) {
   switch (D) {
   default:
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE)                                   \
@@ -30,7 +30,7 @@ std::string toString(const IOFormat &D) {
   }
 }
 
-IOFormat toIOFormat(const std::string &S) {
+IOFormat to_IOFormat(const std::string &S) {
   IOFormat Type = llvm::StringSwitch<IOFormat>(S)
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE) .Case(NAME, IOFormat::TYPE)
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"
@@ -45,6 +45,6 @@ IOFormat toIOFormat(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const IOFormat &D) {
-  return OS << toString(D);
+  return OS << to_string(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/IOFormat.cpp
+++ b/lib/PhasarLLVM/Utils/IOFormat.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const IOFormat &D) {
+std::string toString(const IOFormat &D) {
   switch (D) {
   default:
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE)                                   \
@@ -45,6 +45,6 @@ IOFormat to_IOFormat(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const IOFormat &D) {
-  return OS << to_string(D);
+  return OS << toString(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/IOFormat.cpp
+++ b/lib/PhasarLLVM/Utils/IOFormat.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace psr {
 
-std::string to_string(const IOFormat &D) {
+std::string toString(const IOFormat &D) {
   switch (D) {
   default:
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE)                                   \
@@ -30,7 +30,7 @@ std::string to_string(const IOFormat &D) {
   }
 }
 
-IOFormat to_IOFormat(const std::string &S) {
+IOFormat toIOFormat(const std::string &S) {
   IOFormat Type = llvm::StringSwitch<IOFormat>(S)
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE) .Case(NAME, IOFormat::TYPE)
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"
@@ -45,6 +45,6 @@ IOFormat to_IOFormat(const std::string &S) {
 }
 
 ostream &operator<<(ostream &OS, const IOFormat &D) {
-  return OS << to_string(D);
+  return OS << toString(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/IOFormat.cpp
+++ b/lib/PhasarLLVM/Utils/IOFormat.cpp
@@ -30,7 +30,7 @@ std::string toString(const IOFormat &D) {
   }
 }
 
-IOFormat to_IOFormat(const std::string &S) {
+IOFormat toIOFormat(const std::string &S) {
   IOFormat Type = llvm::StringSwitch<IOFormat>(S)
 #define IO_FORMAT_TYPES(NAME, CMDFLAG, TYPE) .Case(NAME, IOFormat::TYPE)
 #include "phasar/PhasarLLVM/Utils/IOFormat.def"

--- a/lib/PhasarLLVM/Utils/IOFormat.cpp
+++ b/lib/PhasarLLVM/Utils/IOFormat.cpp
@@ -44,7 +44,7 @@ IOFormat to_IOFormat(const std::string &S) {
   return Type;
 }
 
-ostream &operator<<(ostream &os, const IOFormat &D) {
-  return os << to_string(D);
+ostream &operator<<(ostream &OS, const IOFormat &D) {
+  return OS << to_string(D);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/Scopes.cpp
+++ b/lib/PhasarLLVM/Utils/Scopes.cpp
@@ -24,7 +24,7 @@ const map<Scope, string> ScopeToString{{Scope::function, "function"},
                                        {Scope::module, "module"},
                                        {Scope::project, "project"}};
 
-ostream &operator<<(ostream &os, const Scope &s) {
-  return os << ScopeToString.at(s);
+ostream &operator<<(ostream &OS, const Scope &S) {
+  return OS << ScopeToString.at(S);
 }
 } // namespace psr

--- a/lib/PhasarLLVM/Utils/SummaryStrategy.cpp
+++ b/lib/PhasarLLVM/Utils/SummaryStrategy.cpp
@@ -31,7 +31,7 @@ const map<string, SummaryGenerationStrategy> StringToSummaryGenerationStrategy =
 
 };
 
-ostream &operator<<(ostream &os, const SummaryGenerationStrategy &s) {
-  return os << SummaryGenerationStrategyToString.at(s);
+ostream &operator<<(ostream &OS, const SummaryGenerationStrategy &S) {
+  return OS << SummaryGenerationStrategyToString.at(S);
 }
 } // namespace psr

--- a/lib/PhasarPass/PhasarPass.cpp
+++ b/lib/PhasarPass/PhasarPass.cpp
@@ -66,7 +66,7 @@ bool PhasarPass::runOnModule(llvm::Module &M) {
     EntryPointsSet.insert(EP);
   }
   // set up the call-graph algorithm to be used
-  CallGraphAnalysisType CGTy = to_CallGraphAnalysisType(CallGraphAnalysis);
+  CallGraphAnalysisType CGTy = toCallGraphAnalysisType(CallGraphAnalysis);
   LLVMTypeHierarchy H(DB);
   LLVMPointsToInfo PT(DB);
   LLVMBasedCFG CFG;
@@ -187,11 +187,11 @@ bool PhasarPass::doInitialization(llvm::Module &M) {
   if (EntryPoints.empty()) {
     llvm::report_fatal_error("psr error: no entry points provided");
   }
-  if (to_CallGraphAnalysisType(CallGraphAnalysis) ==
+  if (toCallGraphAnalysisType(CallGraphAnalysis) ==
       CallGraphAnalysisType::Invalid) {
     llvm::report_fatal_error("psr error: call-graph analysis does not exist");
   }
-  if (to_DataFlowAnalysisType(DataFlowAnalysis) == DataFlowAnalysisType::None) {
+  if (toDataFlowAnalysisType(DataFlowAnalysis) == DataFlowAnalysisType::None) {
     llvm::report_fatal_error("psr error: data-flow analysis does not exist");
   }
   return false;

--- a/lib/PhasarPass/PhasarPass.cpp
+++ b/lib/PhasarPass/PhasarPass.cpp
@@ -72,46 +72,46 @@ bool PhasarPass::runOnModule(llvm::Module &M) {
   LLVMBasedCFG CFG;
   LLVMBasedICFG I(DB, CGTy, EntryPointsSet, &H, &PT);
   if (DataFlowAnalysis == "ifds-solvertest") {
-    IFDSSolverTest ifdstest(&DB, &H, &I, &PT, EntryPointsSet);
-    IFDSSolver llvmifdstestsolver(ifdstest);
-    llvmifdstestsolver.solve();
+    IFDSSolverTest IFDSTest(&DB, &H, &I, &PT, EntryPointsSet);
+    IFDSSolver LLVMIFDSTestSolver(IFDSTest);
+    LLVMIFDSTestSolver.solve();
     if (DumpResults) {
-      llvmifdstestsolver.dumpResults();
+      LLVMIFDSTestSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ide-solvertest") {
-    IDESolverTest idetest(&DB, &H, &I, &PT, EntryPointsSet);
-    IDESolver llvmidetestsolver(idetest);
-    llvmidetestsolver.solve();
+    IDESolverTest IDETest(&DB, &H, &I, &PT, EntryPointsSet);
+    IDESolver LLVMIDETestSolver(IDETest);
+    LLVMIDETestSolver.solve();
     if (DumpResults) {
-      llvmidetestsolver.dumpResults();
+      LLVMIDETestSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "intra-mono-solvertest") {
-    IntraMonoSolverTest intra(&DB, &H, &I, &PT, EntryPointsSet);
-    IntraMonoSolver solver(intra);
-    solver.solve();
+    IntraMonoSolverTest Intra(&DB, &H, &I, &PT, EntryPointsSet);
+    IntraMonoSolver Solver(Intra);
+    Solver.solve();
     if (DumpResults) {
-      solver.dumpResults();
+      Solver.dumpResults();
     }
   } else if (DataFlowAnalysis == "inter-mono-solvertest") {
-    InterMonoSolverTest inter(&DB, &H, &I, &PT, EntryPointsSet);
-    InterMonoSolver_P<InterMonoSolverTest, 3> solver(inter);
-    solver.solve();
+    InterMonoSolverTest Inter(&DB, &H, &I, &PT, EntryPointsSet);
+    InterMonoSolver_P<InterMonoSolverTest, 3> Solver(Inter);
+    Solver.solve();
     if (DumpResults) {
-      solver.dumpResults();
+      Solver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ifds-const") {
-    IFDSConstAnalysis constproblem(&DB, &H, &I, &PT, EntryPointsSet);
-    IFDSSolver llvmconstsolver(constproblem);
-    llvmconstsolver.solve();
+    IFDSConstAnalysis ConstProblem(&DB, &H, &I, &PT, EntryPointsSet);
+    IFDSSolver LLVMConstSolver(ConstProblem);
+    LLVMConstSolver.solve();
     if (DumpResults) {
-      llvmconstsolver.dumpResults();
+      LLVMConstSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ifds-lca") {
-    IFDSLinearConstantAnalysis lcaproblem(&DB, &H, &I, &PT, EntryPointsSet);
-    IFDSSolver llvmlcasolver(lcaproblem);
-    llvmlcasolver.solve();
+    IFDSLinearConstantAnalysis LcaProblem(&DB, &H, &I, &PT, EntryPointsSet);
+    IFDSSolver LLVMLcaSolver(LcaProblem);
+    LLVMLcaSolver.solve();
     if (DumpResults) {
-      llvmlcasolver.dumpResults();
+      LLVMLcaSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ifds-taint") {
     TaintConfiguration<const llvm::Value *> TSF;
@@ -123,50 +123,50 @@ bool PhasarPass::runOnModule(llvm::Module &M) {
       LLVMTaintSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ifds-type") {
-    IFDSTypeAnalysis typeanalysisproblem(&DB, &H, &I, &PT, EntryPointsSet);
-    IFDSSolver llvmtypesolver(typeanalysisproblem);
-    llvmtypesolver.solve();
+    IFDSTypeAnalysis TypeAnalysisProblem(&DB, &H, &I, &PT, EntryPointsSet);
+    IFDSSolver LLVMTypeSolver(TypeAnalysisProblem);
+    LLVMTypeSolver.solve();
     if (DumpResults) {
-      llvmtypesolver.dumpResults();
+      LLVMTypeSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ifds-uninit") {
-    IFDSUninitializedVariables uninitializedvarproblem(&DB, &H, &I, &PT,
+    IFDSUninitializedVariables UninitializedVarProblem(&DB, &H, &I, &PT,
                                                        EntryPointsSet);
-    IFDSSolver llvmunivsolver(uninitializedvarproblem);
-    llvmunivsolver.solve();
+    IFDSSolver LLVMUnivSolver(UninitializedVarProblem);
+    LLVMUnivSolver.solve();
     if (DumpResults) {
-      llvmunivsolver.dumpResults();
+      LLVMUnivSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ide-lca") {
-    IDELinearConstantAnalysis lcaproblem(&DB, &H, &I, &PT, EntryPointsSet);
-    IDESolver llvmlcasolver(lcaproblem);
-    llvmlcasolver.solve();
+    IDELinearConstantAnalysis LcaProblem(&DB, &H, &I, &PT, EntryPointsSet);
+    IDESolver LLVMLcaSolver(LcaProblem);
+    LLVMLcaSolver.solve();
     if (DumpResults) {
-      llvmlcasolver.dumpResults();
+      LLVMLcaSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ide-taint") {
-    IDETaintAnalysis taintanalysisproblem(&DB, &H, &I, &PT, EntryPointsSet);
-    IDESolver llvmtaintsolver(taintanalysisproblem);
-    llvmtaintsolver.solve();
+    IDETaintAnalysis TaintAnalysisProblem(&DB, &H, &I, &PT, EntryPointsSet);
+    IDESolver LLVMTaintSolver(TaintAnalysisProblem);
+    LLVMTaintSolver.solve();
     if (DumpResults) {
-      llvmtaintsolver.dumpResults();
+      LLVMTaintSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ide-typestate") {
-    CSTDFILEIOTypeStateDescription fileIODesc;
-    IDETypeStateAnalysis typestateproblem(&DB, &H, &I, &PT, fileIODesc,
+    CSTDFILEIOTypeStateDescription FileIODesc;
+    IDETypeStateAnalysis TypeStateProblem(&DB, &H, &I, &PT, FileIODesc,
                                           EntryPointsSet);
-    IDESolver llvmtypestatesolver(typestateproblem);
-    llvmtypestatesolver.solve();
+    IDESolver LLVMTypeStateSolver(TypeStateProblem);
+    LLVMTypeStateSolver.solve();
     if (DumpResults) {
-      llvmtypestatesolver.dumpResults();
+      LLVMTypeStateSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "ide-instinteract") {
-    IDEInstInteractionAnalysis instinteraction(&DB, &H, &I, &PT,
+    IDEInstInteractionAnalysis InstInteraction(&DB, &H, &I, &PT,
                                                EntryPointsSet);
-    IDESolver llvminstinteractionsolver(instinteraction);
-    llvminstinteractionsolver.solve();
+    IDESolver LLVMInstInteractionSolver(InstInteraction);
+    LLVMInstInteractionSolver.solve();
     if (DumpResults) {
-      llvminstinteractionsolver.dumpResults();
+      LLVMInstInteractionSolver.dumpResults();
     }
   } else if (DataFlowAnalysis == "intra-mono-fullconstantpropagation") {
     // todo
@@ -210,7 +210,7 @@ void PhasarPass::print(llvm::raw_ostream &O, const llvm::Module *M) const {
   O << "I am a PhasarPass Analysis Result ;-)\n";
 }
 
-static llvm::RegisterPass<PhasarPass> phasar("phasar", "PhASAR Pass",
+static llvm::RegisterPass<PhasarPass> Phasar("phasar", "PhASAR Pass",
                                              false /* Only looks at CFG */,
                                              false /* Analysis Pass */);
 

--- a/lib/PhasarPass/PhasarPass.cpp
+++ b/lib/PhasarPass/PhasarPass.cpp
@@ -66,7 +66,7 @@ bool PhasarPass::runOnModule(llvm::Module &M) {
     EntryPointsSet.insert(EP);
   }
   // set up the call-graph algorithm to be used
-  CallGraphAnalysisType CGTy = toCallGraphAnalysisType(CallGraphAnalysis);
+  CallGraphAnalysisType CGTy = to_CallGraphAnalysisType(CallGraphAnalysis);
   LLVMTypeHierarchy H(DB);
   LLVMPointsToInfo PT(DB);
   LLVMBasedCFG CFG;
@@ -187,11 +187,11 @@ bool PhasarPass::doInitialization(llvm::Module &M) {
   if (EntryPoints.empty()) {
     llvm::report_fatal_error("psr error: no entry points provided");
   }
-  if (toCallGraphAnalysisType(CallGraphAnalysis) ==
+  if (to_CallGraphAnalysisType(CallGraphAnalysis) ==
       CallGraphAnalysisType::Invalid) {
     llvm::report_fatal_error("psr error: call-graph analysis does not exist");
   }
-  if (toDataFlowAnalysisType(DataFlowAnalysis) == DataFlowAnalysisType::None) {
+  if (to_DataFlowAnalysisType(DataFlowAnalysis) == DataFlowAnalysisType::None) {
     llvm::report_fatal_error("psr error: data-flow analysis does not exist");
   }
   return false;

--- a/lib/PhasarPass/PhasarPrinterPass.cpp
+++ b/lib/PhasarPass/PhasarPrinterPass.cpp
@@ -50,7 +50,7 @@ void PhasarPrinterPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
 void PhasarPrinterPass::releaseMemory() {}
 
 static llvm::RegisterPass<PhasarPrinterPass>
-    phasar("phasar-printer", "PhASAR Printer Pass",
+    Phasar("phasar-printer", "PhASAR Printer Pass",
            false /* Only looks at CFG */, false /* Analysis Pass */);
 
 } // namespace psr

--- a/lib/Utils/IO.cpp
+++ b/lib/Utils/IO.cpp
@@ -27,24 +27,24 @@ namespace psr {
 string readFile(const string &Path) {
   if (boost::filesystem::exists(Path) &&
       !boost::filesystem::is_directory(Path)) {
-    ifstream ifs(Path, ios::binary);
-    if (ifs.is_open()) {
-      ifs.seekg(0, ifs.end);
-      size_t file_size = ifs.tellg();
-      ifs.seekg(0, ifs.beg);
-      string content;
-      content.resize(file_size);
-      ifs.read(const_cast<char *>(content.data()), file_size);
-      return content;
+    ifstream Ifs(Path, ios::binary);
+    if (Ifs.is_open()) {
+      Ifs.seekg(0, Ifs.end);
+      size_t FileSize = Ifs.tellg();
+      Ifs.seekg(0, Ifs.beg);
+      string Content;
+      Content.resize(FileSize);
+      Ifs.read(const_cast<char *>(Content.data()), FileSize);
+      return Content;
     }
   }
   throw ios_base::failure("could not read file: " + Path);
 }
 
 void writeFile(const string &Path, const string &Content) {
-  ofstream ofs(Path, ios::binary);
-  if (ofs.is_open()) {
-    ofs.write(Content.data(), Content.size());
+  ofstream Ofs(Path, ios::binary);
+  if (Ofs.is_open()) {
+    Ofs.write(Content.data(), Content.size());
   }
   throw ios_base::failure("could not write file: " + Path);
 }

--- a/lib/Utils/IO.cpp
+++ b/lib/Utils/IO.cpp
@@ -24,10 +24,10 @@ using namespace std;
 
 namespace psr {
 
-string readFile(const string &path) {
-  if (boost::filesystem::exists(path) &&
-      !boost::filesystem::is_directory(path)) {
-    ifstream ifs(path, ios::binary);
+string readFile(const string &Path) {
+  if (boost::filesystem::exists(Path) &&
+      !boost::filesystem::is_directory(Path)) {
+    ifstream ifs(Path, ios::binary);
     if (ifs.is_open()) {
       ifs.seekg(0, ifs.end);
       size_t file_size = ifs.tellg();
@@ -38,14 +38,14 @@ string readFile(const string &path) {
       return content;
     }
   }
-  throw ios_base::failure("could not read file: " + path);
+  throw ios_base::failure("could not read file: " + Path);
 }
 
-void writeFile(const string &path, const string &content) {
-  ofstream ofs(path, ios::binary);
+void writeFile(const string &Path, const string &Content) {
+  ofstream ofs(Path, ios::binary);
   if (ofs.is_open()) {
-    ofs.write(content.data(), content.size());
+    ofs.write(Content.data(), Content.size());
   }
-  throw ios_base::failure("could not write file: " + path);
+  throw ios_base::failure("could not write file: " + Path);
 }
 } // namespace psr

--- a/lib/Utils/LLVMIRToSrc.cpp
+++ b/lib/Utils/LLVMIRToSrc.cpp
@@ -148,14 +148,14 @@ std::string getFunctionNameFromIR(const llvm::Value *V) {
 
 std::string getFilePathFromIR(const llvm::Value *V) {
   if (auto DIF = getDIFile(V)) {
-    boost::filesystem::path file(DIF->getFilename().str());
-    boost::filesystem::path dir(DIF->getDirectory().str());
-    if (!file.empty()) {
+    boost::filesystem::path File(DIF->getFilename().str());
+    boost::filesystem::path Dir(DIF->getDirectory().str());
+    if (!File.empty()) {
       // try to concatenate file path and dir to get absolut path
-      if (!file.has_root_directory() && !dir.empty()) {
-        file = dir / file;
+      if (!File.has_root_directory() && !Dir.empty()) {
+        File = Dir / File;
       }
-      return file.string();
+      return File.string();
     }
   } else {
     /* As a fallback solution, we will return 'source_filename' info from
@@ -205,21 +205,21 @@ unsigned int getColumnFromIR(const llvm::Value *V) {
 }
 
 std::string getSrcCodeFromIR(const llvm::Value *V) {
-  unsigned int lineNr = getLineFromIR(V);
-  if (lineNr > 0) {
-    boost::filesystem::path path(getFilePathFromIR(V));
-    if (boost::filesystem::exists(path) &&
-        !boost::filesystem::is_directory(path)) {
-      std::ifstream ifs(path.string(), std::ios::binary);
-      if (ifs.is_open()) {
-        ifs.seekg(std::ios::beg);
-        std::string src_line;
-        for (unsigned int i = 0; i < lineNr - 1; ++i) {
-          ifs.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  unsigned int LineNr = getLineFromIR(V);
+  if (LineNr > 0) {
+    boost::filesystem::path Path(getFilePathFromIR(V));
+    if (boost::filesystem::exists(Path) &&
+        !boost::filesystem::is_directory(Path)) {
+      std::ifstream Ifs(Path.string(), std::ios::binary);
+      if (Ifs.is_open()) {
+        Ifs.seekg(std::ios::beg);
+        std::string SrcLine;
+        for (unsigned int I = 0; I < LineNr - 1; ++I) {
+          Ifs.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }
-        std::getline(ifs, src_line);
-        boost::algorithm::trim(src_line);
-        return src_line;
+        std::getline(Ifs, SrcLine);
+        boost::algorithm::trim(SrcLine);
+        return SrcLine;
       }
     }
   }

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -35,13 +35,14 @@
 
 #include "stdlib.h"
 
+using namespace std;
 using namespace psr;
 
 namespace psr {
 
 /// Set of functions that allocate heap memory, e.g. new, new[], malloc.
-const std::set<std::string> HeapAllocationFunctions = {
-    "_Znwm", "_Znam", "malloc", "calloc", "realloc"};
+const set<string> HeapAllocationFunctions = {"_Znwm", "_Znam", "malloc",
+                                             "calloc", "realloc"};
 
 bool isFunctionPointer(const llvm::Value *V) noexcept {
   if (V) {
@@ -226,9 +227,9 @@ std::string getMetaDataID(const llvm::Value *V) {
           .str();
     }
   } else if (auto *Arg = llvm::dyn_cast<llvm::Argument>(V)) {
-    std::string FName = Arg->getParent()->getName().str();
-    std::string ArgNr = std::to_string(getFunctionArgumentNr(Arg));
-    return std::string(FName + "." + ArgNr);
+    string FName = Arg->getParent()->getName().str();
+    string ArgNr = to_string(getFunctionArgumentNr(Arg));
+    return string(FName + "." + ArgNr);
   }
   return "-1";
 }

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -54,7 +54,7 @@ bool isFunctionPointer(const llvm::Value *V) noexcept {
 
 SpecialMemberFunctionTy specialMemberFunctionType(const std::string &S) {
   // test if Codes for Constructors, Destructors or operator= are in string
-  static const std::map<std::string, SpecialMemberFunctionTy> codes{
+  static const std::map<std::string, SpecialMemberFunctionTy> Codes{
       {"C1", SpecialMemberFunctionTy::CTOR},
       {"C2", SpecialMemberFunctionTy::CTOR},
       {"C3", SpecialMemberFunctionTy::CTOR},
@@ -63,46 +63,46 @@ SpecialMemberFunctionTy specialMemberFunctionType(const std::string &S) {
       {"D2", SpecialMemberFunctionTy::DTOR},
       {"aSERKS_", SpecialMemberFunctionTy::CPASSIGNOP},
       {"aSEOS_", SpecialMemberFunctionTy::MVASSIGNOP}};
-  std::vector<std::pair<std::size_t, SpecialMemberFunctionTy>> found;
-  std::size_t blacklist = 0;
-  auto it = codes.begin();
-  while (it != codes.end()) {
-    if (std::size_t index = S.find(it->first, blacklist)) {
-      if (index != std::string::npos) {
-        found.push_back(std::make_pair(index, it->second));
-        blacklist = index + 1;
+  std::vector<std::pair<std::size_t, SpecialMemberFunctionTy>> Found;
+  std::size_t Blacklist = 0;
+  auto It = Codes.begin();
+  while (It != Codes.end()) {
+    if (std::size_t Index = S.find(It->first, Blacklist)) {
+      if (Index != std::string::npos) {
+        Found.push_back(std::make_pair(Index, It->second));
+        Blacklist = Index + 1;
       } else {
-        ++it;
-        blacklist = 0;
+        ++It;
+        Blacklist = 0;
       }
     }
   }
-  if (found.empty()) {
+  if (Found.empty()) {
     return SpecialMemberFunctionTy::NONE;
   }
 
   // test if codes are in function name or type information
-  bool noName = true;
-  for (auto index : found) {
-    for (auto c = S.begin(); c < S.begin() + index.first; ++c) {
-      if (isdigit(*c)) {
-        short i = 0;
-        while (isdigit(*(c + i))) {
-          ++i;
+  bool NoName = true;
+  for (auto Index : Found) {
+    for (auto C = S.begin(); C < S.begin() + Index.first; ++C) {
+      if (isdigit(*C)) {
+        short I = 0;
+        while (isdigit(*(C + I))) {
+          ++I;
         }
-        std::string st(c, c + i);
-        if (index.first <= std::distance(S.begin(), c) + stoul(st)) {
-          noName = false;
+        std::string ST(C, C + I);
+        if (Index.first <= std::distance(S.begin(), C) + stoul(ST)) {
+          NoName = false;
           break;
         } else {
-          c = c + *c;
+          C = C + *C;
         }
       }
     }
-    if (noName) {
-      return index.second;
+    if (NoName) {
+      return Index.second;
     } else {
-      noName = true;
+      NoName = true;
     }
   }
   return SpecialMemberFunctionTy::NONE;
@@ -134,12 +134,12 @@ bool matchesSignature(const llvm::Function *F,
     return false;
   if (F->arg_size() == FType->getNumParams() &&
       F->getReturnType() == FType->getReturnType()) {
-    unsigned i = 0;
-    for (auto &arg : F->args()) {
-      if (arg.getType() != FType->getParamType(i)) {
+    unsigned Idx = 0;
+    for (auto &Arg : F->args()) {
+      if (Arg.getType() != FType->getParamType(Idx)) {
         return false;
       }
-      ++i;
+      ++Idx;
     }
     return true;
   }
@@ -198,31 +198,31 @@ std::string llvmIRToShortString(const llvm::Value *V) {
 
 std::vector<const llvm::Value *>
 globalValuesUsedinFunction(const llvm::Function *F) {
-  std::vector<const llvm::Value *> globals_used;
+  std::vector<const llvm::Value *> GlobalsUsed;
   for (auto &BB : *F) {
     for (auto &I : BB) {
       for (auto &Op : I.operands()) {
         if (const llvm::GlobalValue *G =
                 llvm::dyn_cast<llvm::GlobalValue>(Op)) {
-          globals_used.push_back(G);
+          GlobalsUsed.push_back(G);
         }
       }
     }
   }
-  return globals_used;
+  return GlobalsUsed;
 }
 
 std::string getMetaDataID(const llvm::Value *V) {
   if (auto Inst = llvm::dyn_cast<llvm::Instruction>(V)) {
-    if (auto metaData = Inst->getMetadata(PhasarConfig::MetaDataKind())) {
-      return llvm::cast<llvm::MDString>(metaData->getOperand(0))
+    if (auto Metadata = Inst->getMetadata(PhasarConfig::MetaDataKind())) {
+      return llvm::cast<llvm::MDString>(Metadata->getOperand(0))
           ->getString()
           .str();
     }
 
   } else if (auto GV = llvm::dyn_cast<llvm::GlobalVariable>(V)) {
-    if (auto metaData = GV->getMetadata(PhasarConfig::MetaDataKind())) {
-      return llvm::cast<llvm::MDString>(metaData->getOperand(0))
+    if (auto Metadata = GV->getMetadata(PhasarConfig::MetaDataKind())) {
+      return llvm::cast<llvm::MDString>(Metadata->getOperand(0))
           ->getString()
           .str();
     }
@@ -238,9 +238,9 @@ llvmValueIDLess::llvmValueIDLess() : sless(stringIDLess()) {}
 
 bool llvmValueIDLess::operator()(const llvm::Value *Lhs,
                                  const llvm::Value *Rhs) const {
-  std::string lhs_id = getMetaDataID(Lhs);
-  std::string rhs_id = getMetaDataID(Rhs);
-  return sless(lhs_id, rhs_id);
+  std::string LhsId = getMetaDataID(Lhs);
+  std::string RhsId = getMetaDataID(Rhs);
+  return sless(LhsId, RhsId);
 }
 
 int getFunctionArgumentNr(const llvm::Argument *Arg) {
@@ -257,12 +257,12 @@ int getFunctionArgumentNr(const llvm::Argument *Arg) {
 const llvm::Argument *getNthFunctionArgument(const llvm::Function *F,
                                              unsigned ArgNo) {
   if (ArgNo < F->arg_size()) {
-    unsigned current = 0;
+    unsigned Current = 0;
     for (auto &A : F->args()) {
-      if (ArgNo == current) {
+      if (ArgNo == Current) {
         return &A;
       }
-      ++current;
+      ++Current;
     }
   }
   return nullptr;
@@ -270,13 +270,13 @@ const llvm::Argument *getNthFunctionArgument(const llvm::Function *F,
 
 const llvm::Instruction *getNthInstruction(const llvm::Function *F,
                                            unsigned Idx) {
-  unsigned i = 1;
+  unsigned Current = 1;
   for (auto &BB : *F) {
     for (auto &I : BB) {
-      if (i == Idx) {
+      if (Current == Idx) {
         return &I;
       } else {
-        ++i;
+        ++Current;
       }
     }
   }
@@ -339,13 +339,13 @@ std::size_t computeModuleHash(const llvm::Module *M) {
 
 const llvm::Instruction *getNthTermInstruction(const llvm::Function *F,
                                                unsigned TermInstNo) {
-  unsigned current = 1;
+  unsigned Current = 1;
   for (auto &BB : *F) {
     if (const llvm::Instruction *T = BB.getTerminator()) {
-      if (current == TermInstNo) {
+      if (Current == TermInstNo) {
         return T;
       }
-      current++;
+      Current++;
     }
   }
   return nullptr;
@@ -353,14 +353,14 @@ const llvm::Instruction *getNthTermInstruction(const llvm::Function *F,
 
 const llvm::StoreInst *getNthStoreInstruction(const llvm::Function *F,
                                               unsigned StoNo) {
-  unsigned current = 1;
+  unsigned Current = 1;
   for (auto &BB : *F) {
     for (auto &I : BB) {
       if (const llvm::StoreInst *S = llvm::dyn_cast<llvm::StoreInst>(&I)) {
-        if (current == StoNo) {
+        if (Current == StoNo) {
           return S;
         }
-        current++;
+        Current++;
       }
     }
   }

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -52,7 +52,7 @@ bool isFunctionPointer(const llvm::Value *V) noexcept {
   return false;
 }
 
-SpecialMemberFunctionTy specialMemberFunctionType(const std::string &s) {
+SpecialMemberFunctionTy specialMemberFunctionType(const std::string &S) {
   // test if Codes for Constructors, Destructors or operator= are in string
   static const std::map<std::string, SpecialMemberFunctionTy> codes{
       {"C1", SpecialMemberFunctionTy::CTOR},
@@ -67,7 +67,7 @@ SpecialMemberFunctionTy specialMemberFunctionType(const std::string &s) {
   std::size_t blacklist = 0;
   auto it = codes.begin();
   while (it != codes.end()) {
-    if (std::size_t index = s.find(it->first, blacklist)) {
+    if (std::size_t index = S.find(it->first, blacklist)) {
       if (index != std::string::npos) {
         found.push_back(std::make_pair(index, it->second));
         blacklist = index + 1;
@@ -84,14 +84,14 @@ SpecialMemberFunctionTy specialMemberFunctionType(const std::string &s) {
   // test if codes are in function name or type information
   bool noName = true;
   for (auto index : found) {
-    for (auto c = s.begin(); c < s.begin() + index.first; ++c) {
+    for (auto c = S.begin(); c < S.begin() + index.first; ++c) {
       if (isdigit(*c)) {
         short i = 0;
         while (isdigit(*(c + i))) {
           ++i;
         }
         std::string st(c, c + i);
-        if (index.first <= std::distance(s.begin(), c) + stoul(st)) {
+        if (index.first <= std::distance(S.begin(), c) + stoul(st)) {
           noName = false;
           break;
         } else {
@@ -108,8 +108,8 @@ SpecialMemberFunctionTy specialMemberFunctionType(const std::string &s) {
   return SpecialMemberFunctionTy::NONE;
 }
 
-SpecialMemberFunctionTy specialMemberFunctionType(const llvm::StringRef &sr) {
-  return specialMemberFunctionType(sr.str());
+SpecialMemberFunctionTy specialMemberFunctionType(const llvm::StringRef &Sr) {
+  return specialMemberFunctionType(Sr.str());
 }
 
 bool isAllocaInstOrHeapAllocaFunction(const llvm::Value *V) noexcept {
@@ -236,10 +236,10 @@ std::string getMetaDataID(const llvm::Value *V) {
 
 llvmValueIDLess::llvmValueIDLess() : sless(stringIDLess()) {}
 
-bool llvmValueIDLess::operator()(const llvm::Value *lhs,
-                                 const llvm::Value *rhs) const {
-  std::string lhs_id = getMetaDataID(lhs);
-  std::string rhs_id = getMetaDataID(rhs);
+bool llvmValueIDLess::operator()(const llvm::Value *Lhs,
+                                 const llvm::Value *Rhs) const {
+  std::string lhs_id = getMetaDataID(Lhs);
+  std::string rhs_id = getMetaDataID(Rhs);
   return sless(lhs_id, rhs_id);
 }
 
@@ -255,11 +255,11 @@ int getFunctionArgumentNr(const llvm::Argument *Arg) {
 }
 
 const llvm::Argument *getNthFunctionArgument(const llvm::Function *F,
-                                             unsigned argNo) {
-  if (argNo < F->arg_size()) {
+                                             unsigned ArgNo) {
+  if (ArgNo < F->arg_size()) {
     unsigned current = 0;
     for (auto &A : F->args()) {
-      if (argNo == current) {
+      if (ArgNo == current) {
         return &A;
       }
       ++current;
@@ -269,11 +269,11 @@ const llvm::Argument *getNthFunctionArgument(const llvm::Function *F,
 }
 
 const llvm::Instruction *getNthInstruction(const llvm::Function *F,
-                                           unsigned idx) {
+                                           unsigned Idx) {
   unsigned i = 1;
   for (auto &BB : *F) {
     for (auto &I : BB) {
-      if (i == idx) {
+      if (i == Idx) {
         return &I;
       } else {
         ++i;
@@ -312,9 +312,9 @@ const std::string getModuleNameFromVal(const llvm::Value *V) {
   return M ? M->getModuleIdentifier() : " ";
 }
 
-std::size_t computeModuleHash(llvm::Module *M, bool considerIdentifier) {
+std::size_t computeModuleHash(llvm::Module *M, bool ConsiderIdentifier) {
   std::string SourceCode;
-  if (considerIdentifier) {
+  if (ConsiderIdentifier) {
     llvm::raw_string_ostream RSO(SourceCode);
     llvm::WriteBitcodeToFile(*M, RSO);
     RSO.flush();
@@ -338,11 +338,11 @@ std::size_t computeModuleHash(const llvm::Module *M) {
 }
 
 const llvm::Instruction *getNthTermInstruction(const llvm::Function *F,
-                                               unsigned termInstNo) {
+                                               unsigned TermInstNo) {
   unsigned current = 1;
   for (auto &BB : *F) {
     if (const llvm::Instruction *T = BB.getTerminator()) {
-      if (current == termInstNo) {
+      if (current == TermInstNo) {
         return T;
       }
       current++;
@@ -352,12 +352,12 @@ const llvm::Instruction *getNthTermInstruction(const llvm::Function *F,
 }
 
 const llvm::StoreInst *getNthStoreInstruction(const llvm::Function *F,
-                                              unsigned stoNo) {
+                                              unsigned StoNo) {
   unsigned current = 1;
   for (auto &BB : *F) {
     for (auto &I : BB) {
       if (const llvm::StoreInst *S = llvm::dyn_cast<llvm::StoreInst>(&I)) {
-        if (current == stoNo) {
+        if (current == StoNo) {
           return S;
         }
         current++;

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -35,14 +35,13 @@
 
 #include "stdlib.h"
 
-using namespace std;
 using namespace psr;
 
 namespace psr {
 
 /// Set of functions that allocate heap memory, e.g. new, new[], malloc.
-const set<string> HeapAllocationFunctions = {"_Znwm", "_Znam", "malloc",
-                                             "calloc", "realloc"};
+const std::set<std::string> HeapAllocationFunctions = {
+    "_Znwm", "_Znam", "malloc", "calloc", "realloc"};
 
 bool isFunctionPointer(const llvm::Value *V) noexcept {
   if (V) {
@@ -227,9 +226,9 @@ std::string getMetaDataID(const llvm::Value *V) {
           .str();
     }
   } else if (auto *Arg = llvm::dyn_cast<llvm::Argument>(V)) {
-    string FName = Arg->getParent()->getName().str();
-    string ArgNr = to_string(getFunctionArgumentNr(Arg));
-    return string(FName + "." + ArgNr);
+    std::string FName = Arg->getParent()->getName().str();
+    std::string ArgNr = std::to_string(getFunctionArgumentNr(Arg));
+    return std::string(FName + "." + ArgNr);
   }
   return "-1";
 }

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -228,7 +228,7 @@ std::string getMetaDataID(const llvm::Value *V) {
     }
   } else if (auto *Arg = llvm::dyn_cast<llvm::Argument>(V)) {
     string FName = Arg->getParent()->getName().str();
-    string ArgNr = to_string(getFunctionArgumentNr(Arg));
+    string ArgNr = std::to_string(getFunctionArgumentNr(Arg));
     return string(FName + "." + ArgNr);
   }
   return "-1";

--- a/lib/Utils/Logger.cpp
+++ b/lib/Utils/Logger.cpp
@@ -55,11 +55,11 @@ ostream &operator<<(ostream &OS, enum severity_level L) {
   return OS << SeverityLevelToString.at(L);
 }
 
-bool LogFilter(const boost::log::attribute_value_set &Set) {
+bool logFilter(const boost::log::attribute_value_set &Set) {
   return Set["Severity"].extract<severity_level>() >= LogFilterLevel;
 }
 
-void LogFormatter(const boost::log::record_view &View,
+void logFormatter(const boost::log::record_view &View,
                   boost::log::formatting_ostream &OS) {
   OS << View.attribute_values()["LineCounter"].extract<int>() << " "
      << View.attribute_values()["Timestamp"].extract<boost::posix_time::ptime>()
@@ -97,8 +97,8 @@ void initializeLogger(bool UseLogger, string LogFile) {
   // log_file);
   // }
   Sink->locked_backend()->add_stream(Stream);
-  Sink->set_filter(&LogFilter);
-  Sink->set_formatter(&LogFormatter);
+  Sink->set_filter(&logFilter);
+  Sink->set_formatter(&logFormatter);
   boost::log::core::get()->add_sink(Sink);
   boost::log::core::get()->add_global_attribute(
       "LineCounter", boost::log::attributes::counter<int>{});

--- a/lib/Utils/Logger.cpp
+++ b/lib/Utils/Logger.cpp
@@ -47,16 +47,16 @@ const map<severity_level, string> SeverityLevelToString = {
     {ERROR, "ERROR"},
     {CRITICAL, "CRITICAL"}};
 
-severity_level logFilterLevel = DEBUG;
+severity_level LogFilterLevel = DEBUG;
 
-void setLoggerFilterLevel(severity_level Level) { logFilterLevel = Level; }
+void setLoggerFilterLevel(severity_level Level) { LogFilterLevel = Level; }
 
 ostream &operator<<(ostream &OS, enum severity_level L) {
   return OS << SeverityLevelToString.at(L);
 }
 
 bool LogFilter(const boost::log::attribute_value_set &Set) {
-  return Set["Severity"].extract<severity_level>() >= logFilterLevel;
+  return Set["Severity"].extract<severity_level>() >= LogFilterLevel;
 }
 
 void LogFormatter(const boost::log::record_view &View,
@@ -78,9 +78,9 @@ void initializeLogger(bool UseLogger, string LogFile) {
   typedef boost::log::sinks::synchronous_sink<
       boost::log::sinks::text_ostream_backend>
       text_sink;
-  boost::shared_ptr<text_sink> sink = boost::make_shared<text_sink>();
+  boost::shared_ptr<text_sink> Sink = boost::make_shared<text_sink>();
   // the easiest way is to write the logs to std::clog
-  boost::shared_ptr<std::ostream> stream(&std::clog, boost::null_deleter{});
+  boost::shared_ptr<std::ostream> Stream(&std::clog, boost::null_deleter{});
   // } else {
   // // get the time and make it into a string for log file nameing
   // time_t current_time = std::time(nullptr);
@@ -96,10 +96,10 @@ void initializeLogger(bool UseLogger, string LogFile) {
   // auto stream = boost::make_shared<std::ofstream>(LogFileDirectory + time +
   // log_file);
   // }
-  sink->locked_backend()->add_stream(stream);
-  sink->set_filter(&LogFilter);
-  sink->set_formatter(&LogFormatter);
-  boost::log::core::get()->add_sink(sink);
+  Sink->locked_backend()->add_stream(Stream);
+  Sink->set_filter(&LogFilter);
+  Sink->set_formatter(&LogFormatter);
+  boost::log::core::get()->add_sink(Sink);
   boost::log::core::get()->add_global_attribute(
       "LineCounter", boost::log::attributes::counter<int>{});
   boost::log::core::get()->add_global_attribute(

--- a/lib/Utils/Logger.cpp
+++ b/lib/Utils/Logger.cpp
@@ -55,11 +55,11 @@ ostream &operator<<(ostream &OS, enum severity_level L) {
   return OS << SeverityLevelToString.at(L);
 }
 
-bool logFilter(const boost::log::attribute_value_set &Set) {
+bool LogFilter(const boost::log::attribute_value_set &Set) {
   return Set["Severity"].extract<severity_level>() >= LogFilterLevel;
 }
 
-void logFormatter(const boost::log::record_view &View,
+void LogFormatter(const boost::log::record_view &View,
                   boost::log::formatting_ostream &OS) {
   OS << View.attribute_values()["LineCounter"].extract<int>() << " "
      << View.attribute_values()["Timestamp"].extract<boost::posix_time::ptime>()
@@ -97,8 +97,8 @@ void initializeLogger(bool UseLogger, string LogFile) {
   // log_file);
   // }
   Sink->locked_backend()->add_stream(Stream);
-  Sink->set_filter(&logFilter);
-  Sink->set_formatter(&logFormatter);
+  Sink->set_filter(&LogFilter);
+  Sink->set_formatter(&LogFormatter);
   boost::log::core::get()->add_sink(Sink);
   boost::log::core::get()->add_global_attribute(
       "LineCounter", boost::log::attributes::counter<int>{});

--- a/lib/Utils/Logger.cpp
+++ b/lib/Utils/Logger.cpp
@@ -49,31 +49,31 @@ const map<severity_level, string> SeverityLevelToString = {
 
 severity_level logFilterLevel = DEBUG;
 
-void setLoggerFilterLevel(severity_level level) { logFilterLevel = level; }
+void setLoggerFilterLevel(severity_level Level) { logFilterLevel = Level; }
 
-ostream &operator<<(ostream &os, enum severity_level l) {
-  return os << SeverityLevelToString.at(l);
+ostream &operator<<(ostream &OS, enum severity_level L) {
+  return OS << SeverityLevelToString.at(L);
 }
 
-bool LogFilter(const boost::log::attribute_value_set &set) {
-  return set["Severity"].extract<severity_level>() >= logFilterLevel;
+bool LogFilter(const boost::log::attribute_value_set &Set) {
+  return Set["Severity"].extract<severity_level>() >= logFilterLevel;
 }
 
-void LogFormatter(const boost::log::record_view &view,
-                  boost::log::formatting_ostream &os) {
-  os << view.attribute_values()["LineCounter"].extract<int>() << " "
-     << view.attribute_values()["Timestamp"].extract<boost::posix_time::ptime>()
-     << " - [" << view.attribute_values()["Severity"].extract<severity_level>()
-     << "] " << view.attribute_values()["Message"].extract<std::string>();
+void LogFormatter(const boost::log::record_view &View,
+                  boost::log::formatting_ostream &OS) {
+  OS << View.attribute_values()["LineCounter"].extract<int>() << " "
+     << View.attribute_values()["Timestamp"].extract<boost::posix_time::ptime>()
+     << " - [" << View.attribute_values()["Severity"].extract<severity_level>()
+     << "] " << View.attribute_values()["Message"].extract<std::string>();
 }
 
-void LoggerExceptionHandler::operator()(const std::exception &ex) const {
-  std::cerr << "std::exception: " << ex.what() << '\n';
+void LoggerExceptionHandler::operator()(const std::exception &Ex) const {
+  std::cerr << "std::exception: " << Ex.what() << '\n';
 }
 
-void initializeLogger(bool use_logger, string log_file) {
+void initializeLogger(bool UseLogger, string LogFile) {
   // Using this call, logging can be enabled or disabled
-  boost::log::core::get()->set_logging_enabled(use_logger);
+  boost::log::core::get()->set_logging_enabled(UseLogger);
   // if (log_file == "") {
   typedef boost::log::sinks::synchronous_sink<
       boost::log::sinks::text_ostream_backend>

--- a/lib/Utils/SoundnessFlag.cpp
+++ b/lib/Utils/SoundnessFlag.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string toString(const SoundnessFlag &SF) {
+std::string to_string(const SoundnessFlag &SF) {
   switch (SF) {
   default:
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
@@ -29,7 +29,7 @@ std::string toString(const SoundnessFlag &SF) {
   }
 }
 
-SoundnessFlag toSoundnessFlag(const std::string &S) {
+SoundnessFlag to_SoundnessFlag(const std::string &S) {
   SoundnessFlag Type = llvm::StringSwitch<SoundnessFlag>(S)
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
   .Case(NAME, SoundnessFlag::TYPE)
@@ -46,7 +46,7 @@ SoundnessFlag toSoundnessFlag(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const SoundnessFlag &SF) {
-  return OS << toString(SF);
+  return OS << to_string(SF);
 }
 
 } // namespace psr

--- a/lib/Utils/SoundnessFlag.cpp
+++ b/lib/Utils/SoundnessFlag.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string to_string(const SoundnessFlag &SF) {
+std::string toString(const SoundnessFlag &SF) {
   switch (SF) {
   default:
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
@@ -46,7 +46,7 @@ SoundnessFlag to_SoundnessFlag(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const SoundnessFlag &SF) {
-  return OS << to_string(SF);
+  return OS << toString(SF);
 }
 
 } // namespace psr

--- a/lib/Utils/SoundnessFlag.cpp
+++ b/lib/Utils/SoundnessFlag.cpp
@@ -29,7 +29,7 @@ std::string toString(const SoundnessFlag &SF) {
   }
 }
 
-SoundnessFlag to_SoundnessFlag(const std::string &S) {
+SoundnessFlag toSoundnessFlag(const std::string &S) {
   SoundnessFlag Type = llvm::StringSwitch<SoundnessFlag>(S)
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
   .Case(NAME, SoundnessFlag::TYPE)

--- a/lib/Utils/SoundnessFlag.cpp
+++ b/lib/Utils/SoundnessFlag.cpp
@@ -45,8 +45,8 @@ SoundnessFlag to_SoundnessFlag(const std::string &S) {
   return Type;
 }
 
-std::ostream &operator<<(std::ostream &os, const SoundnessFlag &SF) {
-  return os << to_string(SF);
+std::ostream &operator<<(std::ostream &OS, const SoundnessFlag &SF) {
+  return OS << to_string(SF);
 }
 
 } // namespace psr

--- a/lib/Utils/SoundnessFlag.cpp
+++ b/lib/Utils/SoundnessFlag.cpp
@@ -18,7 +18,7 @@ using namespace psr;
 
 namespace psr {
 
-std::string to_string(const SoundnessFlag &SF) {
+std::string toString(const SoundnessFlag &SF) {
   switch (SF) {
   default:
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
@@ -29,7 +29,7 @@ std::string to_string(const SoundnessFlag &SF) {
   }
 }
 
-SoundnessFlag to_SoundnessFlag(const std::string &S) {
+SoundnessFlag toSoundnessFlag(const std::string &S) {
   SoundnessFlag Type = llvm::StringSwitch<SoundnessFlag>(S)
 #define SOUNDNESS_FLAG_TYPE(NAME, CMDFLAG, TYPE)                               \
   .Case(NAME, SoundnessFlag::TYPE)
@@ -46,7 +46,7 @@ SoundnessFlag to_SoundnessFlag(const std::string &S) {
 }
 
 std::ostream &operator<<(std::ostream &OS, const SoundnessFlag &SF) {
-  return OS << to_string(SF);
+  return OS << toString(SF);
 }
 
 } // namespace psr

--- a/lib/Utils/Utilities.cpp
+++ b/lib/Utils/Utilities.cpp
@@ -39,7 +39,7 @@ std::string createTimeStamp() {
   return TimeStr;
 }
 
-string cxxDemangle(const string &MangledName) {
+string cxx_demangle(const string &MangledName) {
   return boost::core::demangle(MangledName.c_str());
 }
 
@@ -79,7 +79,7 @@ const llvm::Type *stripPointer(const llvm::Type *Pointer) {
   return Pointer;
 }
 
-bool isMangled(const string &Name) { return Name != cxxDemangle(Name); }
+bool isMangled(const string &Name) { return Name != cxx_demangle(Name); }
 
 vector<string> splitString(const string &Str, const string &Delimiter) {
   vector<string> SplitStrings;

--- a/lib/Utils/Utilities.cpp
+++ b/lib/Utils/Utilities.cpp
@@ -39,7 +39,7 @@ std::string createTimeStamp() {
   return TimeStr;
 }
 
-string cxx_demangle(const string &MangledName) {
+string cxxDemangle(const string &MangledName) {
   return boost::core::demangle(MangledName.c_str());
 }
 
@@ -79,7 +79,7 @@ const llvm::Type *stripPointer(const llvm::Type *Pointer) {
   return Pointer;
 }
 
-bool isMangled(const string &Name) { return Name != cxx_demangle(Name); }
+bool isMangled(const string &Name) { return Name != cxxDemangle(Name); }
 
 vector<string> splitString(const string &Str, const string &Delimiter) {
   vector<string> SplitStrings;

--- a/lib/Utils/Utilities.cpp
+++ b/lib/Utils/Utilities.cpp
@@ -39,11 +39,11 @@ std::string createTimeStamp() {
   return TimeStr;
 }
 
-string cxx_demangle(const string &mangled_name) {
-  return boost::core::demangle(mangled_name.c_str());
+string cxx_demangle(const string &MangledName) {
+  return boost::core::demangle(MangledName.c_str());
 }
 
-bool isConstructor(const string &mangled_name) {
+bool isConstructor(const string &MangledName) {
   // WARNING: Doesn't work for templated classes, should
   // the best way to do it I can think of is to use a lexer
   // on the name to detect the constructor point explained
@@ -51,17 +51,17 @@ bool isConstructor(const string &mangled_name) {
   // see https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 
   // This version will not work in some edge cases
-  auto constructor = boost::algorithm::find_last(mangled_name, "C2E");
+  auto constructor = boost::algorithm::find_last(MangledName, "C2E");
 
   if (constructor.begin() != constructor.end())
     return true;
 
-  constructor = boost::algorithm::find_last(mangled_name, "C1E");
+  constructor = boost::algorithm::find_last(MangledName, "C1E");
 
   if (constructor.begin() != constructor.end())
     return true;
 
-  constructor = boost::algorithm::find_last(mangled_name, "C2E");
+  constructor = boost::algorithm::find_last(MangledName, "C2E");
 
   if (constructor.begin() != constructor.end())
     return true;
@@ -69,45 +69,45 @@ bool isConstructor(const string &mangled_name) {
   return false;
 }
 
-const llvm::Type *stripPointer(const llvm::Type *pointer) {
-  auto next = llvm::dyn_cast<llvm::PointerType>(pointer);
+const llvm::Type *stripPointer(const llvm::Type *Pointer) {
+  auto next = llvm::dyn_cast<llvm::PointerType>(Pointer);
   while (next) {
-    pointer = next->getElementType();
-    next = llvm::dyn_cast<llvm::PointerType>(pointer);
+    Pointer = next->getElementType();
+    next = llvm::dyn_cast<llvm::PointerType>(Pointer);
   }
 
-  return pointer;
+  return Pointer;
 }
 
-bool isMangled(const string &name) { return name != cxx_demangle(name); }
+bool isMangled(const string &Name) { return Name != cxx_demangle(Name); }
 
-vector<string> splitString(const string &str, const string &delimiter) {
+vector<string> splitString(const string &Str, const string &Delimiter) {
   vector<string> split_strings;
-  boost::split(split_strings, str, boost::is_any_of(delimiter),
+  boost::split(split_strings, Str, boost::is_any_of(Delimiter),
                boost::token_compress_on);
   return split_strings;
 }
 
-ostream &operator<<(ostream &os, const vector<bool> &bits) {
-  for (auto bit : bits) {
-    os << bit;
+ostream &operator<<(ostream &OS, const vector<bool> &Bits) {
+  for (auto bit : Bits) {
+    OS << bit;
   }
-  return os;
+  return OS;
 }
 
-bool stringIDLess::operator()(const std::string &lhs,
-                              const std::string &rhs) const {
+bool stringIDLess::operator()(const std::string &Lhs,
+                              const std::string &Rhs) const {
   char *endptr1, *endptr2;
-  long lhs_val = strtol(lhs.c_str(), &endptr1, 10);
-  long rhs_val = strtol(rhs.c_str(), &endptr2, 10);
-  if (lhs.c_str() == endptr1 && lhs.c_str() == endptr2) {
-    return lhs < rhs;
-  } else if (lhs.c_str() == endptr1 && rhs.c_str() != endptr2) {
+  long lhsVal = strtol(Lhs.c_str(), &endptr1, 10);
+  long rhsVal = strtol(Rhs.c_str(), &endptr2, 10);
+  if (Lhs.c_str() == endptr1 && Lhs.c_str() == endptr2) {
+    return Lhs < Rhs;
+  } else if (Lhs.c_str() == endptr1 && Rhs.c_str() != endptr2) {
     return false;
-  } else if (lhs.c_str() != endptr1 && rhs.c_str() == endptr2) {
+  } else if (Lhs.c_str() != endptr1 && Rhs.c_str() == endptr2) {
     return true;
   } else {
-    return lhs_val < rhs_val;
+    return lhsVal < rhsVal;
   }
 }
 

--- a/lib/Utils/Utilities.cpp
+++ b/lib/Utils/Utilities.cpp
@@ -51,29 +51,29 @@ bool isConstructor(const string &MangledName) {
   // see https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 
   // This version will not work in some edge cases
-  auto constructor = boost::algorithm::find_last(MangledName, "C2E");
+  auto Constructor = boost::algorithm::find_last(MangledName, "C2E");
 
-  if (constructor.begin() != constructor.end())
+  if (Constructor.begin() != Constructor.end())
     return true;
 
-  constructor = boost::algorithm::find_last(MangledName, "C1E");
+  Constructor = boost::algorithm::find_last(MangledName, "C1E");
 
-  if (constructor.begin() != constructor.end())
+  if (Constructor.begin() != Constructor.end())
     return true;
 
-  constructor = boost::algorithm::find_last(MangledName, "C2E");
+  Constructor = boost::algorithm::find_last(MangledName, "C2E");
 
-  if (constructor.begin() != constructor.end())
+  if (Constructor.begin() != Constructor.end())
     return true;
 
   return false;
 }
 
 const llvm::Type *stripPointer(const llvm::Type *Pointer) {
-  auto next = llvm::dyn_cast<llvm::PointerType>(Pointer);
-  while (next) {
-    Pointer = next->getElementType();
-    next = llvm::dyn_cast<llvm::PointerType>(Pointer);
+  auto Next = llvm::dyn_cast<llvm::PointerType>(Pointer);
+  while (Next) {
+    Pointer = Next->getElementType();
+    Next = llvm::dyn_cast<llvm::PointerType>(Pointer);
   }
 
   return Pointer;
@@ -82,32 +82,32 @@ const llvm::Type *stripPointer(const llvm::Type *Pointer) {
 bool isMangled(const string &Name) { return Name != cxx_demangle(Name); }
 
 vector<string> splitString(const string &Str, const string &Delimiter) {
-  vector<string> split_strings;
-  boost::split(split_strings, Str, boost::is_any_of(Delimiter),
+  vector<string> SplitStrings;
+  boost::split(SplitStrings, Str, boost::is_any_of(Delimiter),
                boost::token_compress_on);
-  return split_strings;
+  return SplitStrings;
 }
 
 ostream &operator<<(ostream &OS, const vector<bool> &Bits) {
-  for (auto bit : Bits) {
-    OS << bit;
+  for (auto Bit : Bits) {
+    OS << Bit;
   }
   return OS;
 }
 
 bool stringIDLess::operator()(const std::string &Lhs,
                               const std::string &Rhs) const {
-  char *endptr1, *endptr2;
-  long lhsVal = strtol(Lhs.c_str(), &endptr1, 10);
-  long rhsVal = strtol(Rhs.c_str(), &endptr2, 10);
-  if (Lhs.c_str() == endptr1 && Lhs.c_str() == endptr2) {
+  char *Endptr1, *Endptr2;
+  long LhsVal = strtol(Lhs.c_str(), &Endptr1, 10);
+  long RhsVal = strtol(Rhs.c_str(), &Endptr2, 10);
+  if (Lhs.c_str() == Endptr1 && Lhs.c_str() == Endptr2) {
     return Lhs < Rhs;
-  } else if (Lhs.c_str() == endptr1 && Rhs.c_str() != endptr2) {
+  } else if (Lhs.c_str() == Endptr1 && Rhs.c_str() != Endptr2) {
     return false;
-  } else if (Lhs.c_str() != endptr1 && Rhs.c_str() == endptr2) {
+  } else if (Lhs.c_str() != Endptr1 && Rhs.c_str() == Endptr2) {
     return true;
   } else {
-    return lhsVal < rhsVal;
+    return LhsVal < RhsVal;
   }
 }
 

--- a/tools/boomerang/boomerang.cpp
+++ b/tools/boomerang/boomerang.cpp
@@ -11,9 +11,9 @@
 
 #include "phasar/DB/ProjectIRDB.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
-#include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
-#include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/SyncPDS/Solver/SyncPDSSolver.h"
+#include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
+#include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/Logger.h"
 
 #include "llvm/Support/raw_ostream.h"

--- a/tools/boomerang/boomerang.cpp
+++ b/tools/boomerang/boomerang.cpp
@@ -26,7 +26,7 @@ namespace bfs = boost::filesystem;
 
 int main(int Argc, char **Argv) {
   initializeLogger(false);
-  auto &lg = lg::get();
+  auto &LG = lg::get();
   if (Argc < 2 || !bfs::exists(Argv[1]) || bfs::is_directory(Argv[1])) {
     std::cerr << "usage: <prog> <ir file>\n";
     std::cerr << "use programs in build/test/llvm_test_code/pointers/\n";
@@ -38,7 +38,9 @@ int main(int Argc, char **Argv) {
   LLVMPointsToInfo P(DB);
   LLVMBasedICFG ICFG(DB, CallGraphAnalysisType::OTF, {"main"}, &H, &P);
   for (auto &F : *DB.getWPAModule()) {
-    if (F.isDeclaration()) { continue; }
+    if (F.isDeclaration()) {
+      continue;
+    }
     llvm::outs() << "ANALYZE FUNCTION: " << F.getName() << '\n';
     for (auto &BB : F) {
       for (auto &I : BB) {
@@ -61,9 +63,9 @@ int main(int Argc, char **Argv) {
             llvm::outs() << '\n';
             // query SPDS solver to find the aliases
             // SyncPDSSolver SPDS(ICFG);
-            // set<const llvm::Value *> Aliases = SPDS.getAliasesOf(Load->getPointerOperand());
-            // llvm::outs() << "Found aliases:";
-            // for (auto A : Aliases) {
+            // set<const llvm::Value *> Aliases =
+            // SPDS.getAliasesOf(Load->getPointerOperand()); llvm::outs() <<
+            // "Found aliases:"; for (auto A : Aliases) {
             //   A->print(llvm::outs() << '\n');
             // }
             llvm::outs() << '\n';

--- a/tools/boomerang/boomerang.cpp
+++ b/tools/boomerang/boomerang.cpp
@@ -24,16 +24,16 @@ using namespace std;
 using namespace psr;
 namespace bfs = boost::filesystem;
 
-int main(int argc, char **argv) {
+int main(int Argc, char **Argv) {
   initializeLogger(false);
   auto &lg = lg::get();
-  if (argc < 2 || !bfs::exists(argv[1]) || bfs::is_directory(argv[1])) {
+  if (Argc < 2 || !bfs::exists(Argv[1]) || bfs::is_directory(Argv[1])) {
     std::cerr << "usage: <prog> <ir file>\n";
     std::cerr << "use programs in build/test/llvm_test_code/pointers/\n";
     return 1;
   }
   initializeLogger(false);
-  ProjectIRDB DB({argv[1]}, IRDBOptions::WPA);
+  ProjectIRDB DB({Argv[1]}, IRDBOptions::WPA);
   LLVMTypeHierarchy H(DB);
   LLVMPointsToInfo P(DB);
   LLVMBasedICFG ICFG(DB, CallGraphAnalysisType::OTF, {"main"}, &H, &P);

--- a/tools/example-tool/myphasartool.cpp
+++ b/tools/example-tool/myphasartool.cpp
@@ -28,18 +28,18 @@ class Value;
 
 using namespace psr;
 
-int main(int argc, const char **argv) {
+int main(int Argc, const char **Argv) {
   initializeLogger(false);
   auto &lg = lg::get();
-  if (argc < 2 || !boost::filesystem::exists(argv[1]) ||
-      boost::filesystem::is_directory(argv[1])) {
+  if (Argc < 2 || !boost::filesystem::exists(Argv[1]) ||
+      boost::filesystem::is_directory(Argv[1])) {
     std::cerr << "myphasartool\n"
                  "A small PhASAR-based example program\n\n"
                  "Usage: myphasartool <LLVM IR file>\n";
     return 1;
   }
   initializeLogger(false);
-  ProjectIRDB DB({argv[1]});
+  ProjectIRDB DB({Argv[1]});
   if (auto F = DB.getFunctionDefinition("main")) {
     LLVMTypeHierarchy H(DB);
     // print type hierarchy

--- a/tools/example-tool/myphasartool.cpp
+++ b/tools/example-tool/myphasartool.cpp
@@ -7,8 +7,8 @@
  *     Philipp Schubert and others
  *****************************************************************************/
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include "boost/filesystem/operations.hpp"
 

--- a/tools/example-tool/myphasartool.cpp
+++ b/tools/example-tool/myphasartool.cpp
@@ -30,7 +30,7 @@ using namespace psr;
 
 int main(int Argc, const char **Argv) {
   initializeLogger(false);
-  auto &lg = lg::get();
+  auto &LG = lg::get();
   if (Argc < 2 || !boost::filesystem::exists(Argv[1]) ||
       boost::filesystem::is_directory(Argv[1])) {
     std::cerr << "myphasartool\n"

--- a/tools/phasar-clang/phasar-clang.cpp
+++ b/tools/phasar-clang/phasar-clang.cpp
@@ -19,13 +19,13 @@ namespace bfs = boost::filesystem;
 using namespace std;
 using namespace psr;
 
-int main(int argc, const char **argv) {
-  if (argc < 2 || !bfs::exists(argv[1]) || bfs::is_directory(argv[1])) {
+int main(int Argc, const char **Argv) {
+  if (Argc < 2 || !bfs::exists(Argv[1]) || bfs::is_directory(Argv[1])) {
     std::cerr << "usage: <prog> <ir file>\n";
     return 1;
   }
   initializeLogger(false);
-  ProjectIRDB DB({argv[1]}, IRDBOptions::WPA);
+  ProjectIRDB DB({Argv[1]}, IRDBOptions::WPA);
   if (DB.getFunction("main")) {
   } else {
     std::cerr << "error: file does not contain a 'main' function!\n";

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -29,9 +29,9 @@ constexpr char MoreHelp[] =
     ;
 
 template <typename T> static std::set<T> vectorToSet(const std::vector<T> &V) {
-  std::set<T> s;
-  for_each(V.begin(), V.end(), [&s](T Item) { s.insert(Item); });
-  return s;
+  std::set<T> S;
+  for_each(V.begin(), V.end(), [&S](T Item) { S.insert(Item); });
+  return S;
 }
 
 void validateParamConfigFile(const std::string &Config) {
@@ -216,11 +216,11 @@ int main(int Argc, const char **Argv) {
   }
   try {
     if (ConfigFile != "") {
-      std::ifstream ifs(ConfigFile.c_str());
-      if (!ifs) {
+      std::ifstream Ifs(ConfigFile.c_str());
+      if (!Ifs) {
       } else {
         boost::program_options::store(
-            boost::program_options::parse_config_file(ifs, ConfigFileOptions),
+            boost::program_options::parse_config_file(Ifs, ConfigFileOptions),
             PhasarConfig::VariablesMap());
         boost::program_options::notify(PhasarConfig::VariablesMap());
       }

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -209,7 +209,7 @@ int main(int argc, const char **argv) {
             .run(),
         PhasarConfig::VariablesMap());
     boost::program_options::notify(PhasarConfig::VariablesMap());
-  } catch (boost::program_options::error Err) {
+  } catch (boost::program_options::error &Err) {
     std::cerr << "Could not parse command-line arguments!\n"
               << "Error: " << Err.what() << '\n';
     return 1;
@@ -225,7 +225,7 @@ int main(int argc, const char **argv) {
         boost::program_options::notify(PhasarConfig::VariablesMap());
       }
     }
-  } catch (boost::program_options::error Err) {
+  } catch (boost::program_options::error &Err) {
     std::cerr << "Could not parse configuration file!\n"
               << "Error: " << Err.what() << '\n';
     return 1;
@@ -359,7 +359,7 @@ int main(int argc, const char **argv) {
     ProjectID = PhasarConfig::VariablesMap()["project-id"].as<std::string>();
   }
   AnalysisController Controller(IRDB, DataFlowAnalyses, AnalysisConfigs, PTATy,
-                                CGTy,SF, EntryPoints, Strategy, EmitterOptions,
+                                CGTy, SF, EntryPoints, Strategy, EmitterOptions,
                                 ProjectID, OutDirectory);
   return 0;
 }

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -28,9 +28,9 @@ constexpr char MoreHelp[] =
 #include "../phasar-llvm_more_help.txt"
     ;
 
-template <typename T> static std::set<T> vectorToSet(const std::vector<T> &v) {
+template <typename T> static std::set<T> vectorToSet(const std::vector<T> &V) {
   std::set<T> s;
-  for_each(v.begin(), v.end(), [&s](T t) { s.insert(t); });
+  for_each(V.begin(), V.end(), [&s](T Item) { s.insert(Item); });
   return s;
 }
 
@@ -143,7 +143,7 @@ void validateParamAnalysisConfig(const std::vector<std::string> &Configs) {
   }
 }
 
-int main(int argc, const char **argv) {
+int main(int Argc, const char **Argv) {
   // handling the command line parameters
   std::string ConfigFile;
   // Declare a group of options that will be allowed only on command line
@@ -204,7 +204,7 @@ int main(int argc, const char **argv) {
   Visible.add(Generic).add(Config);
   try {
     boost::program_options::store(
-        boost::program_options::command_line_parser(argc, argv)
+        boost::program_options::command_line_parser(Argc, Argv)
             .options(CmdlineOptions)
             .run(),
         PhasarConfig::VariablesMap());

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -76,7 +76,7 @@ void validateParamPammOutputFile(const std::string &Output) {}
 
 void validateParamDataFlowAnalysis(const std::vector<std::string> &Analyses) {
   for (auto &Analysis : Analyses) {
-    if (toDataFlowAnalysisType(Analysis) == DataFlowAnalysisType::None) {
+    if (to_DataFlowAnalysisType(Analysis) == DataFlowAnalysisType::None) {
       throw boost::program_options::error_with_option_name(
           "'" + Analysis + "' is not a valid data-flow analysis!");
     }
@@ -84,28 +84,28 @@ void validateParamDataFlowAnalysis(const std::vector<std::string> &Analyses) {
 }
 
 void validateParamAnalysisStrategy(const std::string &Strategy) {
-  if (toAnalysisStrategy(Strategy) == AnalysisStrategy::None) {
+  if (to_AnalysisStrategy(Strategy) == AnalysisStrategy::None) {
     throw boost::program_options::error_with_option_name(
         "Invalid analysis strategy '" + Strategy + "'!");
   }
 }
 
 void validateParamPointerAnalysis(const std::string &Analysis) {
-  if (toPointerAnalysisType(Analysis) == PointerAnalysisType::Invalid) {
+  if (to_PointerAnalysisType(Analysis) == PointerAnalysisType::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Analysis + "' is not a valid pointer analysis!");
   }
 }
 
 void validateParamCallGraphAnalysis(const std::string &Analysis) {
-  if (toCallGraphAnalysisType(Analysis) == CallGraphAnalysisType::Invalid) {
+  if (to_CallGraphAnalysisType(Analysis) == CallGraphAnalysisType::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Analysis + "' is not a valid call-graph analysis!");
   }
 }
 
 void validateSoundnessFlag(const std::string &Flag) {
-  if (toSoundnessFlag(Flag) == SoundnessFlag::Invalid) {
+  if (to_SoundnessFlag(Flag) == SoundnessFlag::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Flag + "' is not a valid soundiness flag!");
   }
@@ -261,7 +261,7 @@ int main(int Argc, const char **Argv) {
   // setup the analysis controller which executes the chosen analyses
   AnalysisStrategy Strategy = AnalysisStrategy::None;
   if (PhasarConfig::VariablesMap().count("analysis-strategy")) {
-    Strategy = toAnalysisStrategy(
+    Strategy = to_AnalysisStrategy(
         PhasarConfig::VariablesMap()["analysis-strategy"].as<std::string>());
     if (Strategy == AnalysisStrategy::None) {
       std::cout << "Invalid analysis strategy!\n";
@@ -284,7 +284,7 @@ int main(int Argc, const char **Argv) {
     auto Analyses = PhasarConfig::VariablesMap()["data-flow-analysis"]
                         .as<std::vector<std::string>>();
     for (auto &Analysis : Analyses) {
-      DataFlowAnalyses.push_back(toDataFlowAnalysisType(Analysis));
+      DataFlowAnalyses.push_back(to_DataFlowAnalysisType(Analysis));
     }
   } else {
     DataFlowAnalyses.push_back(DataFlowAnalysisType::None);
@@ -304,13 +304,13 @@ int main(int Argc, const char **Argv) {
     EntryPoints.insert("main");
   }
   // setup pointer algorithm to be used
-  PointerAnalysisType PTATy = toPointerAnalysisType(
+  PointerAnalysisType PTATy = to_PointerAnalysisType(
       PhasarConfig::VariablesMap()["pointer-analysis"].as<std::string>());
   // setup call-graph algorithm to be used
-  CallGraphAnalysisType CGTy = toCallGraphAnalysisType(
+  CallGraphAnalysisType CGTy = to_CallGraphAnalysisType(
       PhasarConfig::VariablesMap()["call-graph-analysis"].as<std::string>());
   // setup soudiness level to be used
-  SoundnessFlag SF = toSoundnessFlag(
+  SoundnessFlag SF = to_SoundnessFlag(
       PhasarConfig::VariablesMap()["soundiness-flag"].as<std::string>());
   // setup the emitter options to display the computed analysis results
   AnalysisControllerEmitterOptions EmitterOptions =

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -76,7 +76,7 @@ void validateParamPammOutputFile(const std::string &Output) {}
 
 void validateParamDataFlowAnalysis(const std::vector<std::string> &Analyses) {
   for (auto &Analysis : Analyses) {
-    if (to_DataFlowAnalysisType(Analysis) == DataFlowAnalysisType::None) {
+    if (toDataFlowAnalysisType(Analysis) == DataFlowAnalysisType::None) {
       throw boost::program_options::error_with_option_name(
           "'" + Analysis + "' is not a valid data-flow analysis!");
     }
@@ -84,28 +84,28 @@ void validateParamDataFlowAnalysis(const std::vector<std::string> &Analyses) {
 }
 
 void validateParamAnalysisStrategy(const std::string &Strategy) {
-  if (to_AnalysisStrategy(Strategy) == AnalysisStrategy::None) {
+  if (toAnalysisStrategy(Strategy) == AnalysisStrategy::None) {
     throw boost::program_options::error_with_option_name(
         "Invalid analysis strategy '" + Strategy + "'!");
   }
 }
 
 void validateParamPointerAnalysis(const std::string &Analysis) {
-  if (to_PointerAnalysisType(Analysis) == PointerAnalysisType::Invalid) {
+  if (toPointerAnalysisType(Analysis) == PointerAnalysisType::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Analysis + "' is not a valid pointer analysis!");
   }
 }
 
 void validateParamCallGraphAnalysis(const std::string &Analysis) {
-  if (to_CallGraphAnalysisType(Analysis) == CallGraphAnalysisType::Invalid) {
+  if (toCallGraphAnalysisType(Analysis) == CallGraphAnalysisType::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Analysis + "' is not a valid call-graph analysis!");
   }
 }
 
 void validateSoundnessFlag(const std::string &Flag) {
-  if (to_SoundnessFlag(Flag) == SoundnessFlag::Invalid) {
+  if (toSoundnessFlag(Flag) == SoundnessFlag::Invalid) {
     throw boost::program_options::error_with_option_name(
         "'" + Flag + "' is not a valid soundiness flag!");
   }
@@ -261,7 +261,7 @@ int main(int Argc, const char **Argv) {
   // setup the analysis controller which executes the chosen analyses
   AnalysisStrategy Strategy = AnalysisStrategy::None;
   if (PhasarConfig::VariablesMap().count("analysis-strategy")) {
-    Strategy = to_AnalysisStrategy(
+    Strategy = toAnalysisStrategy(
         PhasarConfig::VariablesMap()["analysis-strategy"].as<std::string>());
     if (Strategy == AnalysisStrategy::None) {
       std::cout << "Invalid analysis strategy!\n";
@@ -284,7 +284,7 @@ int main(int Argc, const char **Argv) {
     auto Analyses = PhasarConfig::VariablesMap()["data-flow-analysis"]
                         .as<std::vector<std::string>>();
     for (auto &Analysis : Analyses) {
-      DataFlowAnalyses.push_back(to_DataFlowAnalysisType(Analysis));
+      DataFlowAnalyses.push_back(toDataFlowAnalysisType(Analysis));
     }
   } else {
     DataFlowAnalyses.push_back(DataFlowAnalysisType::None);
@@ -304,13 +304,13 @@ int main(int Argc, const char **Argv) {
     EntryPoints.insert("main");
   }
   // setup pointer algorithm to be used
-  PointerAnalysisType PTATy = to_PointerAnalysisType(
+  PointerAnalysisType PTATy = toPointerAnalysisType(
       PhasarConfig::VariablesMap()["pointer-analysis"].as<std::string>());
   // setup call-graph algorithm to be used
-  CallGraphAnalysisType CGTy = to_CallGraphAnalysisType(
+  CallGraphAnalysisType CGTy = toCallGraphAnalysisType(
       PhasarConfig::VariablesMap()["call-graph-analysis"].as<std::string>());
   // setup soudiness level to be used
-  SoundnessFlag SF = to_SoundnessFlag(
+  SoundnessFlag SF = toSoundnessFlag(
       PhasarConfig::VariablesMap()["soundiness-flag"].as<std::string>());
   // setup the emitter options to display the computed analysis results
   AnalysisControllerEmitterOptions EmitterOptions =

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -339,113 +339,113 @@ TEST_F(LTHTest, VTableConstruction) {
   ASSERT_TRUE(TH5.hasVFTable(TH5.getType("struct.Base")));
   ASSERT_TRUE(TH5.hasVFTable(TH5.getType("struct.Child")));
 
-  ASSERT_TRUE(cxx_demangle(TH1.getVFTable(TH1.getType("struct.Base"))
-                               ->getFunction(0)
-                               ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxxDemangle(TH1.getVFTable(TH1.getType("struct.Base"))
+                              ->getFunction(0)
+                              ->getName()) == "Base::foo()");
   ASSERT_TRUE(TH1.getVFTable(TH1.getType("struct.Base"))->size() == 1);
-  ASSERT_TRUE(cxx_demangle(TH1.getVFTable(TH1.getType("struct.Child"))
-                               ->getFunction(0)
-                               ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxxDemangle(TH1.getVFTable(TH1.getType("struct.Child"))
+                              ->getFunction(0)
+                              ->getName()) == "Child::foo()");
   ASSERT_TRUE(TH1.getVFTable(TH1.getType("struct.Child"))->size() == 1);
 
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.A"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.A"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.B"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.B"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.C"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.C"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.D"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.D"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.X"))->getFunction(0)->getName()) ==
       "X::g()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.X"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.Y"))->getFunction(0)->getName()) ==
       "X::g()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.Y"))->size() == 1);
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.Z"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(
-      cxx_demangle(
+      cxxDemangle(
           TH2.getVFTable(TH2.getType("struct.Z"))->getFunction(1)->getName()) ==
       "X::g()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.Z"))->size() == 2);
 
-  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Base"))
-                               ->getFunction(0)
-                               ->getName()) == "Base::foo()");
-  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Base"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Base"))
+                              ->getFunction(0)
+                              ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Base"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH3.getVFTable(TH3.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                               ->getFunction(0)
-                               ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                               ->getFunction(2)
-                               ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                              ->getFunction(0)
+                              ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                              ->getFunction(2)
+                              ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH3.getVFTable(TH3.getType("struct.Child"))->size() == 3);
 
-  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Base"))
-                               ->getFunction(0)
-                               ->getName()) == "Base::foo()");
-  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Base"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Base"))
+                              ->getFunction(0)
+                              ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Base"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH4.getVFTable(TH4.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                               ->getFunction(0)
-                               ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                               ->getFunction(2)
-                               ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                              ->getFunction(0)
+                              ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                              ->getFunction(2)
+                              ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH4.getVFTable(TH4.getType("struct.Child"))->size() == 3);
 
-  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Base"))
-                               ->getFunction(0)
-                               ->getName()) == "__cxa_pure_virtual");
-  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Base"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Base"))
+                              ->getFunction(0)
+                              ->getName()) == "__cxa_pure_virtual");
+  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Base"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                               ->getFunction(0)
-                               ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                               ->getFunction(1)
-                               ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                               ->getFunction(2)
-                               ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                              ->getFunction(0)
+                              ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                              ->getFunction(1)
+                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                              ->getFunction(2)
+                              ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Child"))->size() == 3);
 }
 

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -339,113 +339,113 @@ TEST_F(LTHTest, VTableConstruction) {
   ASSERT_TRUE(TH5.hasVFTable(TH5.getType("struct.Base")));
   ASSERT_TRUE(TH5.hasVFTable(TH5.getType("struct.Child")));
 
-  ASSERT_TRUE(cxxDemangle(TH1.getVFTable(TH1.getType("struct.Base"))
-                              ->getFunction(0)
-                              ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxx_demangle(TH1.getVFTable(TH1.getType("struct.Base"))
+                               ->getFunction(0)
+                               ->getName()) == "Base::foo()");
   ASSERT_TRUE(TH1.getVFTable(TH1.getType("struct.Base"))->size() == 1);
-  ASSERT_TRUE(cxxDemangle(TH1.getVFTable(TH1.getType("struct.Child"))
-                              ->getFunction(0)
-                              ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxx_demangle(TH1.getVFTable(TH1.getType("struct.Child"))
+                               ->getFunction(0)
+                               ->getName()) == "Child::foo()");
   ASSERT_TRUE(TH1.getVFTable(TH1.getType("struct.Child"))->size() == 1);
 
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.A"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.A"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.B"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.B"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.C"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.C"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.D"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.D"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.X"))->getFunction(0)->getName()) ==
       "X::g()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.X"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.Y"))->getFunction(0)->getName()) ==
       "X::g()");
   ASSERT_TRUE(
 
       TH2.getVFTable(TH2.getType("struct.Y"))->size() == 1);
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.Z"))->getFunction(0)->getName()) ==
       "A::f()");
   ASSERT_TRUE(
-      cxxDemangle(
+      cxx_demangle(
           TH2.getVFTable(TH2.getType("struct.Z"))->getFunction(1)->getName()) ==
       "X::g()");
   ASSERT_TRUE(TH2.getVFTable(TH2.getType("struct.Z"))->size() == 2);
 
-  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Base"))
-                              ->getFunction(0)
-                              ->getName()) == "Base::foo()");
-  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Base"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Base"))
+                               ->getFunction(0)
+                               ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Base"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH3.getVFTable(TH3.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                              ->getFunction(0)
-                              ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxxDemangle(TH3.getVFTable(TH3.getType("struct.Child"))
-                              ->getFunction(2)
-                              ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                               ->getFunction(0)
+                               ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH3.getVFTable(TH3.getType("struct.Child"))
+                               ->getFunction(2)
+                               ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH3.getVFTable(TH3.getType("struct.Child"))->size() == 3);
 
-  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Base"))
-                              ->getFunction(0)
-                              ->getName()) == "Base::foo()");
-  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Base"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Base"))
+                               ->getFunction(0)
+                               ->getName()) == "Base::foo()");
+  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Base"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH4.getVFTable(TH4.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                              ->getFunction(0)
-                              ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxxDemangle(TH4.getVFTable(TH4.getType("struct.Child"))
-                              ->getFunction(2)
-                              ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                               ->getFunction(0)
+                               ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH4.getVFTable(TH4.getType("struct.Child"))
+                               ->getFunction(2)
+                               ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH4.getVFTable(TH4.getType("struct.Child"))->size() == 3);
 
-  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Base"))
-                              ->getFunction(0)
-                              ->getName()) == "__cxa_pure_virtual");
-  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Base"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Base"))
+                               ->getFunction(0)
+                               ->getName()) == "__cxa_pure_virtual");
+  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Base"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Base"))->size() == 2);
-  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                              ->getFunction(0)
-                              ->getName()) == "Child::foo()");
-  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                              ->getFunction(1)
-                              ->getName()) == "Base::bar()");
-  ASSERT_TRUE(cxxDemangle(TH5.getVFTable(TH5.getType("struct.Child"))
-                              ->getFunction(2)
-                              ->getName()) == "Child::baz()");
+  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                               ->getFunction(0)
+                               ->getName()) == "Child::foo()");
+  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                               ->getFunction(1)
+                               ->getName()) == "Base::bar()");
+  ASSERT_TRUE(cxx_demangle(TH5.getVFTable(TH5.getType("struct.Child"))
+                               ->getFunction(2)
+                               ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Child"))->size() == 3);
 }
 

--- a/utils/run-phasar-checks.sh
+++ b/utils/run-phasar-checks.sh
@@ -6,14 +6,26 @@
 # Run some very useful clang-tidy checks and clang-format on the code base.
 #
 
+# hacky way to exclude external projects
+cp .clang-tidy-ignore external/googletest/.clang-tidy
+cp .clang-tidy-ignore external/json/.clang-tidy
+cp .clang-tidy-ignore external/WALi-OpenNWA/.clang-tidy
+
 echo "Run clang-tidy ..."
+
 # You can set the number of concurrent jobs using '-j n'. For debugging it might be useful to
 # use only one job.
-run-clang-tidy.py -p build/ -header-filter='phasar*.h'
+
+/usr/local/llvm-9/share/clang/run-clang-tidy.py -p build/ -header-filter='phasar*.h' -j 8 -quiet -fix
+
 # The option '-fix' applies suggested fixes to the code, see 'run-clang-tidy.py --help'
 # run-clang-tidy.py -p build/ -header-filter='phasar*.h' -fix
 
 echo "Run clang-format ..."
 ./utils/run-clang-format.py
+
+rm external/googletest/.clang-tidy
+rm external/json/.clang-tidy
+rm external/WALi-OpenNWA/.clang-tidy
 
 exit 0

--- a/utils/run-phasar-checks.sh
+++ b/utils/run-phasar-checks.sh
@@ -6,7 +6,7 @@
 # Run some very useful clang-tidy checks and clang-format on the code base.
 #
 
-# hacky way to exclude external projects
+# exclude external projects from clang tidy checks
 cp .clang-tidy-ignore external/googletest/.clang-tidy
 cp .clang-tidy-ignore external/json/.clang-tidy
 cp .clang-tidy-ignore external/WALi-OpenNWA/.clang-tidy

--- a/utils/run-phasar-checks.sh
+++ b/utils/run-phasar-checks.sh
@@ -16,7 +16,7 @@ echo "Run clang-tidy ..."
 # You can set the number of concurrent jobs using '-j n'. For debugging it might be useful to
 # use only one job.
 
-/usr/local/llvm-9/share/clang/run-clang-tidy.py -p build/ -header-filter='phasar*.h' -j 8 -quiet -fix
+run-clang-tidy.py -p build/ -header-filter='phasar*.h'
 
 # The option '-fix' applies suggested fixes to the code, see 'run-clang-tidy.py --help'
 # run-clang-tidy.py -p build/ -header-filter='phasar*.h' -fix


### PR DESCRIPTION
Resolves a lot of the warnings that were produced by running clang tidy on the codebase, especially regarding the correct naming of identifiers.