### PR TITLE
Fix build against LLVM-10 fat shared lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,9 +134,38 @@ if(NOT ${LLVM_LIBRARY} STREQUAL "LLVM_LIBRARY-NOTFOUND")
 endif()
 
 # Clang
+# The clang-cpp shared library is now the preferred way to link dynamically against libclang.
+find_library(CLANG_LIBRARY NAMES clang-cpp REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+# As fallback, look for the small clang libraries
+if(${CLANG_LIBRARY} STREQUAL "CLANG_LIBRARY-NOTFOUND")
+  find_library(CLANG_LIBRARY NAMES
+    clangFrontend
+    clangAST
+    clangTooling
+    clangFrontendTool
+    clangFrontend
+    clangDriver
+    clangSerialization
+    clangCodeGen
+    clangParse
+    clangSema
+    clangStaticAnalyzerFrontend
+    clangStaticAnalyzerCheckers
+    clangStaticAnalyzerCore
+    clangAnalysis
+    clangARCMigrate
+    clangRewrite
+    clangRewriteFrontend
+    clangEdit
+    clangAST
+    clangASTMatchers
+    clangLex
+    clangBasic
+    LLVMFrontendOpenMP
+  REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+endif()
 if (NOT PHASAR_IN_TREE)
   # Only search for clang if we build out of tree
-  find_library(CLANG_LIBRARY NAMES clang-cpp REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
   link_directories(${CLANG_LIB_PATH})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,20 +127,22 @@ endif()
 add_definitions(${LLVM_DEFINITIONS})
 
 find_library(LLVM_LIBRARY NAMES LLVM REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
-message(${LLVM_LIBRARY})
 if(NOT ${LLVM_LIBRARY} STREQUAL "LLVM_LIBRARY-NOTFOUND")
   message(STATUS "Found consolidated shared LLVM lib " ${LLVM_LIBRARY} " that will be linked against.")
   set(USE_LLVM_FAT_LIB on)
 endif()
 
 # Clang
-# The clang-cpp shared library is now the preferred way to link dynamically against libclang.
-find_library(CLANG_LIBRARY NAMES clang-cpp REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+# The clang-cpp shared library is now the preferred way to link dynamically against libclang if we build out of tree.
+if(NOT PHASAR_IN_TREE)
+  find_library(CLANG_LIBRARY NAMES clang-cpp REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+  if(${CLANG_LIBRARY} STREQUAL "CLANG_LIBRARY-NOTFOUND")
+    set(NEED_LIBCLANG_COMPONENT_LIBS on)
+  endif()
+endif()
 # As fallback, look for the small clang libraries
-if(${CLANG_LIBRARY} STREQUAL "CLANG_LIBRARY-NOTFOUND")
-  find_library(CLANG_LIBRARY NAMES
-    clangFrontend
-    clangAST
+if(PHASAR_IN_TREE OR NEED_LIBCLANG_COMPONENT_LIBS)
+  set(CLANG_LIBRARY
     clangTooling
     clangFrontendTool
     clangFrontend
@@ -161,8 +163,7 @@ if(${CLANG_LIBRARY} STREQUAL "CLANG_LIBRARY-NOTFOUND")
     clangASTMatchers
     clangLex
     clangBasic
-    LLVMFrontendOpenMP
-  REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+    LLVMFrontendOpenMP)
 endif()
 if (NOT PHASAR_IN_TREE)
   # Only search for clang if we build out of tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ else()
   include_directories(${LLVM_MAIN_SRC_DIR}/utils/unittest/googlemock/include)
 endif()
 
-# WALi-OpenNWA
-add_subdirectory(external/WALi-OpenNWA)
-include_directories(external/WALi-OpenNWA/Source/wali/include)
-
 # SQL
 find_path(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
 find_library(SQLITE3_LIBRARY NAMES sqlite3)
@@ -124,17 +120,23 @@ include_directories(${SQLITE3_INCLUDE_DIR})
 if (NOT PHASAR_IN_TREE)
   # Only search for LLVM if we build out of tree
   find_package(LLVM 10 REQUIRED CONFIG)
-  find_library(LLVM_LIBRARY NAMES llvm REQUIRED)
   include_directories(${LLVM_INCLUDE_DIRS})
   link_directories(${LLVM_LIB_PATH} ${LLVM_LIBRARY_DIRS})
 endif()
 
 add_definitions(${LLVM_DEFINITIONS})
 
+find_library(LLVM_LIBRARY NAMES LLVM REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
+message(${LLVM_LIBRARY})
+if(NOT ${LLVM_LIBRARY} STREQUAL "LLVM_LIBRARY-NOTFOUND")
+  message(STATUS "Found consolidated shared LLVM lib " ${LLVM_LIBRARY} " that will be linked against.")
+  set(USE_LLVM_FAT_LIB on)
+endif()
+
 # Clang
 if (NOT PHASAR_IN_TREE)
   # Only search for clang if we build out of tree
-  find_library(CLANG_LIBRARY NAMES clang REQUIRED)
+  find_library(CLANG_LIBRARY NAMES clang-cpp REQUIRED HINTS ${LLVM_LIBRARY_DIRS})
   link_directories(${CLANG_LIB_PATH})
 endif()
 
@@ -147,28 +149,10 @@ if (PHASAR_IN_TREE)
   )
 endif()
 
-set(CLANG_LIBRARIES
- clangTooling
- clangFrontendTool
- clangFrontend
- clangDriver
- clangSerialization
- clangCodeGen
- clangParse
- clangSema
- clangStaticAnalyzerFrontend
- clangStaticAnalyzerCheckers
- clangStaticAnalyzerCore
- clangAnalysis
- clangARCMigrate
- clangRewrite
- clangRewriteFrontend
- clangEdit
- clangAST
- clangASTMatchers
- clangLex
- clangBasic
- )
+# WALi-OpenNWA
+add_subdirectory(external/WALi-OpenNWA)
+include_directories(external/WALi-OpenNWA/Source/wali/include)
+
 
 # Add the Phasar subdirectories
 add_subdirectory(include)

--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -5,6 +5,12 @@ function(add_phasar_unittest test_name)
     ${test_name}
   )
 
+  if(USE_LLVM_FAT_LIB)
+    llvm_config(${test} USE_SHARED ${LLVM_LINK_COMPONENTS})
+  else()
+    llvm_config(${test} ${LLVM_LINK_COMPONENTS})
+  endif()
+
   target_link_libraries(${test}
     LINK_PUBLIC
     phasar_config
@@ -28,8 +34,6 @@ function(add_phasar_unittest test_name)
     ${Boost_LIBRARIES}
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    # ${CLANG_LIBRARIES}
-    ${llvm_libs}
     curl
     gtest
   )
@@ -169,7 +173,11 @@ macro(add_phasar_library name)
   endif(PHASAR_LINK_LIBS)
 
   if( LLVM_LINK_COMPONENTS )
-    llvm_config(${name} ${LLVM_LINK_COMPONENTS})
+    if( USE_LLVM_FAT_LIB )
+      llvm_config(${name} USE_SHARED ${LLVM_LINK_COMPONENTS})
+    else()
+      llvm_config(${name} ${LLVM_LINK_COMPONENTS})
+    endif()
   endif( LLVM_LINK_COMPONENTS )
   if(MSVC)
     get_target_property(cflag ${name} COMPILE_FLAGS)

--- a/lib/PhasarClang/CMakeLists.txt
+++ b/lib/PhasarClang/CMakeLists.txt
@@ -27,28 +27,8 @@ endif()
 find_package(Boost COMPONENTS log REQUIRED)
 target_link_libraries(phasar_clang
   LINK_PUBLIC
-  clangTooling
-  clangFrontendTool
-  clangFrontend
-  clangDriver
-  clangSerialization
-  clangCodeGen
-  clangParse
-  clangSema
-  clangStaticAnalyzerFrontend
-  clangStaticAnalyzerCheckers
-  clangStaticAnalyzerCore
-  clangAnalysis
-  clangARCMigrate
-  clangRewrite
-  clangRewriteFrontend
-  clangEdit
-  clangAST
-  clangASTMatchers
-  clangLex
-  clangBasic
-  LLVMFrontendOpenMP
   ${Boost_LIBRARIES}
+  ${CLANG_LIBRARY}
 )
 
 set_target_properties(phasar_clang

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -39,12 +39,25 @@ target_link_libraries(phasar_plugins
   ${CMAKE_DL_LIBS}
 )
 
+set_target_properties(phasar_plugins
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  PREFIX "lib"
+)
+
+
 # Handle all plugins
 foreach(plugin ${PLUGINS_SO})
   get_filename_component(plugin_name ${plugin} NAME_WE)
   add_library(${plugin_name} SHARED ${plugin})
+  if(USE_LLVM_FAT_LIB)
+    llvm_config(${plugin_name} USE_SHARED ${LLVM_LINK_COMPONENTS})
+  else()
+    llvm_config(${plugin_name} ${LLVM_LINK_COMPONENTS})
+  endif()
   set_target_properties(${plugin_name} PROPERTIES PREFIX "")
   target_link_libraries(${plugin_name}
+    LINK_PRIVATE
     phasar_plugins
     phasar_config
     phasar_utils
@@ -53,8 +66,3 @@ foreach(plugin ${PLUGINS_SO})
     )
 endforeach()
 
-set_target_properties(phasar_plugins
-  PROPERTIES
-  LINKER_LANGUAGE CXX
-  PREFIX "lib"
-)

--- a/lib/PhasarLLVM/Plugins/CMakeLists.txt
+++ b/lib/PhasarLLVM/Plugins/CMakeLists.txt
@@ -28,6 +28,11 @@ endif()
 
 
 find_package(Boost COMPONENTS log filesystem program_options REQUIRED)
+if(USE_LLVM_FAT_LIB)
+  llvm_config(phasar_plugins USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(phasar_plugins ${LLVM_LINK_COMPONENTS})
+endif()
 target_link_libraries(phasar_plugins
   LINK_PUBLIC
   ${Boost_LIBRARIES}
@@ -45,8 +50,6 @@ foreach(plugin ${PLUGINS_SO})
     phasar_utils
     phasar_ifdside
     phasar_mono
-    LLVMCore
-    LLVMSupport
     )
 endforeach()
 

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -28,10 +28,6 @@ else()
   )
 endif()
 
-llvm_map_components_to_libnames(llvm_libs
-  ${LLVM_LINK_COMPONENTS}
-)
-
 target_include_directories(phasar_utils PUBLIC ${LLVM_INCLUDE_DIRS})
 target_compile_definitions(phasar_utils PUBLIC -DBOOST_LOG_DYN_LINK)
 
@@ -40,7 +36,6 @@ target_link_libraries(phasar_utils
   LINK_PUBLIC
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
-  ${llvm_libs}
 )
 
 set_target_properties(phasar_utils

--- a/tools/boomerang/CMakeLists.txt
+++ b/tools/boomerang/CMakeLists.txt
@@ -30,14 +30,12 @@ target_link_libraries(boomerang
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
-  ${llvm_libs}
 )
 
-if(NOT PHASAR_IN_TREE)
-target_link_libraries(boomerang
-  LINK_PUBLIC
-  ${llvm_libs}
-)
+if(USE_LLVM_FAT_LIB)
+  llvm_config(boomerang USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(boomerang ${LLVM_LINK_COMPONENTS})
 endif()
 
 set(LLVM_LINK_COMPONENTS

--- a/tools/example-tool/CMakeLists.txt
+++ b/tools/example-tool/CMakeLists.txt
@@ -30,14 +30,12 @@ target_link_libraries(myphasartool
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
-  ${llvm_libs}
 )
 
-if(NOT PHASAR_IN_TREE)
-target_link_libraries(myphasartool
-  LINK_PUBLIC
-  ${llvm_libs}
-)
+if(USE_LLVM_FAT_LIB)
+  llvm_config(myphasartool USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(myphasartool ${LLVM_LINK_COMPONENTS})
 endif()
 
 set(LLVM_LINK_COMPONENTS

--- a/tools/phasar-clang/CMakeLists.txt
+++ b/tools/phasar-clang/CMakeLists.txt
@@ -10,6 +10,11 @@ else()
 endif()
 
 find_package(Boost COMPONENTS log filesystem program_options graph ${BOOST_THREAD} REQUIRED)
+if(USE_LLVM_FAT_LIB)
+  llvm_config(phasar-clang USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(phasar-clang ${LLVM_LINK_COMPONENTS})
+endif()
 target_link_libraries(phasar-clang
   LINK_PUBLIC
   phasar_config
@@ -33,15 +38,8 @@ target_link_libraries(phasar-clang
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
-  # ${CLANG_LIBRARIES}
+  # ${CLANG_LIBRARY}
 )
-
-if(NOT PHASAR_IN_TREE)
-target_link_libraries(phasar-clang
-  LINK_PUBLIC
-  ${llvm_libs}
-)
-endif()
 
 set(LLVM_LINK_COMPONENTS
 )

--- a/tools/phasar-llvm/CMakeLists.txt
+++ b/tools/phasar-llvm/CMakeLists.txt
@@ -36,11 +36,10 @@ target_link_libraries(phasar-llvm
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-if(NOT PHASAR_IN_TREE)
-target_link_libraries(phasar-llvm
-  LINK_PUBLIC
-  ${llvm_libs}
-)
+if(USE_LLVM_FAT_LIB)
+  llvm_config(phasar-llvm USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(phasar-llvm ${LLVM_LINK_COMPONENTS})
 endif()
 
 set(LLVM_LINK_COMPONENTS


### PR DESCRIPTION
Since LLVM 10 it is not recommended to build multiple small shared libraries. Instead, users are supposed to use the combined libraries of LLVM and Clang. This commit implements a check for the presence of that library and links against it on success, otherwise the multiple shared libraries are resolved properly, which was slightly broken before as well. Also, the clang-cpp library is properly resolved and linked against. In summary, phasar builds again for me both with the llvm/clang bootstrapped from bootstrap.sh and the Gentoo system installation of llvm:10/clang:10. Testing on Mac OS would be appreciated.