### PR TITLE
ESG as dot graph

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowEdgeFunctionCache.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowEdgeFunctionCache.h
@@ -64,7 +64,7 @@ public:
   // edge function factory functions.
   FlowEdgeFunctionCache(IDETabulationProblem<N, D, F, T, V, L, I> &problem)
       : problem(problem),
-        autoAddZero(problem.getIFDSIDESolverConfig().autoAddZero),
+        autoAddZero(problem.getIFDSIDESolverConfig().autoAddZero()),
         zeroValue(problem.getZeroValue()) {
     PAMM_GET_INSTANCE;
     REG_COUNTER("Normal-FF Construction", 0, PAMM_SEVERITY_LEVEL::Full);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
@@ -66,7 +66,9 @@ struct IFDSIDESolverConfig {
                                   const IFDSIDESolverConfig &sc);
 
 private:
-  SolverConfigOptions options;
+  SolverConfigOptions options = SolverConfigOptions::AutoAddZero |
+                                SolverConfigOptions::ComputeValues |
+                                SolverConfigOptions::RecordEdges;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
@@ -20,11 +20,14 @@
 #include <iosfwd>
 
 #include "phasar/Config/Configuration.h"
+#include "phasar/Utils/Logger.h"
+#include "phasar/Utils/Utilities.h"
 
 namespace psr {
 
 struct IFDSIDESolverConfig {
   IFDSIDESolverConfig() = default;
+
   IFDSIDESolverConfig(bool followReturnsPastSeeds, bool autoAddZero,
                       bool computeValues, bool recordEdges, bool emitESG,
                       bool computePersistedSummaries);
@@ -37,10 +40,7 @@ struct IFDSIDESolverConfig {
   bool autoAddZero = true;
   bool computeValues = true;
   bool recordEdges = true;
-  bool emitESG =
-      (PhasarConfig::VariablesMap().count("emit-esg-as-dot"))
-          ? PhasarConfig::VariablesMap()["emit-esg-as-dot"].as<bool>()
-          : false;
+  bool emitESG = PhasarConfig::VariablesMap().count("emit-esg-as-dot");
   bool computePersistedSummaries = false;
   friend std::ostream &operator<<(std::ostream &os,
                                   const IFDSIDESolverConfig &sc);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.h
@@ -20,30 +20,53 @@
 #include <iosfwd>
 
 #include "phasar/Config/Configuration.h"
+#include "phasar/Utils/EnumFlags.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/Utilities.h"
 
 namespace psr {
 
-struct IFDSIDESolverConfig {
-  IFDSIDESolverConfig() = default;
+enum class SolverConfigOptions : uint32_t {
+  None = 0,
+  FollowReturnsPastSeeds = 1,
+  AutoAddZero = 2,
+  ComputeValues = 4,
+  RecordEdges = 8,
+  EmitESG = 16,
+  ComputePersistedSummaries = 32,
 
-  IFDSIDESolverConfig(bool followReturnsPastSeeds, bool autoAddZero,
-                      bool computeValues, bool recordEdges, bool emitESG,
-                      bool computePersistedSummaries);
+  All = ~0u
+};
+
+struct IFDSIDESolverConfig {
+  IFDSIDESolverConfig();
+
+  IFDSIDESolverConfig(SolverConfigOptions options);
   ~IFDSIDESolverConfig() = default;
   IFDSIDESolverConfig(const IFDSIDESolverConfig &) = default;
   IFDSIDESolverConfig &operator=(const IFDSIDESolverConfig &) = default;
   IFDSIDESolverConfig(IFDSIDESolverConfig &&) = default;
   IFDSIDESolverConfig &operator=(IFDSIDESolverConfig &&) = default;
-  bool followReturnsPastSeeds = false;
-  bool autoAddZero = true;
-  bool computeValues = true;
-  bool recordEdges = true;
-  bool emitESG = PhasarConfig::VariablesMap().count("emit-esg-as-dot");
-  bool computePersistedSummaries = false;
+
+  bool followReturnsPastSeeds() const;
+  bool autoAddZero() const;
+  bool computeValues() const;
+  bool recordEdges() const;
+  bool emitESG() const;
+  bool computePersistedSummaries() const;
+
+  void setFollowReturnsPastSeeds(bool set = true);
+  void setAutoAddZero(bool set = true);
+  void setComputeValues(bool set = true);
+  void setRecordEdges(bool set = true);
+  void setEmitESG(bool set = true);
+  void setComputePersistedSummaries(bool set = true);
+
   friend std::ostream &operator<<(std::ostream &os,
                                   const IFDSIDESolverConfig &sc);
+
+private:
+  SolverConfigOptions options;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -315,7 +315,7 @@ protected:
   IDETabulationProblem<N, D, F, T, V, L, I> &IDEProblem;
   D ZeroValue;
   const I *ICF;
-  const IFDSIDESolverConfig SolverConfig;
+  IFDSIDESolverConfig SolverConfig;
   unsigned PathEdgeCount = 0;
 
   FlowEdgeFunctionCache<N, D, F, T, V, L, I> cachedFlowEdgeFunctions;
@@ -1826,11 +1826,10 @@ public:
 };
 
 template <typename Problem>
-IDESolver(Problem &)
-    ->IDESolver<typename Problem::n_t, typename Problem::d_t,
-                typename Problem::f_t, typename Problem::t_t,
-                typename Problem::v_t, typename Problem::l_t,
-                typename Problem::i_t>;
+IDESolver(Problem &) -> IDESolver<typename Problem::n_t, typename Problem::d_t,
+                                  typename Problem::f_t, typename Problem::t_t,
+                                  typename Problem::v_t, typename Problem::l_t,
+                                  typename Problem::i_t>;
 
 template <typename Problem>
 using IDESolver_P = IDESolver<typename Problem::n_t, typename Problem::d_t,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -1585,6 +1585,7 @@ protected:
   }
 
 public:
+  void enableESAasDot() { SolverConfig.emitESG = true; }
   void emitESGasDot() {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Emit Exploded super-graph (ESG) as DOT graph";
@@ -1794,7 +1795,9 @@ public:
             auto EFVec = intermediateEdgeFunctions[std::make_tuple(
                 Edge.first, D1Fact, Edge.second, D2Fact)];
             for (auto EF : EFVec) {
-              EFLabel += EF->str() + ", ";
+              LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
+                            << "Partial EF Label: " << EF->str());
+              EFLabel.append(EF->str() + ", ");
             }
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "EF LABEL: " << EFLabel);
@@ -1823,10 +1826,11 @@ public:
 };
 
 template <typename Problem>
-IDESolver(Problem &) -> IDESolver<typename Problem::n_t, typename Problem::d_t,
-                                  typename Problem::f_t, typename Problem::t_t,
-                                  typename Problem::v_t, typename Problem::l_t,
-                                  typename Problem::i_t>;
+IDESolver(Problem &)
+    ->IDESolver<typename Problem::n_t, typename Problem::d_t,
+                typename Problem::f_t, typename Problem::t_t,
+                typename Problem::v_t, typename Problem::l_t,
+                typename Problem::i_t>;
 
 template <typename Problem>
 using IDESolver_P = IDESolver<typename Problem::n_t, typename Problem::d_t,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -155,7 +155,7 @@ public:
     // We start our analysis and construct exploded supergraph
     submitInitialSeeds();
     STOP_TIMER("DFA Phase I", PAMM_SEVERITY_LEVEL::Full);
-    if (SolverConfig.computeValues) {
+    if (SolverConfig.computeValues()) {
       START_TIMER("DFA Phase II", PAMM_SEVERITY_LEVEL::Full);
       // Computing the final values for the edge functions
       LOG_IF_ENABLE(
@@ -168,7 +168,7 @@ public:
     if constexpr (PAMM_CURR_SEV_LEVEL >= PAMM_SEVERITY_LEVEL::Core) {
       computeAndPrintStatistics();
     }
-    if (SolverConfig.emitESG) {
+    if (SolverConfig.emitESG()) {
       emitESGasDot();
     }
   }
@@ -525,7 +525,7 @@ protected:
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                                 << "Queried Return Edge Function: "
                                 << f5->str());
-                  if (SolverConfig.emitESG) {
+                  if (SolverConfig.emitESG()) {
                     for (auto sP : ICF->getStartPointsOf(sCalledProcN)) {
                       intermediateEdgeFunctions[std::make_tuple(n, d2, sP, d3)]
                           .push_back(f4);
@@ -580,7 +580,7 @@ protected:
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                         << "Queried Call-to-Return Edge Function: "
                         << edgeFnE->str());
-          if (SolverConfig.emitESG) {
+          if (SolverConfig.emitESG()) {
             intermediateEdgeFunctions[std::make_tuple(n, d2, returnSiteN, d3)]
                 .push_back(edgeFnE);
           }
@@ -625,7 +625,7 @@ protected:
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Queried Normal Edge Function: " << g->str());
         std::shared_ptr<EdgeFunction<L>> fprime = f->composeWith(g);
-        if (SolverConfig.emitESG) {
+        if (SolverConfig.emitESG()) {
           intermediateEdgeFunctions[std::make_tuple(n, d2, fn, d3)].push_back(
               fprime);
         }
@@ -671,7 +671,7 @@ protected:
             cachedFlowEdgeFunctions.getCallEdgeFunction(n, d, q, dPrime);
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Queried Call Edge Function: " << edgeFn->str());
-        if (SolverConfig.emitESG) {
+        if (SolverConfig.emitESG()) {
           for (const auto sP : ICF->getStartPointsOf(q)) {
             intermediateEdgeFunctions[std::make_tuple(n, d, sP, dPrime)]
                 .push_back(edgeFn);
@@ -833,7 +833,7 @@ protected:
 
   virtual void saveEdges(N sourceNode, N sinkStmt, D sourceVal,
                          const std::set<D> &destVals, bool interP) {
-    if (!SolverConfig.recordEdges)
+    if (!SolverConfig.recordEdges())
       return;
     Table<N, N, std::map<D, std::set<D>>> &tgtMap =
         (interP) ? computedInterPathEdges : computedIntraPathEdges;
@@ -964,7 +964,7 @@ protected:
                     c, ICF->getFunctionOf(n), n, d2, retSiteC, d5);
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "Queried Return Edge Function: " << f5->str());
-            if (SolverConfig.emitESG) {
+            if (SolverConfig.emitESG()) {
               for (auto sP : ICF->getStartPointsOf(ICF->getFunctionOf(n))) {
                 intermediateEdgeFunctions[std::make_tuple(c, d4, sP, d1)]
                     .push_back(f4);
@@ -1012,7 +1012,7 @@ protected:
     // conditionally generated values should only
     // be propagated into callers that have an incoming edge for this
     // condition
-    if (SolverConfig.followReturnsPastSeeds && inc.empty() &&
+    if (SolverConfig.followReturnsPastSeeds() && inc.empty() &&
         IDEProblem.isZeroValue(d1)) {
       const std::set<N> callers = ICF->getCallersOf(functionThatNeedsSummary);
       for (N c : callers) {
@@ -1032,7 +1032,7 @@ protected:
                     c, ICF->getFunctionOf(n), n, d2, retSiteC, d5);
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "Queried Return Edge Function: " << f5->str());
-            if (SolverConfig.emitESG) {
+            if (SolverConfig.emitESG()) {
               intermediateEdgeFunctions[std::make_tuple(n, d2, retSiteC, d5)]
                   .push_back(f5);
             }
@@ -1585,7 +1585,7 @@ protected:
   }
 
 public:
-  void enableESAasDot() { SolverConfig.emitESG = true; }
+  void enableESAasDot() { SolverConfig.setEmitESG(); }
   void emitESGasDot() {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Emit Exploded super-graph (ESG) as DOT graph";

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -627,7 +627,7 @@ protected:
         std::shared_ptr<EdgeFunction<L>> fprime = f->composeWith(g);
         if (SolverConfig.emitESG()) {
           intermediateEdgeFunctions[std::make_tuple(n, d2, fn, d3)].push_back(
-              fprime);
+              g);
         }
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "Compose: " << g->str() << " * " << f->str()

--- a/include/phasar/Utils/EnumFlags.h
+++ b/include/phasar/Utils/EnumFlags.h
@@ -75,6 +75,20 @@ constexpr T operator~(T t) {
   return static_cast<T>(~static_cast<typename std::underlying_type_t<T>>(t));
 }
 
+template <typename T,
+          typename = typename std::enable_if_t<std::is_enum<T>::value, T>>
+constexpr void setFlag(T &_this, T flag, bool set = true) {
+  if (set) {
+    _this |= flag;
+  } else {
+    _this &= ~flag;
+  }
+}
+template <typename T,
+          typename = typename std::enable_if_t<std::is_enum<T>::value, T>>
+constexpr bool hasFlag(T _this, T flag) {
+  return static_cast<bool>(_this & flag);
+}
 } // namespace psr
 
 #endif

--- a/include/phasar/Utils/Logger.h
+++ b/include/phasar/Utils/Logger.h
@@ -27,6 +27,7 @@
 #include "boost/log/support/date_time.hpp"
 // Not useful here but enable all logging macros in files that include Logger.h
 #include "boost/log/sources/record_ostream.hpp"
+#include <llvm/Support/Compiler.h> // LLVM_UNLIKELY
 
 #include "llvm/Support/ErrorHandling.h"
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSIDESolverConfig.cpp
@@ -15,22 +15,62 @@ using namespace std;
 using namespace psr;
 
 namespace psr {
+IFDSIDESolverConfig::IFDSIDESolverConfig() {
+  setFlag(
+      options, SolverConfigOptions::EmitESG,
+      PhasarConfig::getPhasarConfig().VariablesMap().count("emit-esg-as-dot"));
+}
+IFDSIDESolverConfig::IFDSIDESolverConfig(SolverConfigOptions options)
+    : options(options) {}
 
-IFDSIDESolverConfig::IFDSIDESolverConfig(bool FollowReturnsPastSeeds,
-                                         bool AutoAddZero, bool ComputeValues,
-                                         bool RecordEdges, bool EmitESG,
-                                         bool ComputePersistedSummaries)
-    : followReturnsPastSeeds(FollowReturnsPastSeeds), autoAddZero(AutoAddZero),
-      computeValues(ComputeValues), recordEdges(RecordEdges), emitESG(EmitESG),
-      computePersistedSummaries(ComputePersistedSummaries) {}
+bool IFDSIDESolverConfig::followReturnsPastSeeds() const {
+  return hasFlag(options, SolverConfigOptions::FollowReturnsPastSeeds);
+}
+bool IFDSIDESolverConfig::autoAddZero() const {
+  return hasFlag(options, SolverConfigOptions::AutoAddZero);
+}
+bool IFDSIDESolverConfig::computeValues() const {
+  return hasFlag(options, SolverConfigOptions::ComputeValues);
+}
+bool IFDSIDESolverConfig::recordEdges() const {
+  return hasFlag(options, SolverConfigOptions::RecordEdges);
+}
+bool IFDSIDESolverConfig::emitESG() const {
+  return hasFlag(options, SolverConfigOptions::EmitESG);
+}
+bool IFDSIDESolverConfig::computePersistedSummaries() const {
+  return hasFlag(options, SolverConfigOptions::ComputePersistedSummaries);
+}
+
+void IFDSIDESolverConfig::setFollowReturnsPastSeeds(bool set) {
+  setFlag(options, SolverConfigOptions::FollowReturnsPastSeeds, set);
+}
+void IFDSIDESolverConfig::setAutoAddZero(bool set) {
+  setFlag(options, SolverConfigOptions::AutoAddZero, set);
+}
+void IFDSIDESolverConfig::setComputeValues(bool set) {
+  setFlag(options, SolverConfigOptions::ComputeValues, set);
+}
+void IFDSIDESolverConfig::setRecordEdges(bool set) {
+  setFlag(options, SolverConfigOptions::RecordEdges, set);
+}
+void IFDSIDESolverConfig::setEmitESG(bool set) {
+  setFlag(options, SolverConfigOptions::EmitESG, set);
+}
+void IFDSIDESolverConfig::setComputePersistedSummaries(bool set) {
+  setFlag(options, SolverConfigOptions::ComputePersistedSummaries, set);
+}
 
 ostream &operator<<(ostream &OS, const IFDSIDESolverConfig &SC) {
   return OS << "IFDSIDESolverConfig:\n"
-            << "\tfollowReturnsPastSeeds: " << SC.followReturnsPastSeeds << "\n"
-            << "\tautoAddZero: " << SC.autoAddZero << "\n"
-            << "\tcomputeValues: " << SC.computeValues << "\n"
-            << "\trecordEdges: " << SC.recordEdges << "\n"
-            << "\tcomputePersistedSummaries: " << SC.computePersistedSummaries;
+            << "\tfollowReturnsPastSeeds: " << SC.followReturnsPastSeeds()
+            << "\n"
+            << "\tautoAddZero: " << SC.autoAddZero() << "\n"
+            << "\tcomputeValues: " << SC.computeValues() << "\n"
+            << "\trecordEdges: " << SC.recordEdges() << "\n"
+            << "\tcomputePersistedSummaries: " << SC.computePersistedSummaries()
+            << "\n"
+            << "\temitESG: " << SC.emitESG();
 }
 
 } // namespace psr

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/CMakeLists.txt
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/CMakeLists.txt
@@ -4,6 +4,7 @@ if(PHASAR_BUILD_OPENSSL_TS_UNITTESTS)
 	IFDSTaintAnalysisTest.cpp
 	IDEInstInteractionAnalysisTest.cpp
 	IDELinearConstantAnalysisTest.cpp
+	IDELinearConstantAnalysis_DotTest.cpp
 	IDETSAnalysisFileIOTest.cpp
 	IDETSAnalysisOpenSSLEVPKDFTest.cpp
 	IDETSAnalysisOpenSSLSecureHeapTest.cpp
@@ -16,6 +17,7 @@ else()
 	IFDSTaintAnalysisTest.cpp
 	IDEInstInteractionAnalysisTest.cpp
 	IDELinearConstantAnalysisTest.cpp
+	IDELinearConstantAnalysis_DotTest.cpp
 	IFDSUninitializedVariablesTest.cpp
   )
 endif(PHASAR_BUILD_OPENSSL_TS_UNITTESTS)

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
@@ -1,0 +1,638 @@
+#include "phasar/DB/ProjectIRDB.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h"
+#include "phasar/PhasarLLVM/Passes/ValueAnnotationPass.h"
+#include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
+#include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
+#include "gtest/gtest.h"
+
+#include <tuple>
+
+using namespace psr;
+
+/* ============== TEST FIXTURE ============== */
+class IDELinearConstantAnalysisTest : public ::testing::Test {
+protected:
+  const std::string PathToLlFiles =
+      PhasarConfig::getPhasarConfig().PhasarDirectory() +
+      "build/test/llvm_test_code/linear_constant/";
+  const std::set<std::string> EntryPoints = {"main"};
+
+  // Function - Line Nr - Variable - Value
+  using LCACompactResult_t =
+      std::tuple<std::string, std::size_t, std::string, int64_t>;
+  ProjectIRDB *IRDB = nullptr;
+
+  void SetUp() override { boost::log::core::get()->set_logging_enabled(false); }
+
+  IDELinearConstantAnalysis::lca_results_t
+  doAnalysis(const std::string &LlvmFilePath, bool PrintDump = false,
+             bool emitESG = false) {
+    IRDB = new ProjectIRDB({PathToLlFiles + LlvmFilePath}, IRDBOptions::WPA);
+    ValueAnnotationPass::resetValueID();
+    LLVMTypeHierarchy TH(*IRDB);
+    LLVMPointsToInfo PT(*IRDB);
+    LLVMBasedICFG ICFG(*IRDB, CallGraphAnalysisType::OTF, EntryPoints, &TH,
+                       &PT);
+    IDELinearConstantAnalysis LCAProblem(IRDB, &TH, &ICFG, &PT, EntryPoints);
+    IDESolver<IDELinearConstantAnalysis::n_t, IDELinearConstantAnalysis::d_t,
+              IDELinearConstantAnalysis::f_t, IDELinearConstantAnalysis::t_t,
+              IDELinearConstantAnalysis::v_t, IDELinearConstantAnalysis::l_t,
+              IDELinearConstantAnalysis::i_t>
+        LCASolver(LCAProblem);
+    LCASolver.solve();
+    if (emitESG) {
+      boost::log::core::get()->set_logging_enabled(true);
+      LCASolver.emitESGasDot();
+      boost::log::core::get()->set_logging_enabled(false);
+    }
+    if (PrintDump) {
+      LCASolver.dumpResults();
+    }
+    return LCAProblem.getLCAResults(LCASolver.getSolverResults());
+  }
+
+  void TearDown() override { delete IRDB; }
+
+  /**
+   * We map instruction id to value for the ground truth. ID has to be
+   * a string since Argument ID's are not integer type (e.g. main.0 for argc).
+   * @param groundTruth results to compare against
+   * @param solver provides the results
+   */
+  static void compareResults(IDELinearConstantAnalysis::lca_results_t &Results,
+                             std::set<LCACompactResult_t> &GroundTruth) {
+    std::set<LCACompactResult_t> RelevantResults;
+    for (auto G : GroundTruth) {
+      std::string FName = std::get<0>(G);
+      unsigned Line = std::get<1>(G);
+      if (Results.find(FName) != Results.end()) {
+        if (auto It = Results[FName].find(Line); It != Results[FName].end()) {
+          for (const auto &VarToVal : It->second.variableToValue) {
+            RelevantResults.emplace(FName, Line, VarToVal.first,
+                                    VarToVal.second);
+          }
+        }
+      }
+    }
+    EXPECT_EQ(RelevantResults, GroundTruth);
+  }
+}; // Test Fixture
+
+/* ============== BASIC TESTS ============== */
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_01) {
+  auto Results = doAnalysis("basic_01_cpp_dbg.ll", false, true);
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 13);
+  GroundTruth.emplace("main", 3, "i", 13);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_02) {
+  auto Results = doAnalysis("basic_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 13);
+  GroundTruth.emplace("main", 3, "i", 17);
+  GroundTruth.emplace("main", 4, "i", 17);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_03) {
+  auto Results = doAnalysis("basic_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 10);
+  GroundTruth.emplace("main", 3, "i", 10);
+  GroundTruth.emplace("main", 3, "j", 14);
+  GroundTruth.emplace("main", 4, "i", 14);
+  GroundTruth.emplace("main", 4, "j", 14);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_04) {
+  auto Results = doAnalysis("basic_04_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "i", 14);
+  GroundTruth.emplace("main", 4, "i", 14);
+  GroundTruth.emplace("main", 4, "j", 20);
+  GroundTruth.emplace("main", 5, "i", 14);
+  GroundTruth.emplace("main", 5, "j", 20);
+  GroundTruth.emplace("main", 6, "i", 14);
+  GroundTruth.emplace("main", 6, "j", 20);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_05) {
+  auto Results = doAnalysis("basic_05_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 3);
+  GroundTruth.emplace("main", 3, "i", 3);
+  GroundTruth.emplace("main", 3, "j", 14);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_06) {
+  auto Results = doAnalysis("basic_06_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 4);
+  GroundTruth.emplace("main", 3, "i", 16);
+  GroundTruth.emplace("main", 4, "i", 16);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_07) {
+  auto Results = doAnalysis("basic_07_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 4);
+  GroundTruth.emplace("main", 3, "i", 4);
+  GroundTruth.emplace("main", 3, "j", 3);
+  GroundTruth.emplace("main", 4, "j", 3);
+  GroundTruth.emplace("main", 5, "j", 3);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_08) {
+  auto Results = doAnalysis("basic_08_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 3, "i", 42);
+  GroundTruth.emplace("main", 3, "j", 40);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", 40);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_09) {
+  auto Results = doAnalysis("basic_09_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 3, "i", 42);
+  GroundTruth.emplace("main", 3, "j", 126);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", 126);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_10) {
+  auto Results = doAnalysis("basic_10_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 3, "i", 42);
+  GroundTruth.emplace("main", 3, "j", 14);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", 14);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBasicTest_11) {
+  auto Results = doAnalysis("basic_11_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 3, "i", 42);
+  GroundTruth.emplace("main", 3, "j", 2);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", 2);
+  compareResults(Results, GroundTruth);
+}
+
+/* ============== BRANCH TESTS ============== */
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_01) {
+  auto Results = doAnalysis("branch_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "i", 10);
+  GroundTruth.emplace("main", 5, "i", 2);
+  compareResults(Results, GroundTruth);
+  // Results available for line 5 but not for line 7
+  EXPECT_FALSE(Results["main"].find(5) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(7) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_02) {
+  auto Results = doAnalysis("branch_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 6, "i", 10);
+  compareResults(Results, GroundTruth);
+  // Results available for line 6 but not for line 8
+  EXPECT_FALSE(Results["main"].find(6) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(8) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_03) {
+  auto Results = doAnalysis("branch_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "i", 42);
+  GroundTruth.emplace("main", 5, "i", 10);
+  GroundTruth.emplace("main", 7, "i", 30);
+  GroundTruth.emplace("main", 8, "i", 30);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_04) {
+  auto Results = doAnalysis("branch_04_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "j", 10);
+  GroundTruth.emplace("main", 4, "j", 10);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 6, "j", 10);
+  GroundTruth.emplace("main", 6, "i", 20);
+  GroundTruth.emplace("main", 8, "j", 10);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_05) {
+  auto Results = doAnalysis("branch_05_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "j", 10);
+  GroundTruth.emplace("main", 4, "j", 10);
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 6, "j", 10);
+  GroundTruth.emplace("main", 6, "i", 42);
+  GroundTruth.emplace("main", 8, "j", 10);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_06) {
+  auto Results = doAnalysis("branch_06_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "i", 10);
+  GroundTruth.emplace("main", 5, "i", 10);
+  GroundTruth.emplace("main", 7, "i", 10);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleBranchTest_07) {
+  auto Results = doAnalysis("branch_07_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 3, "j", 10);
+  GroundTruth.emplace("main", 4, "j", 10);
+  GroundTruth.emplace("main", 4, "i", 30);
+  GroundTruth.emplace("main", 6, "j", 10);
+  GroundTruth.emplace("main", 6, "i", 30);
+  GroundTruth.emplace("main", 8, "j", 10);
+  compareResults(Results, GroundTruth);
+}
+
+/* ============== LOOP TESTS ============== */
+TEST_F(IDELinearConstantAnalysisTest, HandleLoopTest_01) {
+  auto Results = doAnalysis("while_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(4) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(6) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleLoopTest_02) {
+  auto Results = doAnalysis("while_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(2) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(4) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(6) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleLoopTest_03) {
+  auto Results = doAnalysis("while_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 7, "a", 13);
+  GroundTruth.emplace("main", 8, "a", 13);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(4) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(6) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleLoopTest_04) {
+  auto Results = doAnalysis("while_04_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "i", 42);
+  GroundTruth.emplace("main", 4, "a", 0);
+  GroundTruth.emplace("main", 5, "a", 0);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(7) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleLoopTest_05) {
+  auto Results = doAnalysis("for_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 2, "a", 0);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(4) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(6) == Results["main"].end());
+}
+
+/* ============== CALL TESTS ============== */
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_01) {
+  auto Results = doAnalysis("call_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooi", 1, "a", 42);
+  GroundTruth.emplace("_Z3fooi", 2, "a", 42);
+  GroundTruth.emplace("_Z3fooi", 2, "b", 42);
+
+  GroundTruth.emplace("main", 6, "i", 42);
+  GroundTruth.emplace("main", 7, "i", 42);
+  GroundTruth.emplace("main", 8, "i", 42);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["_Z3fooi"].find(3) == Results["_Z3fooi"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_02) {
+  auto Results = doAnalysis("call_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooi", 1, "a", 2);
+  GroundTruth.emplace("_Z3fooi", 2, "a", 2);
+
+  GroundTruth.emplace("main", 7, "i", 42);
+  GroundTruth.emplace("main", 8, "i", 42);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(6) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_03) {
+  auto Results = doAnalysis("call_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 6, "i", 42);
+  GroundTruth.emplace("main", 7, "i", 42);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_04) {
+  auto Results = doAnalysis("call_04_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 6, "i", 10);
+  GroundTruth.emplace("main", 7, "i", 10);
+  GroundTruth.emplace("main", 8, "i", 10);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_05) {
+  auto Results = doAnalysis("call_05_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  EXPECT_TRUE(Results["main"].empty());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_06) {
+  auto Results = doAnalysis("call_06_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z9incrementi", 1, "a", 42);
+  GroundTruth.emplace("_Z9incrementi", 2, "a", 43);
+
+  GroundTruth.emplace("main", 6, "i", 42);
+  GroundTruth.emplace("main", 7, "i", 43);
+  GroundTruth.emplace("main", 8, "i", 43);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_07) {
+  auto Results = doAnalysis("call_07_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 6, "i", 42);
+  GroundTruth.emplace("main", 7, "i", 42);
+  GroundTruth.emplace("main", 7, "j", 43);
+  GroundTruth.emplace("main", 8, "i", 42);
+  GroundTruth.emplace("main", 8, "j", 43);
+  GroundTruth.emplace("main", 8, "k", 44);
+  GroundTruth.emplace("main", 9, "i", 42);
+  GroundTruth.emplace("main", 9, "j", 43);
+  GroundTruth.emplace("main", 9, "k", 44);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["_Z9incrementi"].find(1) ==
+              Results["_Z9incrementi"].end());
+  EXPECT_TRUE(Results["_Z9incrementi"].find(2) ==
+              Results["_Z9incrementi"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_08) {
+  auto Results = doAnalysis("call_08_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooii", 1, "a", 10);
+  GroundTruth.emplace("_Z3fooii", 1, "b", 1);
+  GroundTruth.emplace("_Z3fooii", 2, "a", 10);
+  GroundTruth.emplace("_Z3fooii", 2, "b", 1);
+
+  GroundTruth.emplace("main", 6, "i", 10);
+  GroundTruth.emplace("main", 7, "i", 10);
+  GroundTruth.emplace("main", 7, "j", 1);
+  GroundTruth.emplace("main", 8, "i", 10);
+  GroundTruth.emplace("main", 8, "j", 1);
+  GroundTruth.emplace("main", 9, "i", 10);
+  GroundTruth.emplace("main", 9, "j", 1);
+  GroundTruth.emplace("main", 10, "i", 10);
+  GroundTruth.emplace("main", 10, "j", 1);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_09) {
+  auto Results = doAnalysis("call_09_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z9incrementi", 1, "a", 42);
+  GroundTruth.emplace("_Z9incrementi", 2, "a", 43);
+
+  GroundTruth.emplace("main", 6, "i", 43);
+  GroundTruth.emplace("main", 7, "i", 43);
+  GroundTruth.emplace("main", 7, "j", 43);
+  GroundTruth.emplace("main", 8, "i", 43);
+  GroundTruth.emplace("main", 8, "j", 43);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_10) {
+  auto Results = doAnalysis("call_10_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3bari", 1, "b", 2);
+  GroundTruth.emplace("_Z3fooi", 3, "a", 2);
+  GroundTruth.emplace("_Z3fooi", 4, "a", 2);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["main"].find(8) == Results["main"].end());
+  EXPECT_TRUE(Results["main"].find(9) == Results["main"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleCallTest_11) {
+  auto Results = doAnalysis("call_11_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3bari", 1, "b", 2);
+  GroundTruth.emplace("_Z3bari", 2, "b", 2);
+
+  GroundTruth.emplace("_Z3fooi", 5, "a", 2);
+  GroundTruth.emplace("_Z3fooi", 6, "a", 2);
+
+  GroundTruth.emplace("main", 11, "i", 2);
+  GroundTruth.emplace("main", 12, "i", 2);
+  compareResults(Results, GroundTruth);
+}
+
+/* ============== RECURSION TESTS ============== */
+
+TEST_F(IDELinearConstantAnalysisTest, HandleRecursionTest_01) {
+  auto Results = doAnalysis("recursion_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 10, "j", -1);
+  GroundTruth.emplace("main", 11, "j", -1);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["_Z9decrementi"].find(2) ==
+              Results["_Z9decrementi"].end());
+  EXPECT_TRUE(Results["_Z9decrementi"].find(4) ==
+              Results["_Z9decrementi"].end());
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleRecursionTest_02) {
+  auto Results = doAnalysis("recursion_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleRecursionTest_03) {
+  auto Results = doAnalysis("recursion_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 9, "a", 1);
+  GroundTruth.emplace("main", 10, "a", 1);
+  compareResults(Results, GroundTruth);
+  EXPECT_TRUE(Results["_Z3fooj"].find(1) == Results["_Z3fooj"].end());
+  EXPECT_TRUE(Results["_Z3fooj"].find(3) == Results["_Z3fooj"].end());
+  EXPECT_TRUE(Results["_Z3fooj"].find(5) == Results["_Z3fooj"].end());
+}
+
+/* ============== GLOBAL VARIABLE TESTS ============== */
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_01) {
+  auto Results = doAnalysis("global_01_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 6, "g1", 42);
+  GroundTruth.emplace("main", 6, "g2", 1);
+  GroundTruth.emplace("main", 7, "g1", 42);
+  GroundTruth.emplace("main", 7, "g2", 42);
+  GroundTruth.emplace("main", 8, "g1", 42);
+  GroundTruth.emplace("main", 8, "g2", 42);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_02) {
+  auto Results = doAnalysis("global_02_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("main", 4, "g", 10);
+  GroundTruth.emplace("main", 4, "i", 10);
+  GroundTruth.emplace("main", 5, "g", 10);
+  GroundTruth.emplace("main", 5, "i", -10);
+  GroundTruth.emplace("main", 6, "g", -10);
+  GroundTruth.emplace("main", 6, "i", -10);
+  GroundTruth.emplace("main", 7, "g", -10);
+  GroundTruth.emplace("main", 7, "i", -10);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_03) {
+  auto Results = doAnalysis("global_03_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3foov", 4, "g", 2);
+  GroundTruth.emplace("main", 8, "g", 0);
+  GroundTruth.emplace("main", 8, "i", 42);
+  GroundTruth.emplace("main", 9, "g", 1);
+  GroundTruth.emplace("main", 9, "i", 42);
+  GroundTruth.emplace("main", 10, "g", 2);
+  GroundTruth.emplace("main", 10, "i", 42);
+  GroundTruth.emplace("main", 11, "g", 2);
+  GroundTruth.emplace("main", 11, "i", 42);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_04) {
+  auto Results = doAnalysis("global_04_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooi", 3, "g", 1);
+  GroundTruth.emplace("_Z3fooi", 3, "a", 1);
+  GroundTruth.emplace("_Z3fooi", 4, "g", 1);
+  GroundTruth.emplace("_Z3fooi", 4, "a", 2);
+
+  GroundTruth.emplace("main", 8, "g", 1);
+  GroundTruth.emplace("main", 9, "g", 1);
+  GroundTruth.emplace("main", 9, "i", 2);
+  GroundTruth.emplace("main", 10, "g", 1);
+  GroundTruth.emplace("main", 10, "i", 2);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_05) {
+  auto Results = doAnalysis("global_05_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooi", 3, "g", 2);
+  GroundTruth.emplace("_Z3fooi", 3, "a", 2);
+  GroundTruth.emplace("_Z3fooi", 4, "g", 2);
+  GroundTruth.emplace("_Z3fooi", 4, "a", 3);
+
+  GroundTruth.emplace("main", 8, "g", 1);
+  GroundTruth.emplace("main", 9, "g", 2);
+  GroundTruth.emplace("main", 9, "i", 3);
+  GroundTruth.emplace("main", 10, "g", 2);
+  GroundTruth.emplace("main", 10, "i", 3);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_06) {
+  auto Results = doAnalysis("global_06_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3foov", 4, "g", 2);
+  GroundTruth.emplace("main", 8, "g", 1);
+  GroundTruth.emplace("main", 9, "g", 2);
+  GroundTruth.emplace("main", 9, "i", 2);
+  GroundTruth.emplace("main", 10, "g", 2);
+  GroundTruth.emplace("main", 10, "i", 2);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_07) {
+  auto Results = doAnalysis("global_07_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3fooi", 3, "g", 1);
+  GroundTruth.emplace("_Z3fooi", 3, "a", 10);
+  GroundTruth.emplace("_Z3fooi", 4, "g", 1);
+  GroundTruth.emplace("_Z3fooi", 5, "g", 1);
+
+  GroundTruth.emplace("_Z3bari", 8, "g", 1);
+  GroundTruth.emplace("_Z3bari", 8, "b", 3);
+  GroundTruth.emplace("_Z3bari", 9, "g", 2);
+  GroundTruth.emplace("_Z3bari", 9, "b", 3);
+  GroundTruth.emplace("_Z3bari", 10, "g", 2);
+  GroundTruth.emplace("_Z3bari", 10, "b", 3);
+
+  GroundTruth.emplace("main", 14, "g", 1);
+  GroundTruth.emplace("main", 15, "g", 1);
+  GroundTruth.emplace("main", 15, "i", 0);
+  GroundTruth.emplace("main", 16, "g", 1);
+  GroundTruth.emplace("main", 17, "g", 2);
+  GroundTruth.emplace("main", 17, "i", 4);
+  GroundTruth.emplace("main", 18, "g", 2);
+  GroundTruth.emplace("main", 18, "i", 4);
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_08) {
+  auto Results = doAnalysis("global_08_cpp_dbg.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+  GroundTruth.emplace("_Z3bari", 7, "b", 2);
+  GroundTruth.emplace("_Z3bari", 7, "g", 2);
+  GroundTruth.emplace("_Z3bari", 8, "b", 2);
+  GroundTruth.emplace("_Z3bari", 8, "g", 2);
+
+  GroundTruth.emplace("_Z3bazi", 3, "g", 2);
+  GroundTruth.emplace("_Z3bazi", 3, "c", 3);
+  GroundTruth.emplace("_Z3bazi", 4, "g", 2);
+  GroundTruth.emplace("_Z3bazi", 4, "c", 3);
+
+  GroundTruth.emplace("_Z3fooi", 11, "g", 2);
+  GroundTruth.emplace("_Z3fooi", 11, "a", 1);
+  GroundTruth.emplace("_Z3fooi", 12, "g", 2);
+  GroundTruth.emplace("_Z3fooi", 12, "a", 1);
+
+  GroundTruth.emplace("main", 16, "g", 2);
+  GroundTruth.emplace("main", 17, "g", 2);
+  GroundTruth.emplace("main", 17, "i", 0);
+  GroundTruth.emplace("main", 18, "g", 2);
+  GroundTruth.emplace("main", 19, "g", 2);
+  compareResults(Results, GroundTruth);
+}
+
+// main function for the test case/*  */
+int main(int Argc, char **Argv) {
+  ::testing::InitGoogleTest(&Argc, Argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Use an enum instead of boolean flags in IFDSIDESolverConfig
- Enable emitting the Dot graph programatically (not only through the phasar-llvm interface)
- Annotate intra-edges in the dot graph with the computed edge functions instead of the composed edge functions