### PR TITLE
Add LLVM & Phasar paths to dynamic linker.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -120,7 +120,6 @@ ${DO_UNIT_TESTS} && echo "with unit tests."
 git submodule init
 git submodule update
 
-export LD_LIBRARY_PATH=${LLVM_INSTALL_DIR}/lib:$LD_LIBRARY_PATH
 export CC=${LLVM_INSTALL_DIR}/bin/clang
 export CXX=${LLVM_INSTALL_DIR}/bin/clang++
 
@@ -142,6 +141,7 @@ echo "phasar successfully built"
 echo "install phasar..."
 sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
 
+echo "${PHASAR_INSTALL_DIR}/lib" | sudo tee /etc/ld.so.conf.d/phasar.conf > /dev/null
 sudo ldconfig
 cd ..
 echo "phasar successfully installed to ${PHASAR_INSTALL_DIR}"

--- a/utils/install-llvm.sh
+++ b/utils/install-llvm.sh
@@ -8,19 +8,33 @@ re_number="^[0-9]+$"
 re_llvm_release="^llvmorg-[0-9]+\.[0-9]+\.[0-9]+$"
 
 num_cores=${1}
-build_dir="${2}"
-dest_dir="${3}"
-llvm_release="${4}"
+readonly build_dir="${2}"
+readonly dest_dir="${3}"
+readonly llvm_release="${4}"
 
 if [ "$#" -ne 4 ] || ! [[ "$num_cores" =~ ${re_number} ]] || ! [ -d "${build_dir}" ] || ! [[ "${llvm_release}" =~ ${re_llvm_release} ]]; then
 	echo "usage: <prog> <# cores> <build dir> <install dir> <LLVM release (e.g. 'llvmorg-9.0.0')>" >&2
 	exit 1
 fi
 
+readonly llvm_version=${llvm_release##*-} # i.e. 10.0.0, if llvm_release is "llvmorg-10.0.0"
+readonly llvm_major_rev=${llvm_version%%.*}  # i.e. 10, if llvm_release is "llvmorg-10.0.0"
+
+function addLibraryPath {
+   #libclang.so.<major rev> has been part of LLVM for a while, and we expect it to stick around -- so this should work for checking to make sure the library is available.
+   if ! ldconfig -p |grep -q libclang.so.${llvm_major_rev}; then 
+       echo "libLLVM-${llvm_major_rev}.so not found in ldconfig. Trying to add it."; 
+       echo "${dest_dir}/lib" | sudo tee /etc/ld.so.conf.d/llvm-${llvm_version}.conf > /dev/null
+       sudo ldconfig
+       ldconfig -p |grep -q libclang.so.${llvm_major_rev} && echo "done." || echo "WARNING: Failed to add LLVM library path"
+   fi
+}
+
 
 if [ -x ${dest_dir}/bin/llvm-config ]; then
    version=`${dest_dir}/bin/llvm-config --version`
    echo "Found LLVM ${version} already installed at ${dest_dir}."
+   addLibraryPath
    exit 0;
 fi
 
@@ -41,5 +55,6 @@ make -j${num_cores}
 # make -j3 check-all
 echo "Installing LLVM to ${dest_dir}"
 sudo cmake -DCMAKE_INSTALL_PREFIX=${dest_dir} -P cmake_install.cmake
-sudo ldconfig
+
+addLibraryPath
 echo "Installed LLVM successfully."


### PR DESCRIPTION
Modify the install scripts to add the LLVM and Phasar paths for the
dynamic linker.  This removes the need to set the LD_LIBRARY_PATH both
for Phasar and any applications using Phasar as a library.