### PR TITLE
Reworks phasar analyses to take an AnalysisDomain

### DIFF
--- a/examples/plugins/MyIFDSProblem.cxx
+++ b/examples/plugins/MyIFDSProblem.cxx
@@ -35,7 +35,7 @@ MyIFDSProblem::MyIFDSProblem(const ProjectIRDB *IRDB,
                              std::set<std::string> EntryPoints)
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, EntryPoints) {}
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+MyIFDSProblem::FlowFunctionPtrType
 MyIFDSProblem::getNormalFlowFunction(const llvm::Instruction *curr,
                                      const llvm::Instruction *succ) {
   cout << "MyIFDSProblem::getNormalFlowFunction()\n";
@@ -46,7 +46,7 @@ MyIFDSProblem::getNormalFlowFunction(const llvm::Instruction *curr,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+MyIFDSProblem::FlowFunctionPtrType
 MyIFDSProblem::getCallFlowFunction(const llvm::Instruction *callStmt,
                                    const llvm::Function *destMthd) {
   cout << "MyIFDSProblem::getCallFlowFunction()\n";
@@ -65,7 +65,7 @@ MyIFDSProblem::getCallFlowFunction(const llvm::Instruction *callStmt,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>> MyIFDSProblem::getRetFlowFunction(
+MyIFDSProblem::FlowFunctionPtrType MyIFDSProblem::getRetFlowFunction(
     const llvm::Instruction *callSite, const llvm::Function *calleeMthd,
     const llvm::Instruction *exitStmt, const llvm::Instruction *retSite) {
   cout << "MyIFDSProblem::getRetFlowFunction()\n";
@@ -80,7 +80,7 @@ shared_ptr<FlowFunction<const llvm::Value *>> MyIFDSProblem::getRetFlowFunction(
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+MyIFDSProblem::FlowFunctionPtrType
 MyIFDSProblem::getCallToRetFlowFunction(const llvm::Instruction *callSite,
                                         const llvm::Instruction *retSite,
                                         set<const llvm::Function *> callees) {
@@ -94,7 +94,7 @@ MyIFDSProblem::getCallToRetFlowFunction(const llvm::Instruction *callSite,
 // May be used to model function calls to libc or llvm.intrinsic functions
 // for which no implementation is accessible. If nullptr is returned it applies
 // identity on all flow facts that are present.
-shared_ptr<FlowFunction<const llvm::Value *>>
+MyIFDSProblem::FlowFunctionPtrType
 MyIFDSProblem::getSummaryFlowFunction(const llvm::Instruction *callStmt,
                                       const llvm::Function *destMthd) {
   cout << "MyIFDSProblem::getSummaryFlowFunction()\n";

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
@@ -211,26 +211,30 @@ public:
 //===----------------------------------------------------------------------===//
 // EdgeFunctions interface
 
-template <typename N, typename D, typename F, typename L> class EdgeFunctions {
+template <typename AnalysisDomainTy> class EdgeFunctions {
 public:
-  using EdgeFunctionType = EdgeFunction<L>;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using l_t = typename AnalysisDomainTy::l_t;
+
+  using EdgeFunctionType = EdgeFunction<l_t>;
   using EdgeFunctionPtrType = std::shared_ptr<EdgeFunctionType>;
 
   virtual ~EdgeFunctions() = default;
-  virtual EdgeFunctionPtrType getNormalEdgeFunction(N curr, D currNode, N succ,
-                                                    D succNode) = 0;
-  virtual EdgeFunctionPtrType getCallEdgeFunction(N callStmt, D srcNode,
-                                                  F destinationFunction,
-                                                  D destNode) = 0;
-  virtual EdgeFunctionPtrType getReturnEdgeFunction(N callSite,
-                                                    F calleeFunction,
-                                                    N exitStmt, D exitNode,
-                                                    N reSite, D retNode) = 0;
-  virtual EdgeFunctionPtrType getCallToRetEdgeFunction(N callSite, D callNode,
-                                                       N retSite, D retSiteNode,
-                                                       std::set<F> callees) = 0;
-  virtual EdgeFunctionPtrType getSummaryEdgeFunction(N curr, D currNode, N succ,
-                                                     D succNode) = 0;
+  virtual EdgeFunctionPtrType getNormalEdgeFunction(n_t curr, d_t currNode,
+                                                    n_t succ, d_t succNode) = 0;
+  virtual EdgeFunctionPtrType getCallEdgeFunction(n_t callStmt, d_t srcNode,
+                                                  f_t destinationFunction,
+                                                  d_t destNode) = 0;
+  virtual EdgeFunctionPtrType
+  getReturnEdgeFunction(n_t callSite, f_t calleeFunction, n_t exitStmt,
+                        d_t exitNode, n_t reSite, d_t retNode) = 0;
+  virtual EdgeFunctionPtrType
+  getCallToRetEdgeFunction(n_t callSite, d_t callNode, n_t retSite,
+                           d_t retSiteNode, std::set<f_t> callees) = 0;
+  virtual EdgeFunctionPtrType
+  getSummaryEdgeFunction(n_t curr, d_t currNode, n_t succ, d_t succNode) = 0;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowFunctions.h
@@ -329,26 +329,34 @@ public:
 //                             FlowFunctions Class
 //===----------------------------------------------------------------------===//
 
-template <typename N, typename D, typename F, typename Container = std::set<D>>
+template <typename AnalysisDomainTy,
+          typename Container = std::set<typename AnalysisDomainTy::d_t>>
 class FlowFunctions {
   static_assert(
-      std::is_same<typename Container::value_type, D>::value,
+      std::is_same<typename Container::value_type,
+                   typename AnalysisDomainTy::d_t>::value,
       "Value type of the container needs to match the type parameter D");
 
 public:
-  using FlowFunctionType = FlowFunction<D, Container>;
-  using FlowFunctionPtrType = std::shared_ptr<FlowFunction<D, Container>>;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+
+  using FlowFunctionType = FlowFunction<d_t, Container>;
+  using FlowFunctionPtrType = std::shared_ptr<FlowFunction<d_t, Container>>;
 
   using container_type = typename FlowFunctionType::container_type;
 
   virtual ~FlowFunctions() = default;
-  virtual FlowFunctionPtrType getNormalFlowFunction(N curr, N succ) = 0;
-  virtual FlowFunctionPtrType getCallFlowFunction(N callStmt, F destFun) = 0;
-  virtual FlowFunctionPtrType getRetFlowFunction(N callSite, F calleeFun,
-                                                 N exitStmt, N retSite) = 0;
-  virtual FlowFunctionPtrType getCallToRetFlowFunction(N callSite, N retSite,
-                                                       std::set<F> callees) = 0;
-  virtual FlowFunctionPtrType getSummaryFlowFunction(N curr, F destFun) = 0;
+  virtual FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) = 0;
+  virtual FlowFunctionPtrType getCallFlowFunction(n_t callStmt,
+                                                  f_t destFun) = 0;
+  virtual FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                                 n_t exitStmt, n_t retSite) = 0;
+  virtual FlowFunctionPtrType
+  getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                           std::set<f_t> callees) = 0;
+  virtual FlowFunctionPtrType getSummaryFlowFunction(n_t curr, f_t destFun) = 0;
 };
 } // namespace  psr
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowFunctions.h
@@ -34,6 +34,9 @@ template <typename D, typename Container = std::set<D>> class FlowFunction {
                 "Container values needs to be the same as D");
 
 public:
+  using FlowFunctionType = FlowFunction<D, Container>;
+  using FlowFunctionPtrType = std::shared_ptr<FlowFunctionType>;
+
   using container_type = Container;
   using value_type = typename container_type::value_type;
 
@@ -41,50 +44,60 @@ public:
   virtual container_type computeTargets(D source) = 0;
 };
 
-template <typename D> class Identity : public FlowFunction<D> {
-private:
-  Identity() = default;
-
+template <typename D, typename Container = std::set<D>>
+class Identity : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::FlowFunctionType;
+  using typename FlowFunction<D, Container>::FlowFunctionPtrType;
+
+  using typename FlowFunction<D, Container>::container_type;
+
   virtual ~Identity() = default;
   Identity(const Identity &i) = delete;
   Identity &operator=(const Identity &i) = delete;
   // simply return what the user provides
-  std::set<D> computeTargets(D source) override { return {source}; }
+  container_type computeTargets(D source) override { return {source}; }
   static std::shared_ptr<Identity> getInstance() {
     static std::shared_ptr<Identity> instance =
         std::shared_ptr<Identity>(new Identity);
     return instance;
   }
+
+private:
+  Identity() = default;
 };
 
 template <typename D, typename Container = std::set<D>>
 class LambdaFlow : public FlowFunction<D, Container> {
+public:
   using typename FlowFunction<D, Container>::container_type;
 
-  std::function<container_type(D)> flow;
-
-public:
-  LambdaFlow(std::function<Container(D)> f) : flow(std::move(f)) {}
+  LambdaFlow(std::function<container_type(D)> f) : flow(std::move(f)) {}
   virtual ~LambdaFlow() = default;
   container_type computeTargets(D source) override { return flow(source); }
+
+private:
+  std::function<container_type(D)> flow;
 };
 
-template <typename D> class Compose : public FlowFunction<D> {
-protected:
-  const std::vector<FlowFunction<D>> funcs;
-
+template <typename D, typename Container = std::set<D>>
+class Compose : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::FlowFunctionType;
+  using typename FlowFunction<D, Container>::FlowFunctionPtrType;
+
+  using typename FlowFunction<D, Container>::container_type;
+
   Compose(const std::vector<FlowFunction<D>> &funcs) : funcs(funcs) {}
 
   virtual ~Compose() = default;
 
-  std::set<D> computeTargets(const D &source) override {
-    std::set<D> current(source);
-    for (const FlowFunction<D> &func : funcs) {
-      std::set<D> next;
+  container_type computeTargets(const D &source) override {
+    container_type current(source);
+    for (const FlowFunctionType &func : funcs) {
+      container_type next;
       for (const D &d : current) {
-        std::set<D> target = func.computeTargets(d);
+        container_type target = func.computeTargets(d);
         next.insert(target.begin(), target.end());
       }
       current = next;
@@ -92,21 +105,24 @@ public:
     return current;
   }
 
-  static std::shared_ptr<FlowFunction<D>>
-  compose(const std::vector<FlowFunction<D>> &funcs) {
-    std::vector<FlowFunction<D>> vec;
-    for (const FlowFunction<D> &func : funcs) {
-      if (func != Identity<D>::getInstance()) {
+  static FlowFunctionPtrType
+  compose(const std::vector<FlowFunctionType> &funcs) {
+    std::vector<FlowFunctionType> vec;
+    for (const FlowFunctionType &func : funcs) {
+      if (func != Identity<D, Container>::getInstance()) {
         vec.insert(func);
       }
     }
     if (vec.size == 1) {
       return vec[0];
     } else if (vec.empty()) {
-      return Identity<D>::getInstance();
+      return Identity<D, Container>::getInstance();
     }
     return std::make_shared<Compose>(vec);
   }
+
+protected:
+  const std::vector<FlowFunctionType> funcs;
 };
 
 //===----------------------------------------------------------------------===//
@@ -137,23 +153,22 @@ public:
  * @brief Generates the given value if the given predicate evaluates to true.
  * @tparam D The type of data-flow facts to be generated.
  */
-template <typename D> class GenIf : public FlowFunction<D> {
-protected:
-  std::set<D> GenValues;
-  std::function<bool(D)> Predicate;
-
+template <typename D, typename Container = std::set<D>>
+class GenIf : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   GenIf(D GenValue, std::function<bool(D)> Predicate)
       : GenValues({GenValue}), Predicate(Predicate) {}
 
-  GenIf(std::set<D> GenValues, std::function<bool(D)> Predicate)
+  GenIf(container_type GenValues, std::function<bool(D)> Predicate)
       : GenValues(std::move(GenValues)), Predicate(Predicate) {}
 
   virtual ~GenIf() = default;
 
-  std::set<D> computeTargets(D Source) override {
+  container_type computeTargets(D Source) override {
     if (Predicate(Source)) {
-      std::set<D> ToGenerate;
+      container_type ToGenerate;
       ToGenerate.insert(Source);
       ToGenerate.insert(GenValues.begin(), GenValues.end());
       return ToGenerate;
@@ -161,18 +176,21 @@ public:
       return {Source};
     }
   }
+
+protected:
+  container_type GenValues;
+  std::function<bool(D)> Predicate;
 };
 
-template <typename D> class GenAll : public FlowFunction<D> {
-protected:
-  std::set<D> genValues;
-  D zeroValue;
-
+template <typename D, typename Container = std::set<D>>
+class GenAll : public FlowFunction<D, Container> {
 public:
-  GenAll(std::set<D> genValues, D zeroValue)
+  using typename FlowFunction<D, Container>::container_type;
+
+  GenAll(container_type genValues, D zeroValue)
       : genValues(genValues), zeroValue(zeroValue) {}
   virtual ~GenAll() = default;
-  std::set<D> computeTargets(D source) override {
+  container_type computeTargets(D source) override {
     if (source == zeroValue) {
       genValues.insert(source);
       return genValues;
@@ -180,88 +198,103 @@ public:
       return {source};
     }
   }
+
+protected:
+  container_type genValues;
+  D zeroValue;
 };
 
 //===----------------------------------------------------------------------===//
 // Kill flow functions
 
-template <typename D> class Kill : public FlowFunction<D> {
-protected:
-  D killValue;
-
+template <typename D, typename Container = std::set<D>>
+class Kill : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   Kill(D killValue) : killValue(killValue) {}
   virtual ~Kill() = default;
-  std::set<D> computeTargets(D source) override {
+  container_type computeTargets(D source) override {
     if (source == killValue) {
       return {};
     } else {
       return {source};
     }
   }
+
+protected:
+  D killValue;
 };
 
 /**
  * @brief Kills all facts for which the given predicate evaluates to true.
  * @tparam D The type of data-flow facts to be killed.
  */
-template <typename D> class KillIf : public FlowFunction<D> {
-protected:
-  std::function<bool(D)> Predicate;
-
+template <typename D, typename Container = std::set<D>>
+class KillIf : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   KillIf(std::function<bool(D)> Predicate) : Predicate(Predicate) {}
   virtual ~KillIf() = default;
-  std::set<D> computeTargets(D source) override {
+  container_type computeTargets(D source) override {
     if (Predicate(source)) {
       return {};
     } else {
       return {source};
     }
   }
+
+protected:
+  std::function<bool(D)> Predicate;
 };
 
-template <typename D> class KillMultiple : public FlowFunction<D> {
-protected:
-  std::set<D> killValues;
-
+template <typename D, typename Container = std::set<D>>
+class KillMultiple : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   KillMultiple(std::set<D> killValues) : killValues(killValues) {}
   virtual ~KillMultiple() = default;
-  std::set<D> computeTargets(D source) override {
+  container_type computeTargets(D source) override {
     if (killValues.find(source) != killValues.end()) {
       return {};
     } else {
       return {source};
     }
   }
+
+protected:
+  container_type killValues;
 };
 
-template <typename D> class KillAll : public FlowFunction<D> {
-private:
-  KillAll() = default;
-
+template <typename D, typename Container = std::set<D>>
+class KillAll : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   virtual ~KillAll() = default;
   KillAll(const KillAll &k) = delete;
   KillAll &operator=(const KillAll &k) = delete;
-  std::set<D> computeTargets(D source) override { return std::set<D>(); }
+  container_type computeTargets(D source) override { return container_type(); }
   static std::shared_ptr<KillAll<D>> getInstance() {
     static std::shared_ptr<KillAll> instance =
         std::shared_ptr<KillAll>(new KillAll);
     return instance;
   }
+
+private:
+  KillAll() = default;
 };
 
-template <typename D> class Transfer : public FlowFunction<D> {
-protected:
-  D toValue;
-  D fromValue;
-
+template <typename D, typename Container = std::set<D>>
+class Transfer : public FlowFunction<D, Container> {
 public:
+  using typename FlowFunction<D, Container>::container_type;
+
   Transfer(D toValue, D fromValue) : toValue(toValue), fromValue(fromValue) {}
   virtual ~Transfer() = default;
-  std::set<D> computeTargets(D source) override {
+  container_type computeTargets(D source) override {
     if (source == fromValue) {
       return {source, toValue};
     } else if (source == toValue) {
@@ -270,49 +303,56 @@ public:
       return {source};
     }
   }
+
+protected:
+  D toValue;
+  D fromValue;
 };
 
-template <typename D> class Union : public FlowFunction<D> {
-protected:
-  const std::vector<FlowFunction<D>> funcs;
-
+template <typename D, typename Container = std::set<D>>
+class Union : public FlowFunction<D, Container> {
 public:
-  Union(const std::vector<FlowFunction<D>> &funcs) : funcs(funcs) {}
+  using typename FlowFunction<D, Container>::FlowFunctionType;
+  using typename FlowFunction<D, Container>::FlowFunctionPtrType;
+
+  using typename FlowFunction<D, Container>::container_type;
+
+  Union(const std::vector<FlowFunctionType> &funcs) : funcs(funcs) {}
   virtual ~Union() = default;
-  std::set<D> computeTargets(const D &source) override {
-    std::set<D> result;
-    for (const FlowFunction<D> &func : funcs) {
-      std::set<D> target = func.computeTarget(source);
+  container_type computeTargets(const D &source) override {
+    container_type result;
+    for (const FlowFunctionType &func : funcs) {
+      container_type target = func.computeTarget(source);
       result.insert(target.begin(), target.end());
     }
     return result;
   }
-  static FlowFunction<D> setunion(const std::vector<FlowFunction<D>> &funcs) {
-    std::vector<FlowFunction<D>> vec;
-    for (const FlowFunction<D> &func : funcs) {
-      if (func != Identity<D>::getInstance()) {
+  static FlowFunctionType setunion(const std::vector<FlowFunctionType> &funcs) {
+    std::vector<FlowFunctionType> vec;
+    for (const FlowFunctionType &func : funcs) {
+      if (func != Identity<D, Container>::getInstance()) {
         vec.add(func);
       }
     }
     if (vec.size() == 1) {
       return vec[0];
     } else if (vec.empty()) {
-      return Identity<D>::getInstance();
+      return Identity<D, Container>::getInstance();
     }
     return Union(vec);
   }
+
+protected:
+  const std::vector<FlowFunctionType> funcs;
 };
 
 template <typename D, typename Container = std::set<D>>
 class ZeroedFlowFunction : public FlowFunction<D, Container> {
   using typename FlowFunction<D, Container>::container_type;
-
-private:
-  std::shared_ptr<FlowFunction<D, Container>> delegate;
-  D zerovalue;
+  using typename FlowFunction<D, Container>::FlowFunctionPtrType;
 
 public:
-  ZeroedFlowFunction(std::shared_ptr<FlowFunction<D, Container>> ff, D zv)
+  ZeroedFlowFunction(FlowFunctionPtrType ff, D zv)
       : delegate(ff), zerovalue(zv) {}
   container_type computeTargets(D source) override {
     if (source == zerovalue) {
@@ -323,6 +363,10 @@ public:
       return delegate->computeTargets(source);
     }
   }
+
+private:
+  FlowFunctionPtrType delegate;
+  D zerovalue;
 };
 
 //===----------------------------------------------------------------------===//
@@ -343,7 +387,7 @@ public:
   using n_t = typename AnalysisDomainTy::n_t;
 
   using FlowFunctionType = FlowFunction<d_t, Container>;
-  using FlowFunctionPtrType = std::shared_ptr<FlowFunction<d_t, Container>>;
+  using FlowFunctionPtrType = typename FlowFunctionType::FlowFunctionPtrType;
 
   using container_type = typename FlowFunctionType::container_type;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h
@@ -33,29 +33,38 @@ class ProjectIRDB;
 template <typename T, typename F> class TypeHierarchy;
 template <typename V, typename N> class PointsToInfo;
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename L, typename I, typename Container = std::set<D>>
+template <typename AnalysisDomainTy,
+          typename Container = std::set<typename AnalysisDomainTy::d_t>>
 class IDETabulationProblem
-    : public IFDSTabulationProblem<N, D, F, T, V, I, Container>,
-      public virtual EdgeFunctions<N, D, F, L>,
-      public virtual JoinLattice<L>,
-      public virtual EdgeFactPrinter<L> {
-  static_assert(std::is_base_of_v<ICFG<N, F>, I>,
+    : public IFDSTabulationProblem<AnalysisDomainTy, Container>,
+      public virtual EdgeFunctions<AnalysisDomainTy>,
+      public virtual JoinLattice<AnalysisDomainTy>,
+      public virtual EdgeFactPrinter<AnalysisDomainTy> {
+public:
+  using d_t = typename AnalysisDomainTy::d_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+  using l_t = typename AnalysisDomainTy::l_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+
+  static_assert(std::is_base_of_v<ICFG<n_t, f_t>, i_t>, // TODO: fix ICFG
                 "I must implement the ICFG interface!");
 
-public:
-  using typename EdgeFunctions<N, D, F, L>::EdgeFunctionPtrType;
+  using typename EdgeFunctions<AnalysisDomainTy>::EdgeFunctionPtrType;
 
-  IDETabulationProblem(const ProjectIRDB *IRDB, const TypeHierarchy<T, F> *TH,
-                       const I *ICF, PointsToInfo<V, N> *PT,
+  IDETabulationProblem(const ProjectIRDB *IRDB,
+                       const TypeHierarchy<t_t, f_t> *TH, const i_t *ICF,
+                       PointsToInfo<v_t, n_t> *PT,
                        std::set<std::string> EntryPoints = {})
-      : IFDSTabulationProblem<N, D, F, T, V, I, Container>(
+      : IFDSTabulationProblem<AnalysisDomainTy, Container>(
             IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
   ~IDETabulationProblem() override = default;
   virtual EdgeFunctionPtrType allTopFunction() = 0;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-  virtual void emitTextReport(const SolverResults<N, D, L> &SR,
+  virtual void emitTextReport(const SolverResults<n_t, d_t, l_t> &SR,
                               std::ostream &OS = std::cout) {
     OS << "No text report available!\n";
   }
@@ -63,14 +72,14 @@ public:
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-  virtual void emitGraphicalReport(const SolverResults<N, D, L> &SR,
+  virtual void emitGraphicalReport(const SolverResults<n_t, d_t, l_t> &SR,
                                    std::ostream &OS = std::cout) {
     OS << "No graphical report available!\n";
   }
 #pragma clang diagnostic pop
 private:
-  using IFDSTabulationProblem<N, D, F, T, V, I, Container>::emitTextReport;
-  using IFDSTabulationProblem<N, D, F, T, V, I, Container>::emitGraphicalReport;
+  using IFDSTabulationProblem<AnalysisDomainTy, Container>::emitTextReport;
+  using IFDSTabulationProblem<AnalysisDomainTy, Container>::emitGraphicalReport;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h
@@ -38,43 +38,55 @@ class ProjectIRDB;
 template <typename T, typename F> class TypeHierarchy;
 template <typename V, typename N> class PointsToInfo;
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename I, typename Container = std::set<D>>
-class IFDSTabulationProblem : public virtual FlowFunctions<N, D, F, Container>,
-                              public virtual NodePrinter<N>,
-                              public virtual DataFlowFactPrinter<D>,
-                              public virtual FunctionPrinter<F> {
-  static_assert(std::is_base_of_v<ICFG<N, F>, I>,
+template <typename AnalysisDomainTy,
+          typename Container = std::set<typename AnalysisDomainTy::d_t>>
+class IFDSTabulationProblem
+    : public virtual FlowFunctions<AnalysisDomainTy, Container>,
+      public virtual NodePrinter<AnalysisDomainTy>,
+      public virtual DataFlowFactPrinter<AnalysisDomainTy>,
+      public virtual FunctionPrinter<AnalysisDomainTy> {
+public:
+  using ProblemAnalysisDomain = AnalysisDomainTy;
+
+  using d_t = typename AnalysisDomainTy::d_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+
+  static_assert(std::is_base_of_v<ICFG<n_t, f_t>, i_t>,
                 "I must implement the ICFG interface!");
 
 protected:
   IFDSIDESolverConfig SolverConfig;
   const ProjectIRDB *IRDB;
-  const TypeHierarchy<T, F> *TH;
-  const I *ICF;
-  PointsToInfo<V, N> *PT;
-  D ZeroValue;
+  const TypeHierarchy<t_t, f_t> *TH;
+  const i_t *ICF;
+  PointsToInfo<v_t, n_t> *PT;
+  d_t ZeroValue;
   std::set<std::string> EntryPoints;
   [[maybe_unused]] SoundnessFlag SF = SoundnessFlag::UNUSED;
 
 public:
   using ConfigurationTy = HasNoConfigurationType;
 
-  IFDSTabulationProblem(const ProjectIRDB *IRDB, const TypeHierarchy<T, F> *TH,
-                        const I *ICF, PointsToInfo<V, N> *PT,
+  IFDSTabulationProblem(const ProjectIRDB *IRDB,
+                        const TypeHierarchy<t_t, f_t> *TH, const i_t *ICF,
+                        PointsToInfo<v_t, n_t> *PT,
                         std::set<std::string> EntryPoints = {})
       : IRDB(IRDB), TH(TH), ICF(ICF), PT(PT),
         EntryPoints(std::move(EntryPoints)) {}
 
   ~IFDSTabulationProblem() override = default;
 
-  virtual D createZeroValue() const = 0;
+  virtual d_t createZeroValue() const = 0;
 
-  virtual bool isZeroValue(D d) const = 0;
+  virtual bool isZeroValue(d_t d) const = 0;
 
-  virtual std::map<N, std::set<D>> initialSeeds() = 0;
+  virtual std::map<n_t, std::set<d_t>> initialSeeds() = 0;
 
-  D getZeroValue() const { return ZeroValue; }
+  d_t getZeroValue() const { return ZeroValue; }
 
   [[nodiscard]] std::set<std::string> getEntryPoints() const {
     return EntryPoints;
@@ -82,11 +94,11 @@ public:
 
   const ProjectIRDB *getProjectIRDB() const { return IRDB; }
 
-  const TypeHierarchy<T, F> *getTypeHierarchy() const { return TH; }
+  const TypeHierarchy<t_t, f_t> *getTypeHierarchy() const { return TH; }
 
-  const I *getICFG() const { return ICF; }
+  const i_t *getICFG() const { return ICF; }
 
-  PointsToInfo<V, N> *getPointstoInfo() const { return PT; }
+  PointsToInfo<v_t, n_t> *getPointstoInfo() const { return PT; }
 
   void setIFDSIDESolverConfig(IFDSIDESolverConfig Config) {
     SolverConfig = Config;
@@ -96,13 +108,14 @@ public:
     return SolverConfig;
   }
 
-  virtual void emitTextReport(const SolverResults<N, D, BinaryDomain> &SR,
+  virtual void emitTextReport(const SolverResults<n_t, d_t, BinaryDomain> &SR,
                               std::ostream &OS = std::cout) {
     OS << "No text report available!\n";
   }
 
-  virtual void emitGraphicalReport(const SolverResults<N, D, BinaryDomain> &SR,
-                                   std::ostream &OS = std::cout) {
+  virtual void
+  emitGraphicalReport(const SolverResults<n_t, d_t, BinaryDomain> &SR,
+                      std::ostream &OS = std::cout) {
     OS << "No graphical report available!\n";
   }
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/JoinLattice.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/JoinLattice.h
@@ -19,12 +19,14 @@
 
 namespace psr {
 
-template <typename L> class JoinLattice {
+template <typename AnalysisDomainTy> class JoinLattice {
 public:
+  using l_t = typename AnalysisDomainTy::l_t;
+
   virtual ~JoinLattice() = default;
-  virtual L topElement() = 0;
-  virtual L bottomElement() = 0;
-  virtual L join(L lhs, L rhs) = 0;
+  virtual l_t topElement() = 0;
+  virtual l_t bottomElement() = 0;
+  virtual l_t join(l_t lhs, l_t rhs) = 0;
 };
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions.h
@@ -40,18 +40,16 @@ namespace psr {
  */
 class AutoKillTMPs : public FlowFunction<const llvm::Value *> {
 protected:
-  std::shared_ptr<FlowFunction<const llvm::Value *>> delegate;
+  FlowFunctionPtrType delegate;
   const llvm::Instruction *inst;
 
 public:
-  AutoKillTMPs(std::shared_ptr<FlowFunction<const llvm::Value *>> FF,
-               const llvm::Instruction *In)
+  AutoKillTMPs(FlowFunctionPtrType FF, const llvm::Instruction *In)
       : delegate(std::move(FF)), inst(In) {}
   virtual ~AutoKillTMPs() = default;
 
-  std::set<const llvm::Value *>
-  computeTargets(const llvm::Value *Source) override {
-    std::set<const llvm::Value *> Result = delegate->computeTargets(Source);
+  container_type computeTargets(const llvm::Value *Source) override {
+    container_type Result = delegate->computeTargets(Source);
     for (const llvm::Use &U : inst->operands()) {
       if (llvm::isa<llvm::LoadInst>(U)) {
         Result.erase(U);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -143,8 +143,7 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override {
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override {
     // generate all global variables (only once)
     // if (LLVM_UNLIKELY(!GeneratedGlobalVariables)) {
     //   if (const llvm::Module *M = curr->getModule()) {

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -35,6 +35,7 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMFlowFunctions.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMZeroValue.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/PhasarLLVM/Utils/LatticeDomain.h"
@@ -63,6 +64,14 @@ getAllocaInstruction(const llvm::GetElementPtrInst *GEP) {
 
 namespace psr {
 
+template <typename EdgeFactType>
+struct IDEInstInteractionAnalysisDomain : public LLVMAnalysisDomainDefault {
+  // type of the element contained in the sets of edge functions
+  using e_t = EdgeFactType;
+  using l_t = LatticeDomain<BitVectorSet<e_t>>;
+  using i_t = LLVMBasedICFG;
+};
+
 ///
 /// SyntacticAnalysisOnly: Can be set if a syntactic-only analysis is desired
 /// (without using points-to information)
@@ -73,28 +82,24 @@ template <typename EdgeFactType = std::string,
           bool SyntacticAnalysisOnly = false, bool EnableIndirectTaints = false>
 class IDEInstInteractionAnalysisT
     : public IDETabulationProblem<
-          const llvm::Instruction *, const llvm::Value *,
-          const llvm::Function *, const llvm::StructType *, const llvm::Value *,
-          LatticeDomain<BitVectorSet<EdgeFactType>>, LLVMBasedICFG> {
-  using IDETabProblemType = IDETabulationProblem<
-      const llvm::Instruction *, const llvm::Value *, const llvm::Function *,
-      const llvm::StructType *, const llvm::Value *,
-      LatticeDomain<BitVectorSet<EdgeFactType>>, LLVMBasedICFG>;
+          IDEInstInteractionAnalysisDomain<EdgeFactType>> {
+public:
+  using AnalysisDomainTy = IDEInstInteractionAnalysisDomain<EdgeFactType>;
+
+  using IDETabProblemType = IDETabulationProblem<AnalysisDomainTy>;
+  using typename IDETabProblemType::container_type;
   using typename IDETabProblemType::FlowFunctionPtrType;
 
-public:
-  using typename IDETabProblemType::container_type;
-
-  using d_t = const llvm::Value *;
-  using n_t = const llvm::Instruction *;
-  using f_t = const llvm::Function *;
-  using t_t = const llvm::StructType *;
-  using v_t = const llvm::Value *;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
 
   // type of the element contained in the sets of edge functions
-  using e_t = EdgeFactType;
-  using l_t = LatticeDomain<BitVectorSet<e_t>>;
-  using i_t = LLVMBasedICFG;
+  using e_t = typename AnalysisDomainTy::e_t;
+  using l_t = typename AnalysisDomainTy::l_t;
+  using i_t = typename AnalysisDomainTy::i_t;
 
   using EdgeFactGeneratorTy = std::set<e_t>(n_t curr);
 
@@ -118,11 +123,7 @@ public:
                               const LLVMTypeHierarchy *TH,
                               const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                               std::set<std::string> EntryPoints = {"main"})
-      : IDETabulationProblem<const llvm::Instruction *, const llvm::Value *,
-                             const llvm::Function *, const llvm::StructType *,
-                             const llvm::Value *,
-                             LatticeDomain<BitVectorSet<EdgeFactType>>,
-                             LLVMBasedICFG, container_type>(
+      : IDETabulationProblem<AnalysisDomainTy, container_type>(
             IRDB, TH, ICF, PT, std::move(EntryPoints)) {
     this->ZeroValue =
         IDEInstInteractionAnalysisT<EdgeFactType, SyntacticAnalysisOnly,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
@@ -18,6 +18,7 @@
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposer.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -28,15 +29,17 @@ class Value;
 
 namespace psr {
 
+struct IDELinearConstantAnalysisDomain : public LLVMAnalysisDomainDefault {
+  // int64_t corresponds to llvm's type of constant integer
+  using l_t = int64_t;
+};
+
 class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
 class IDELinearConstantAnalysis
-    : public IDETabulationProblem<const llvm::Instruction *,
-                                  const llvm::Value *, const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  int64_t, LLVMBasedICFG> {
+    : public IDETabulationProblem<IDELinearConstantAnalysisDomain> {
 private:
   // For debug purpose only
   static unsigned CurrGenConstantId;
@@ -44,14 +47,15 @@ private:
   static unsigned CurrBinaryId;
 
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-  // int64_t corresponds to llvm's type of constant integer
-  typedef int64_t l_t;
+  using IDETabProblemType =
+      IDETabulationProblem<IDELinearConstantAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
 
   static const l_t TOP;
   static const l_t BOTTOM;
@@ -72,7 +76,7 @@ public:
     void print(std::ostream &os);
   };
 
-  typedef std::map<std::string, std::map<unsigned, LCAResult>> lca_results_t;
+  using lca_results_t = std::map<std::string, std::map<unsigned, LCAResult>>;
 
   static void stripBottomResults(std::unordered_map<d_t, l_t> &Res);
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h
@@ -82,23 +82,18 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -31,19 +32,20 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
-class IDEProtoAnalysis
-    : public IDETabulationProblem<const llvm::Instruction *,
-                                  const llvm::Value *, const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  const llvm::Value *, LLVMBasedICFG> {
+struct IDEProtoAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = const llvm::Value *;
+};
+
+class IDEProtoAnalysis : public IDETabulationProblem<IDEProtoAnalysisDomain> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef const llvm::Value *l_t;
-  typedef LLVMBasedICFG i_t;
+  using IDETabProblemType = IDETabulationProblem<IDEProtoAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
 
   IDEProtoAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                    const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.h
@@ -55,23 +55,18 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.h
@@ -16,6 +16,7 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposer.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 
@@ -29,22 +30,29 @@ class Function;
 namespace psr {
 enum class SecureHeapFact { ZERO, INITIALIZED };
 enum class SecureHeapValue { TOP, INITIALIZED, BOT };
+
+struct IDESecureHeapPropagationAnalysisDomain : LLVMAnalysisDomainDefault {
+  using d_t = SecureHeapFact;
+  using l_t = SecureHeapValue;
+};
+
 class IDESecureHeapPropagation
-    : public IDETabulationProblem<const llvm::Instruction *, SecureHeapFact,
-                                  const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  SecureHeapValue, LLVMBasedICFG> {
+    : public IDETabulationProblem<IDESecureHeapPropagationAnalysisDomain> {
+
   const llvm::StringLiteral initializerFn = "CRYPTO_secure_malloc_init";
   const llvm::StringLiteral shutdownFn = "CRYPTO_secure_malloc_done";
 
 public:
-  typedef SecureHeapFact d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef SecureHeapValue l_t;
-  typedef LLVMBasedICFG i_t;
+  using IDETabProblemType =
+      IDETabulationProblem<IDESecureHeapPropagationAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
+
   IDESecureHeapPropagation(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                            const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                            std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.h
@@ -58,23 +58,18 @@ public:
                            std::set<std::string> EntryPoints = {"main"});
   ~IDESecureHeapPropagation() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destMthd) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destMthd) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeMthd,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeMthd,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destMthd) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destMthd) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.h
@@ -58,23 +58,18 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -31,22 +32,23 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
-class IDESolverTest
-    : public IDETabulationProblem<const llvm::Instruction *,
-                                  const llvm::Value *, const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  const llvm::Value *, LLVMBasedICFG> {
+struct IDESolverTestAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = const llvm::Value *;
+};
+
+class IDESolverTest : public IDETabulationProblem<IDESolverTestAnalysisDomain> {
 private:
   std::vector<std::string> EntryPoints;
 
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef const llvm::Value *l_t;
-  typedef LLVMBasedICFG i_t;
+  using IDETabProblemType = IDETabulationProblem<IDESolverTestAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
 
   IDESolverTest(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                 const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -30,19 +31,20 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
-class IDETaintAnalysis
-    : public IDETabulationProblem<const llvm::Instruction *,
-                                  const llvm::Value *, const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  const llvm::Value *, LLVMBasedICFG> {
+struct IDETaintAnalysisDomain : LLVMAnalysisDomainDefault {
+  using l_t = const llvm::Value *;
+};
+
+class IDETaintAnalysis : public IDETabulationProblem<IDETaintAnalysisDomain> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef const llvm::Value *l_t;
-  typedef LLVMBasedICFG i_t;
+  using IDETabProblemType = IDETabulationProblem<IDETaintAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
 
   std::set<std::string> source_functions = {"fread", "read"};
   // keep in mind that 'char** argv' of main is a source for tainted values as

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.h
@@ -60,23 +60,18 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.h
@@ -20,6 +20,7 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposer.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -33,19 +34,22 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
+struct IDETypeStateAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = int;
+};
+
 class IDETypeStateAnalysis
-    : public IDETabulationProblem<const llvm::Instruction *,
-                                  const llvm::Value *, const llvm::Function *,
-                                  const llvm::StructType *, const llvm::Value *,
-                                  int, LLVMBasedICFG> {
+    : public IDETabulationProblem<IDETypeStateAnalysisDomain> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef int l_t;
-  typedef LLVMBasedICFG i_t;
+  using IDETabProblemType = IDETabulationProblem<IDETypeStateAnalysisDomain>;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
+
   using ConfigurationTy = TypeStateDescription;
 
 private:

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.h
@@ -109,23 +109,18 @@ public:
 
   // start formulating our analysis by specifying the parts required for IFDS
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 // Forward declaration of types for which we only use its pointer or ref type
 namespace llvm {
@@ -43,18 +44,7 @@ class LLVMTypeHierarchy;
  * @brief Computes all possibly mutable memory locations.
  */
 class IFDSConstAnalysis
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
-public:
-  using d_t = const llvm::Value *;
-  using n_t = const llvm::Instruction *;
-  using f_t = const llvm::Function *;
-  using t_t = const llvm::StructType *;
-  using v_t = const llvm::Value *;
-  using i_t = LLVMBasedICFG;
-
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 private:
   // Holds all allocated memory locations, including global variables
   std::set<d_t> AllMemLocs; // FIXME: initialize within the constructor body!

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.h
@@ -80,8 +80,7 @@ public:
    * @param curr Currently analyzed program statement.
    * @param succ Successor statement.
    */
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
   /**
    * The following llvm intrinsics
@@ -103,8 +102,7 @@ public:
    * @param callStmt Call statement.
    * @param destFun Callee function.
    */
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
   /**
    * Maps formal parameters back into actual parameters. Data-flow fact(s)
@@ -115,10 +113,8 @@ public:
    * @param exitStmt Exit statement in callee.
    * @param retSite Return site.
    */
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
   /**
    * If the called function is a llvm memory intrinsic function, appropriate
@@ -131,15 +127,14 @@ public:
    * @param callSite Call site.
    * @param retSite Return site.
    */
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
   /**
    * @brief Not used for this analysis, i.e. always returning nullptr.
    */
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   /**
    * Only the zero value is valid at the first program statement, i.e.

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.h
@@ -19,6 +19,7 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/Stats/TraceStats.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMZeroValue.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Domain/ExtendedValue.h"
 #include "phasar/PhasarLLVM/Utils/TaintConfiguration.h"
 #include "phasar/Utils/LLVMShorthands.h"
@@ -35,17 +36,13 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
+struct IFDSFieldSensTaintAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using d_t = ExtendedValue;
+};
+
 class IFDSFieldSensTaintAnalysis
-    : public IFDSTabulationProblem<
-          const llvm::Instruction *, ExtendedValue, const llvm::Function *,
-          const llvm::StructType *, const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<IFDSFieldSensTaintAnalysisDomain> {
 public:
-  typedef ExtendedValue d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
   using ConfigurationTy = TaintConfiguration<ExtendedValue>;
 
   IFDSFieldSensTaintAnalysis(

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.h
@@ -52,26 +52,26 @@ public:
       std::set<std::string> EntryPoints = {"main"});
   ~IFDSFieldSensTaintAnalysis() override = default;
 
-  std::shared_ptr<FlowFunction<ExtendedValue>>
+  FlowFunctionPtrType
   getNormalFlowFunction(const llvm::Instruction *curr,
                         const llvm::Instruction *succ) override;
 
-  std::shared_ptr<FlowFunction<ExtendedValue>>
+  FlowFunctionPtrType
   getCallFlowFunction(const llvm::Instruction *callStmt,
                       const llvm::Function *destFun) override;
 
-  std::shared_ptr<FlowFunction<ExtendedValue>>
+  FlowFunctionPtrType
   getRetFlowFunction(const llvm::Instruction *callSite,
                      const llvm::Function *calleeFun,
                      const llvm::Instruction *exitStmt,
                      const llvm::Instruction *retSite) override;
 
-  std::shared_ptr<FlowFunction<ExtendedValue>>
+  FlowFunctionPtrType
   getCallToRetFlowFunction(const llvm::Instruction *callSite,
                            const llvm::Instruction *retSite,
                            std::set<const llvm::Function *> callees) override;
 
-  std::shared_ptr<FlowFunction<ExtendedValue>>
+  FlowFunctionPtrType
   getSummaryFlowFunction(const llvm::Instruction *callStmt,
                          const llvm::Function *destFun) override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 // Forward declaration of types for which we only use its pointer or ref type
 namespace llvm {
@@ -54,18 +55,13 @@ template <> struct hash<psr::LCAPair> {
 
 namespace psr {
 
-class IFDSLinearConstantAnalysis
-    : public IFDSTabulationProblem<
-          const llvm::Instruction *, LCAPair, const llvm::Function *,
-          const llvm::StructType *, const llvm::Value *, LLVMBasedICFG> {
-public:
-  typedef LCAPair d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
+struct IFDSLinearConstantAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using d_t = LCAPair;
+};
 
+class IFDSLinearConstantAnalysis
+    : public IFDSTabulationProblem<IFDSLinearConstantAnalysisDomain> {
+public:
   IFDSLinearConstantAnalysis(const ProjectIRDB *IRDB,
                              const LLVMTypeHierarchy *TH,
                              const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.h
@@ -69,23 +69,19 @@ public:
 
   ~IFDSLinearConstantAnalysis() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallToRetFlowFunction(
+  FlowFunctionPtrType getCallToRetFlowFunction(
       n_t callSite, n_t retSite,
       std::set<IFDSLinearConstantAnalysis::f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.h
@@ -41,23 +41,18 @@ public:
 
   virtual ~IFDSProtoAnalysis() = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -32,18 +33,8 @@ class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
 class IFDSProtoAnalysis
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   IFDSProtoAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                     const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                     std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -32,18 +33,8 @@ class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
 class IFDSSignAnalysis
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   IFDSSignAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                    const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                    std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.h
@@ -41,23 +41,18 @@ public:
 
   ~IFDSSignAnalysis() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -31,19 +32,8 @@ class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
-class IFDSSolverTest
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+class IFDSSolverTest : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   IFDSSolverTest(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                  const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                  std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h
@@ -40,23 +40,18 @@ public:
 
   ~IFDSSolverTest() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.h
@@ -11,7 +11,9 @@
 #define PHASAR_PHASARLLVM_IFDSIDE_PROBLEMS_IFDSTAINTANALYSIS_H_
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Utils/TaintConfiguration.h"
+
 #include <iostream>
 #include <map>
 #include <memory>
@@ -43,20 +45,11 @@ struct HasNoConfigurationType;
  * taint-sensitive source and sink functions.
  */
 class IFDSTaintAnalysis
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 private:
   const TaintConfiguration<const llvm::Value *> &SourceSinkFunctions;
 
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
   // Setup the configuration type
   using ConfigurationTy = TaintConfiguration<const llvm::Value *>;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.h
@@ -69,23 +69,18 @@ public:
 
   ~IFDSTaintAnalysis() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.h
@@ -40,23 +40,17 @@ public:
 
   ~IFDSTypeAnalysis() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t curr, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t curr, f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -31,18 +32,8 @@ class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
 class IFDSTypeAnalysis
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   IFDSTypeAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                    const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                    std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.h
@@ -58,23 +58,18 @@ public:
 
   ~IFDSUninitializedVariables() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
 
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
 
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override;
 
   std::map<n_t, std::set<d_t>> initialSeeds() override;
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -32,18 +33,7 @@ class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
 class IFDSUninitializedVariables
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
-public:
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
 private:
   struct UninitResult {
     UninitResult() = default;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
@@ -15,6 +15,7 @@
 #include <set>
 #include <string>
 
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h"
 #include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
@@ -25,11 +26,6 @@ class Value;
 } // namespace llvm
 
 namespace psr {
-
-struct OpenSSLEVPKDFCTXDescriptionAnalysisDomain
-    : public LLVMAnalysisDomainDefault {
-  using l_t = int;
-};
 
 /**
  * A type state description for OpenSSL's EVP Key Derivation functions. The
@@ -76,12 +72,12 @@ private:
 
   // std::map<std::pair<const llvm::Instruction *, const llvm::Value *>, int>
   //     requiredKDFState;
-  IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain> &kdfAnalysisResults;
+  IDESolver<IDETypeStateAnalysisDomain> &kdfAnalysisResults;
   static OpenSSLEVTKDFToken funcNameToToken(const std::string &F);
 
 public:
   OpenSSLEVPKDFCTXDescription(
-      IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain> &kdfAnalysisResults)
+      IDESolver<IDETypeStateAnalysisDomain> &kdfAnalysisResults)
       : kdfAnalysisResults(kdfAnalysisResults) {}
   bool isFactoryFunction(const std::string &F) const override;
   bool isConsumingFunction(const std::string &F) const override;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
@@ -17,6 +17,7 @@
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Instruction;
@@ -24,6 +25,11 @@ class Value;
 } // namespace llvm
 
 namespace psr {
+
+struct OpenSSLEVPKDFCTXDescriptionAnalysisDomain
+    : public LLVMAnalysisDomainDefault {
+  using l_t = int;
+};
 
 /**
  * A type state description for OpenSSL's EVP Key Derivation functions. The
@@ -70,16 +76,12 @@ private:
 
   // std::map<std::pair<const llvm::Instruction *, const llvm::Value *>, int>
   //     requiredKDFState;
-  IDESolver<const llvm::Instruction *, const llvm::Value *,
-            const llvm::Function *, const llvm::StructType *,
-            const llvm::Value *, int, LLVMBasedICFG> &kdfAnalysisResults;
+  IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain> &kdfAnalysisResults;
   static OpenSSLEVTKDFToken funcNameToToken(const std::string &F);
 
 public:
   OpenSSLEVPKDFCTXDescription(
-      IDESolver<const llvm::Instruction *, const llvm::Value *,
-                const llvm::Function *, const llvm::StructType *,
-                const llvm::Value *, int, LLVMBasedICFG> &kdfAnalysisResults)
+      IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain> &kdfAnalysisResults)
       : kdfAnalysisResults(kdfAnalysisResults) {}
   bool isFactoryFunction(const std::string &F) const override;
   bool isConsumingFunction(const std::string &F) const override;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
@@ -17,8 +17,15 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace psr {
+
+struct OpenSSLSecureHeapDescriptionAnalysisDomain
+    : public LLVMAnalysisDomainDefault {
+  using d_t = SecureHeapFact;
+  using l_t = SecureHeapValue;
+};
 
 class OpenSSLSecureHeapDescription : public TypeStateDescription {
 private:
@@ -44,17 +51,14 @@ private:
   // Delta matrix to implement the state machine's Delta function
   static const OpenSSLSecureHeapState Delta[5][6];
 
-  IDESolver<const llvm::Instruction *, SecureHeapFact, const llvm::Function *,
-            const llvm::StructType *, const llvm::Value *, SecureHeapValue,
-            LLVMBasedICFG> &secureHeapPropagationResults;
+  IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
+      &secureHeapPropagationResults;
 
   static OpenSSLSecureHeapToken funcNameToToken(const std::string &F);
 
 public:
   OpenSSLSecureHeapDescription(
-      IDESolver<const llvm::Instruction *, SecureHeapFact,
-                const llvm::Function *, const llvm::StructType *,
-                const llvm::Value *, SecureHeapValue, LLVMBasedICFG>
+      IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
           &secureHeapPropagationResults);
 
   bool isFactoryFunction(const std::string &F) const override;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
@@ -51,9 +51,8 @@ private:
   static OpenSSLSecureHeapToken funcNameToToken(const std::string &F);
 
 public:
-  OpenSSLSecureHeapDescription(
-      IDESolver<IDESecureHeapPropagationAnalysisDomain>
-          &secureHeapPropagationResults);
+  OpenSSLSecureHeapDescription(IDESolver<IDESecureHeapPropagationAnalysisDomain>
+                                   &secureHeapPropagationResults);
 
   bool isFactoryFunction(const std::string &F) const override;
   bool isConsumingFunction(const std::string &F) const override;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
@@ -21,12 +21,6 @@
 
 namespace psr {
 
-struct OpenSSLSecureHeapDescriptionAnalysisDomain
-    : public LLVMAnalysisDomainDefault {
-  using d_t = SecureHeapFact;
-  using l_t = SecureHeapValue;
-};
-
 class OpenSSLSecureHeapDescription : public TypeStateDescription {
 private:
   enum OpenSSLSecureHeapState {
@@ -51,14 +45,14 @@ private:
   // Delta matrix to implement the state machine's Delta function
   static const OpenSSLSecureHeapState Delta[5][6];
 
-  IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
+  IDESolver<IDESecureHeapPropagationAnalysisDomain>
       &secureHeapPropagationResults;
 
   static OpenSSLSecureHeapToken funcNameToToken(const std::string &F);
 
 public:
   OpenSSLSecureHeapDescription(
-      IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
+      IDESolver<IDESecureHeapPropagationAnalysisDomain>
           &secureHeapPropagationResults);
 
   bool isFactoryFunction(const std::string &F) const override;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -1130,18 +1130,18 @@ protected:
    * @param d2 The abstraction at the current node
    * @return The set of abstractions at the successor node
    */
-  container_type computeNormalFlowFunction(
-      const std::shared_ptr<FlowFunction<d_t, Container>> &flowFunction, d_t d1,
-      d_t d2) {
+  container_type
+  computeNormalFlowFunction(const FlowFunctionPtrType &flowFunction, d_t d1,
+                            d_t d2) {
     return flowFunction->computeTargets(d2);
   }
 
   /**
    * TODO: comment
    */
-  container_type computeSummaryFlowFunction(
-      const std::shared_ptr<FlowFunction<d_t, Container>> &SummaryFlowFunction,
-      d_t d1, d_t d2) {
+  container_type
+  computeSummaryFlowFunction(const FlowFunctionPtrType &SummaryFlowFunction,
+                             d_t d1, d_t d2) {
     return SummaryFlowFunction->computeTargets(d2);
   }
 
@@ -1152,9 +1152,9 @@ protected:
    * @param d2 The abstraction at the call site
    * @return The set of caller-side abstractions at the callee's start node
    */
-  container_type computeCallFlowFunction(
-      const std::shared_ptr<FlowFunction<d_t, Container>> &callFlowFunction,
-      d_t d1, d_t d2) {
+  container_type
+  computeCallFlowFunction(const FlowFunctionPtrType &callFlowFunction, d_t d1,
+                          d_t d2) {
     return callFlowFunction->computeTargets(d2);
   }
 
@@ -1168,9 +1168,7 @@ protected:
    * @return The set of caller-side abstractions at the return site
    */
   container_type computeCallToReturnFlowFunction(
-      const std::shared_ptr<FlowFunction<d_t, Container>>
-          &callToReturnFlowFunction,
-      d_t d1, d_t d2) {
+      const FlowFunctionPtrType &callToReturnFlowFunction, d_t d1, d_t d2) {
     return callToReturnFlowFunction->computeTargets(d2);
   }
 
@@ -1184,9 +1182,10 @@ protected:
    * @param callerSideDs The abstractions at the call site
    * @return The set of caller-side abstractions at the return site
    */
-  container_type computeReturnFlowFunction(
-      const std::shared_ptr<FlowFunction<d_t, Container>> &retFunction, d_t d1,
-      d_t d2, n_t callSite, const Container &callerSideDs) {
+  container_type
+  computeReturnFlowFunction(const FlowFunctionPtrType &retFunction, d_t d1,
+                            d_t d2, n_t callSite,
+                            const Container &callerSideDs) {
     return retFunction->computeTargets(d2);
   }
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSSolver.h
@@ -20,19 +20,25 @@
 #include <memory>
 #include <set>
 
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h"
 #include "phasar/PhasarLLVM/Utils/BinaryDomain.h"
 
 namespace psr {
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename I>
-class IFDSSolver : public IDESolver<N, D, F, T, V, BinaryDomain, I> {
-public:
-  using ProblemTy = IFDSTabulationProblem<N, D, F, T, V, I>;
+template <typename OriginalAnalysisDomain> struct AnalysisDomainExtender;
 
-  IFDSSolver(IFDSTabulationProblem<N, D, F, T, V, I> &ifdsProblem)
-      : IDESolver<N, D, F, T, V, BinaryDomain, I>(ifdsProblem) {}
+template <typename AnalysisDomainTy>
+class IFDSSolver : public IDESolver<AnalysisDomainExtender<AnalysisDomainTy>> {
+public:
+  using ProblemTy = IFDSTabulationProblem<AnalysisDomainTy>;
+  using D = typename AnalysisDomainTy::d_t;
+  using N = typename AnalysisDomainTy::n_t;
+
+  IFDSSolver(IFDSTabulationProblem<AnalysisDomainTy> &ifdsProblem)
+      : IDESolver<AnalysisDomainExtender<AnalysisDomainTy>>(ifdsProblem) {}
 
   ~IFDSSolver() override = default;
 
@@ -47,15 +53,10 @@ public:
 };
 
 template <typename Problem>
-IFDSSolver(Problem &)
-    -> IFDSSolver<typename Problem::n_t, typename Problem::d_t,
-                  typename Problem::f_t, typename Problem::t_t,
-                  typename Problem::v_t, typename Problem::i_t>;
+IFDSSolver(Problem &) -> IFDSSolver<typename Problem::ProblemAnalysisDomain>;
 
 template <typename Problem>
-using IFDSSolver_P = IFDSSolver<typename Problem::n_t, typename Problem::d_t,
-                                typename Problem::f_t, typename Problem::t_t,
-                                typename Problem::v_t, typename Problem::i_t>;
+using IFDSSolver_P = IFDSSolver<typename Problem::ProblemAnalysisDomain>;
 
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
@@ -24,24 +24,50 @@ namespace psr {
 
 extern const std::shared_ptr<AllBottom<BinaryDomain>> ALLBOTTOM;
 
+template <typename OriginalAnalysisDomain>
+struct AnalysisDomainExtender : public OriginalAnalysisDomain {
+  // TODO (philipp): should we keep this assert?
+  static_assert(
+      std::is_same<void, typename OriginalAnalysisDomain::l_t>::value ||
+          std::is_same<BinaryDomain,
+                       typename OriginalAnalysisDomain::l_t>::value,
+      "Lattice domain is overwritten here, expected it to be void or "
+      "BinaryDomain but found a different type.");
+  using BaseAnalysisDomain = OriginalAnalysisDomain;
+  using l_t = BinaryDomain;
+};
+
+template <typename, typename = void>
+struct is_analysis_domain_extensions : std::false_type {};
+
+template <typename AnalysisDomainTy>
+struct is_analysis_domain_extensions<
+    AnalysisDomainTy,
+    std::void_t<typename AnalysisDomainTy::BaseAnalysisDomain>>
+    : std::true_type {};
+
 /**
  * This class promotes a given IFDSTabulationProblem to an IDETabulationProblem
  * using a binary domain for the edge functions.
  */
-template <typename N, typename D, typename F, typename T, typename V,
-          typename I, typename Container = std::set<D>>
+template <typename AnalysisDomainTy,
+          typename Container = std::set<typename AnalysisDomainTy::d_t>>
 class IFDSToIDETabulationProblem
-    : public IDETabulationProblem<N, D, F, T, V, BinaryDomain, I, Container> {
-
-  using typename IDETabulationProblem<N, D, F, T, V, BinaryDomain, I,
+    : public IDETabulationProblem<AnalysisDomainExtender<AnalysisDomainTy>,
+                                  Container> {
+  using typename IDETabulationProblem<AnalysisDomainExtender<AnalysisDomainTy>,
                                       Container>::FlowFunctionPtrType;
 
+  using n_t = typename AnalysisDomainExtender<AnalysisDomainTy>::n_t;
+  using f_t = typename AnalysisDomainExtender<AnalysisDomainTy>::f_t;
+  using d_t = typename AnalysisDomainExtender<AnalysisDomainTy>::d_t;
+
 public:
-  IFDSTabulationProblem<N, D, F, T, V, I, Container> &Problem;
+  IFDSTabulationProblem<AnalysisDomainTy, Container> &Problem;
 
   IFDSToIDETabulationProblem(
-      IFDSTabulationProblem<N, D, F, T, V, I> &IFDSProblem)
-      : IDETabulationProblem<N, D, F, T, V, BinaryDomain, I>(
+      IFDSTabulationProblem<AnalysisDomainTy> &IFDSProblem)
+      : IDETabulationProblem<AnalysisDomainExtender<AnalysisDomainTy>>(
             IFDSProblem.getProjectIRDB(), IFDSProblem.getTypeHierarchy(),
             IFDSProblem.getICFG(), IFDSProblem.getPointstoInfo(),
             IFDSProblem.getEntryPoints()),
@@ -49,35 +75,36 @@ public:
     this->ZeroValue = Problem.createZeroValue();
   }
 
-  FlowFunctionPtrType getNormalFlowFunction(N curr, N succ) override {
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override {
     return Problem.getNormalFlowFunction(curr, succ);
   }
 
-  FlowFunctionPtrType getCallFlowFunction(N callStmt, F destFun) override {
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override {
     return Problem.getCallFlowFunction(callStmt, destFun);
   }
 
-  FlowFunctionPtrType getRetFlowFunction(N callSite, F calleeFun, N exitStmt,
-                                         N retSite) override {
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override {
     return Problem.getRetFlowFunction(callSite, calleeFun, exitStmt, retSite);
   }
 
-  FlowFunctionPtrType getCallToRetFlowFunction(N callSite, N retSite,
-                                               std::set<F> callees) override {
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override {
     return Problem.getCallToRetFlowFunction(callSite, retSite, callees);
   }
 
-  FlowFunctionPtrType getSummaryFlowFunction(N callStmt, F destFun) override {
+  FlowFunctionPtrType getSummaryFlowFunction(n_t callStmt,
+                                             f_t destFun) override {
     return Problem.getSummaryFlowFunction(callStmt, destFun);
   }
 
-  std::map<N, std::set<D>> initialSeeds() override {
+  std::map<n_t, std::set<d_t>> initialSeeds() override {
     return Problem.initialSeeds();
   }
 
-  D createZeroValue() const override { return Problem.createZeroValue(); }
+  d_t createZeroValue() const override { return Problem.createZeroValue(); }
 
-  bool isZeroValue(D d) const override { return Problem.isZeroValue(d); }
+  bool isZeroValue(d_t d) const override { return Problem.isZeroValue(d); }
 
   BinaryDomain topElement() override { return BinaryDomain::TOP; }
 
@@ -96,7 +123,7 @@ public:
   }
 
   std::shared_ptr<EdgeFunction<BinaryDomain>>
-  getNormalEdgeFunction(N src, D srcNode, N tgt, D tgtNode) override {
+  getNormalEdgeFunction(n_t src, d_t srcNode, n_t tgt, d_t tgtNode) override {
     if (Problem.isZeroValue(srcNode)) {
       return ALLBOTTOM;
     }
@@ -104,8 +131,8 @@ public:
   }
 
   std::shared_ptr<EdgeFunction<BinaryDomain>>
-  getCallEdgeFunction(N callStmt, D srcNode, F destinationFunction,
-                      D destNode) override {
+  getCallEdgeFunction(n_t callStmt, d_t srcNode, f_t destinationFunction,
+                      d_t destNode) override {
     if (Problem.isZeroValue(srcNode)) {
       return ALLBOTTOM;
     }
@@ -113,8 +140,8 @@ public:
   }
 
   std::shared_ptr<EdgeFunction<BinaryDomain>>
-  getReturnEdgeFunction(N callSite, F calleeFunction, N exitStmt, D exitNode,
-                        N returnSite, D retNode) override {
+  getReturnEdgeFunction(n_t callSite, f_t calleeFunction, n_t exitStmt,
+                        d_t exitNode, n_t returnSite, d_t retNode) override {
     if (Problem.isZeroValue(exitNode)) {
       return ALLBOTTOM;
     }
@@ -122,8 +149,8 @@ public:
   }
 
   std::shared_ptr<EdgeFunction<BinaryDomain>>
-  getCallToRetEdgeFunction(N callStmt, D callNode, N returnSite,
-                           D returnSideNode, std::set<F> callees) override {
+  getCallToRetEdgeFunction(n_t callStmt, d_t callNode, n_t returnSite,
+                           d_t returnSideNode, std::set<f_t> callees) override {
     if (Problem.isZeroValue(callNode)) {
       return ALLBOTTOM;
     }
@@ -131,20 +158,20 @@ public:
   }
 
   std::shared_ptr<EdgeFunction<BinaryDomain>>
-  getSummaryEdgeFunction(N callStmt, D callNode, N retSite,
-                         D retSiteNode) override {
+  getSummaryEdgeFunction(n_t callStmt, d_t callNode, n_t retSite,
+                         d_t retSiteNode) override {
     return EdgeIdentity<BinaryDomain>::getInstance();
   }
 
-  void printNode(std::ostream &os, N n) const override {
+  void printNode(std::ostream &os, n_t n) const override {
     Problem.printNode(os, n);
   }
 
-  void printDataFlowFact(std::ostream &os, D d) const override {
+  void printDataFlowFact(std::ostream &os, d_t d) const override {
     Problem.printDataFlowFact(os, d);
   }
 
-  void printFunction(std::ostream &os, F f) const override {
+  void printFunction(std::ostream &os, f_t f) const override {
     Problem.printFunction(os, f);
   }
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSToIDETabulationProblem.h
@@ -26,7 +26,6 @@ extern const std::shared_ptr<AllBottom<BinaryDomain>> ALLBOTTOM;
 
 template <typename OriginalAnalysisDomain>
 struct AnalysisDomainExtender : public OriginalAnalysisDomain {
-  // TODO (philipp): should we keep this assert?
   static_assert(
       std::is_same<void, typename OriginalAnalysisDomain::l_t>::value ||
           std::is_same<BinaryDomain,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/SpecialSummaries.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/SpecialSummaries.h
@@ -34,8 +34,11 @@
 namespace psr {
 
 template <typename D, typename V = BinaryDomain> class SpecialSummaries {
+  using FlowFunctionType = FlowFunction<D>;
+  using FlowFunctionPtrType = std::shared_ptr<FlowFunction<D>>;
+
 private:
-  std::map<std::string, std::shared_ptr<FlowFunction<D>>> SpecialFlowFunctions;
+  std::map<std::string, FlowFunctionPtrType> SpecialFlowFunctions;
   std::map<std::string, std::shared_ptr<EdgeFunction<V>>> SpecialEdgeFunctions;
   std::vector<std::string> SpecialFunctionNames;
 
@@ -67,7 +70,7 @@ public:
 
   // Returns true, when an existing function is overwritten, false otherwise.
   bool provideSpecialSummary(const std::string &name,
-                             std::shared_ptr<FlowFunction<D>> flowfunction) {
+                             FlowFunctionPtrType flowfunction) {
     bool Override = containsSpecialSummary(name);
     SpecialFlowFunctions[name] = flowfunction;
     return Override;
@@ -75,7 +78,7 @@ public:
 
   // Returns true, when an existing function is overwritten, false otherwise.
   bool provideSpecialSummary(const std::string &name,
-                             std::shared_ptr<FlowFunction<D>> flowfunction,
+                             FlowFunctionPtrType flowfunction,
                              std::shared_ptr<EdgeFunction<V>> edgefunction) {
     bool Override = containsSpecialSummary(name);
     SpecialFlowFunctions[name] = flowfunction;
@@ -91,13 +94,12 @@ public:
     return SpecialFlowFunctions.count(name);
   }
 
-  std::shared_ptr<FlowFunction<D>>
+  FlowFunctionPtrType
   getSpecialFlowFunctionSummary(const llvm::Function *function) {
     return getSpecialFlowFunctionSummary(function->getName().str());
   }
 
-  std::shared_ptr<FlowFunction<D>>
-  getSpecialFlowFunctionSummary(const std::string &name) {
+  FlowFunctionPtrType getSpecialFlowFunctionSummary(const std::string &name) {
     return SpecialFlowFunctions[name];
   }
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/InterMonoProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/InterMonoProblem.h
@@ -29,20 +29,27 @@ template <typename T, typename F> class TypeHierarchy;
 template <typename V, typename N> class PointsToInfo;
 template <typename N, typename F> class ICFG;
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename I>
-class InterMonoProblem : public IntraMonoProblem<N, D, F, T, V, I> {
-  static_assert(std::is_base_of_v<ICFG<N, F>, I>,
+template <typename AnalysisDomainTy>
+class InterMonoProblem : public IntraMonoProblem<AnalysisDomainTy> {
+public:
+  using n_t = typename AnalysisDomainTy::n_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+
+  static_assert(std::is_base_of_v<ICFG<n_t, f_t>, i_t>,
                 "I must implement the ICFG interface!");
 
 protected:
-  const I *ICF;
+  const i_t *ICF;
 
 public:
-  InterMonoProblem(const ProjectIRDB *IRDB, const TypeHierarchy<T, F> *TH,
-                   const I *ICF, const PointsToInfo<V, N> *PT,
+  InterMonoProblem(const ProjectIRDB *IRDB, const TypeHierarchy<t_t, f_t> *TH,
+                   const i_t *ICF, const PointsToInfo<v_t, n_t> *PT,
                    std::set<std::string> EntryPoints = {})
-      : IntraMonoProblem<N, D, F, T, V, I>(IRDB, TH, ICF, PT, EntryPoints),
+      : IntraMonoProblem<AnalysisDomainTy>(IRDB, TH, ICF, PT, EntryPoints),
         ICF(ICF) {}
 
   InterMonoProblem(const InterMonoProblem &copy) = delete;
@@ -50,15 +57,16 @@ public:
   InterMonoProblem &operator=(const InterMonoProblem &copy) = delete;
   InterMonoProblem &operator=(InterMonoProblem &&move) = delete;
 
-  virtual BitVectorSet<D> callFlow(N CallSite, F Callee,
-                                   const BitVectorSet<D> &In) = 0;
-  virtual BitVectorSet<D> returnFlow(N CallSite, F Callee, N ExitStmt,
-                                     N RetSite, const BitVectorSet<D> &In) = 0;
-  virtual BitVectorSet<D> callToRetFlow(N CallSite, N RetSite,
-                                        std::set<F> Callees,
-                                        const BitVectorSet<D> &In) = 0;
+  virtual BitVectorSet<d_t> callFlow(n_t CallSite, f_t Callee,
+                                     const BitVectorSet<d_t> &In) = 0;
+  virtual BitVectorSet<d_t> returnFlow(n_t CallSite, f_t Callee, n_t ExitStmt,
+                                       n_t RetSite,
+                                       const BitVectorSet<d_t> &In) = 0;
+  virtual BitVectorSet<d_t> callToRetFlow(n_t CallSite, n_t RetSite,
+                                          std::set<f_t> Callees,
+                                          const BitVectorSet<d_t> &In) = 0;
 
-  const I *getICFG() const { return ICF; }
+  const i_t *getICFG() const { return ICF; }
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/IntraMonoProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/IntraMonoProblem.h
@@ -36,19 +36,29 @@ template <typename T, typename F> class TypeHierarchy;
 template <typename V, typename N> class PointsToInfo;
 template <typename N, typename F> class CFG;
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename C>
-class IntraMonoProblem : public NodePrinter<N>,
-                         public DataFlowFactPrinter<D>,
-                         public FunctionPrinter<F> {
-  static_assert(std::is_base_of_v<CFG<N, F>, C>,
+template <typename AnalysisDomainTy>
+class IntraMonoProblem : public NodePrinter<AnalysisDomainTy>,
+                         public DataFlowFactPrinter<AnalysisDomainTy>,
+                         public FunctionPrinter<AnalysisDomainTy> {
+public:
+  using n_t = typename AnalysisDomainTy::n_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+  using C =
+      typename AnalysisDomainTy::i_t; // TODO (philipp): why is this named C?
+
+  static_assert(std::is_base_of_v<CFG<n_t, f_t>, C>,
                 "C must implement the CFG interface!");
+
+  using ProblemAnalysisDomain = AnalysisDomainTy;
 
 protected:
   const ProjectIRDB *IRDB;
-  const TypeHierarchy<T, F> *TH;
+  const TypeHierarchy<t_t, f_t> *TH;
   const C *CF;
-  const PointsToInfo<V, N> *PT;
+  const PointsToInfo<v_t, n_t> *PT;
   std::set<std::string> EntryPoints;
   [[maybe_unused]] SoundnessFlag SF = SoundnessFlag::UNUSED;
 
@@ -57,31 +67,31 @@ public:
   // a user problem can override the type of configuration to be used, if any
   using ConfigurationTy = HasNoConfigurationType;
 
-  IntraMonoProblem(const ProjectIRDB *IRDB, const TypeHierarchy<T, F> *TH,
-                   const C *CF, const PointsToInfo<V, N> *PT,
+  IntraMonoProblem(const ProjectIRDB *IRDB, const TypeHierarchy<t_t, f_t> *TH,
+                   const C *CF, const PointsToInfo<v_t, n_t> *PT,
                    std::set<std::string> EntryPoints = {})
       : IRDB(IRDB), TH(TH), CF(CF), PT(PT), EntryPoints(EntryPoints) {}
   ~IntraMonoProblem() override = default;
 
-  virtual BitVectorSet<D> join(const BitVectorSet<D> &Lhs,
-                               const BitVectorSet<D> &Rhs) = 0;
+  virtual BitVectorSet<d_t> join(const BitVectorSet<d_t> &Lhs,
+                                 const BitVectorSet<d_t> &Rhs) = 0;
 
-  virtual bool sqSubSetEqual(const BitVectorSet<D> &Lhs,
-                             const BitVectorSet<D> &Rhs) = 0;
+  virtual bool sqSubSetEqual(const BitVectorSet<d_t> &Lhs,
+                             const BitVectorSet<d_t> &Rhs) = 0;
 
-  virtual BitVectorSet<D> normalFlow(N S, const BitVectorSet<D> &In) = 0;
+  virtual BitVectorSet<d_t> normalFlow(n_t S, const BitVectorSet<d_t> &In) = 0;
 
-  virtual std::unordered_map<N, BitVectorSet<D>> initialSeeds() = 0;
+  virtual std::unordered_map<n_t, BitVectorSet<d_t>> initialSeeds() = 0;
 
   std::set<std::string> getEntryPoints() const { return EntryPoints; }
 
   const ProjectIRDB *getProjectIRDB() const { return IRDB; }
 
-  const TypeHierarchy<T, F> *getTypeHierarchy() const { return TH; }
+  const TypeHierarchy<t_t, f_t> *getTypeHierarchy() const { return TH; }
 
   const C *getCFG() const { return CF; }
 
-  const PointsToInfo<V, N> *getPointstoInfo() const { return PT; }
+  const PointsToInfo<v_t, n_t> *getPointstoInfo() const { return PT; }
 
   virtual bool setSoundnessFlag(SoundnessFlag SF) { return false; }
 };

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.h
@@ -22,7 +22,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/Mono/InterMonoProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/Utils/BitVectorSet.h"
 
 namespace llvm {
@@ -36,20 +38,9 @@ namespace psr {
 
 class LLVMPointsToInfo;
 class LLVMTypeHierarchy;
-class LLVMBasedICFG;
 
-class InterMonoSolverTest
-    : public InterMonoProblem<const llvm::Instruction *, const llvm::Value *,
-                              const llvm::Function *, const llvm::StructType *,
-                              const llvm::Value *, LLVMBasedICFG> {
+class InterMonoSolverTest : public InterMonoProblem<LLVMAnalysisDomainDefault> {
 public:
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   InterMonoSolverTest(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                       const LLVMBasedICFG *ICF, const LLVMPointsToInfo *PT,
                       std::set<std::string> EntryPoints = {});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.h
@@ -23,6 +23,7 @@
 
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/Mono/InterMonoProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Utils/TaintConfiguration.h"
 #include "phasar/Utils/BitVectorSet.h"
 
@@ -39,21 +40,12 @@ class LLVMPointsToInfo;
 class LLVMTypeHierarchy;
 
 class InterMonoTaintAnalysis
-    : public InterMonoProblem<const llvm::Instruction *, const llvm::Value *,
-                              const llvm::Function *, const llvm::StructType *,
-                              const llvm::Value *, LLVMBasedICFG> {
+    : public InterMonoProblem<LLVMAnalysisDomainDefault> {
 private:
   const TaintConfiguration<const llvm::Value *> &TSF;
   std::map<const llvm::Instruction *, std::set<const llvm::Value *>> Leaks;
 
 public:
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
-
   using ConfigurationTy = TaintConfiguration<const llvm::Value *>;
 
   InterMonoTaintAnalysis(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.h
@@ -22,7 +22,10 @@
 #include <unordered_map>
 #include <utility>
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/Mono/IntraMonoProblem.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoFullConstantPropagation.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/Utils/BitVectorSet.h"
 
 namespace llvm {
@@ -36,22 +39,16 @@ namespace psr {
 
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
-class LLVMBasedCFG;
-class LLVMBasedICFG;
+
+struct IntraMonoFullConstantPropagationAnalysisDomain
+    : public LLVMAnalysisDomainDefault {
+  using d_t = std::pair<const llvm::Value *, unsigned>;
+  using i_t = LLVMBasedCFG;
+};
 
 class IntraMonoFullConstantPropagation
-    : public IntraMonoProblem<const llvm::Instruction *,
-                              std::pair<const llvm::Value *, unsigned>,
-                              const llvm::Function *, const llvm::StructType *,
-                              const llvm::Value *, LLVMBasedCFG> {
+    : public IntraMonoProblem<IntraMonoFullConstantPropagationAnalysisDomain> {
 public:
-  typedef const llvm::Instruction *n_t;
-  typedef std::pair<const llvm::Value *, unsigned> d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedCFG i_t;
-
   IntraMonoFullConstantPropagation(const ProjectIRDB *IRDB,
                                    const LLVMTypeHierarchy *TH,
                                    const LLVMBasedCFG *CF,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.h
@@ -21,7 +21,9 @@
 #include <string>
 #include <unordered_map>
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/Mono/IntraMonoProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/Utils/BitVectorSet.h"
 
 namespace llvm {
@@ -33,23 +35,17 @@ class Function;
 
 namespace psr {
 
-class LLVMBasedCFG;
 class LLVMBasedICFG;
 class LLVMTypeHierarchy;
 class LLVMPointsToInfo;
 
-class IntraMonoSolverTest
-    : public IntraMonoProblem<const llvm::Instruction *, const llvm::Value *,
-                              const llvm::Function *, const llvm::StructType *,
-                              const llvm::Value *, LLVMBasedCFG> {
-public:
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedCFG i_t;
+struct IntraMonoSolverTestAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using i_t = LLVMBasedCFG;
+};
 
+class IntraMonoSolverTest
+    : public IntraMonoProblem<IntraMonoSolverTestAnalysisDomain> {
+public:
   IntraMonoSolverTest(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                       const LLVMBasedCFG *CF, const LLVMPointsToInfo *PT,
                       std::set<std::string> EntryPoints = {});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Solver/IntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Solver/IntraMonoSolver.h
@@ -28,16 +28,21 @@
 
 namespace psr {
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename C>
-class IntraMonoSolver {
+template <typename AnalysisDomainTy> class IntraMonoSolver {
 public:
-  using ProblemTy = IntraMonoProblem<N, D, F, T, V, C>;
+  using ProblemTy = IntraMonoProblem<AnalysisDomainTy>;
+  using C =
+      typename AnalysisDomainTy::i_t; // TODO (philipp): why is this named C?
+  using n_t = typename AnalysisDomainTy::n_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
 
 protected:
   ProblemTy &IMProblem;
-  std::deque<std::pair<N, N>> Worklist;
-  std::unordered_map<N, BitVectorSet<D>> Analysis;
+  std::deque<std::pair<n_t, n_t>> Worklist;
+  std::unordered_map<n_t, BitVectorSet<d_t>> Analysis;
   const C *CFG;
 
   void initialize() {
@@ -51,7 +56,7 @@ protected:
                       ControlFlowEdges.end());
       // set all analysis information to the empty set
       for (auto s : CFG->getAllInstructionsOf(Function)) {
-        Analysis.insert(std::make_pair(s, BitVectorSet<D>()));
+        Analysis.insert(std::make_pair(s, BitVectorSet<d_t>()));
       }
     }
     // insert initial seeds
@@ -61,8 +66,7 @@ protected:
   }
 
 public:
-  IntraMonoSolver(IntraMonoProblem<N, D, F, T, V, C> &IMP)
-      : IMProblem(IMP), CFG(IMP.getCFG()) {}
+  IntraMonoSolver(ProblemTy &IMP) : IMProblem(IMP), CFG(IMP.getCFG()) {}
   virtual ~IntraMonoSolver() = default;
   virtual void solve() {
     // step 1: Initalization (of Worklist and Analysis)
@@ -70,11 +74,11 @@ public:
     // step 2: Iteration (updating Worklist and Analysis)
     while (!Worklist.empty()) {
       // std::cout << "worklist size: " << Worklist.size() << "\n";
-      std::pair<N, N> path = Worklist.front();
+      std::pair<n_t, n_t> path = Worklist.front();
       Worklist.pop_front();
-      N src = path.first;
-      N dst = path.second;
-      BitVectorSet<D> Out = IMProblem.normalFlow(src, Analysis[src]);
+      n_t src = path.first;
+      n_t dst = path.second;
+      BitVectorSet<d_t> Out = IMProblem.normalFlow(src, Analysis[src]);
       if (!IMProblem.sqSubSetEqual(Out, Analysis[dst])) {
         Analysis[dst] = IMProblem.join(Analysis[dst], Out);
         for (auto nprimeprime : CFG->getSuccsOf(dst)) {
@@ -90,7 +94,7 @@ public:
     }
   }
 
-  BitVectorSet<D> getResultsAt(N n) { return Analysis[n]; }
+  BitVectorSet<d_t> getResultsAt(n_t n) { return Analysis[n]; }
 
   virtual void dumpResults(std::ostream &OS = std::cout) {
     OS << "Intra-Monotone solver results:\n"
@@ -116,15 +120,11 @@ public:
 
 template <typename Problem>
 IntraMonoSolver(Problem &)
-    -> IntraMonoSolver<typename Problem::n_t, typename Problem::d_t,
-                       typename Problem::f_t, typename Problem::t_t,
-                       typename Problem::v_t, typename Problem::i_t>;
+    -> IntraMonoSolver<typename Problem::ProblemAnalysisDomain>;
 
 template <typename Problem>
 using IntraMonoSolver_P =
-    IntraMonoSolver<typename Problem::n_t, typename Problem::d_t,
-                    typename Problem::f_t, typename Problem::t_t,
-                    typename Problem::v_t, typename Problem::i_t>;
+    IntraMonoSolver<typename Problem::ProblemAnalysisDomain>;
 
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Solver/IntraMonoSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/Mono/Solver/IntraMonoSolver.h
@@ -31,8 +31,7 @@ namespace psr {
 template <typename AnalysisDomainTy> class IntraMonoSolver {
 public:
   using ProblemTy = IntraMonoProblem<AnalysisDomainTy>;
-  using C =
-      typename AnalysisDomainTy::i_t; // TODO (philipp): why is this named C?
+  using c_t = typename AnalysisDomainTy::i_t;
   using n_t = typename AnalysisDomainTy::n_t;
   using d_t = typename AnalysisDomainTy::d_t;
   using f_t = typename AnalysisDomainTy::f_t;
@@ -43,7 +42,7 @@ protected:
   ProblemTy &IMProblem;
   std::deque<std::pair<n_t, n_t>> Worklist;
   std::unordered_map<n_t, BitVectorSet<d_t>> Analysis;
-  const C *CFG;
+  const c_t *CFG;
 
   void initialize() {
     auto EntryPoints = IMProblem.getEntryPoints();

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.h
@@ -16,6 +16,7 @@
 
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Utils/BinaryDomain.h"
 #include "phasar/PhasarLLVM/Utils/Printer.h"
 
@@ -33,19 +34,13 @@ class LLVMPointsToInfo;
 class LLVMTypeHierarchy;
 class ProjectIRDB;
 
-class WPDSAliasCollector
-    : public WPDSProblem<const llvm::Instruction *, const llvm::Value *,
-                         const llvm::Function *, const llvm::StructType *,
-                         const llvm::Value *, BinaryDomain, LLVMBasedICFG> {
-public:
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef BinaryDomain l_t;
-  typedef const llvm::Value *v_t;
-  typedef LLVMBasedICFG i_t;
+struct WPDSAliasCollectorAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = BinaryDomain;
+};
 
+class WPDSAliasCollector
+    : public WPDSProblem<WPDSAliasCollectorAnalysisDomain> {
+public:
   WPDSAliasCollector(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                      const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                      std::set<std::string> EntryPoints);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.h
@@ -47,19 +47,13 @@ public:
 
   ~WPDSAliasCollector() override = default;
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t curr, f_t destFun) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t curr, f_t destFun) override;
 
   std::shared_ptr<EdgeFunction<l_t>>
   getNormalEdgeFunction(n_t curr, d_t currNode, n_t succ,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSLinearConstantAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSLinearConstantAnalysis.h
@@ -15,6 +15,7 @@
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace llvm {
 class Value;
@@ -30,11 +31,12 @@ class LLVMPointsToInfo;
 class LLVMTypeHierarchy;
 class ProjectIRDB;
 
+struct WPDSLinearConstantAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = int64_t;
+};
+
 class WPDSLinearConstantAnalysis
-    : public virtual WPDSProblem<const llvm::Instruction *, const llvm::Value *,
-                                 const llvm::Function *,
-                                 const llvm::StructType *, const llvm::Value *,
-                                 int64_t, LLVMBasedICFG>,
+    : public virtual WPDSProblem<WPDSLinearConstantAnalysisDomain>,
       public virtual IDELinearConstantAnalysis {
 public:
   WPDSLinearConstantAnalysis(const ProjectIRDB *IRDB,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.h
@@ -42,19 +42,13 @@ public:
                  const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                  std::set<std::string> EntryPoints = {"main"});
 
-  std::shared_ptr<FlowFunction<d_t>> getNormalFlowFunction(n_t curr,
-                                                           n_t succ) override;
-  std::shared_ptr<FlowFunction<d_t>> getCallFlowFunction(n_t callStmt,
-                                                         f_t destFun) override;
-  std::shared_ptr<FlowFunction<d_t>> getRetFlowFunction(n_t callSite,
-                                                        f_t calleeFun,
-                                                        n_t exitStmt,
-                                                        n_t retSite) override;
-  std::shared_ptr<FlowFunction<d_t>>
-  getCallToRetFlowFunction(n_t callSite, n_t retSite,
-                           std::set<f_t> callees) override;
-  std::shared_ptr<FlowFunction<d_t>>
-  getSummaryFlowFunction(n_t curr, f_t destFun) override;
+  FlowFunctionPtrType getNormalFlowFunction(n_t curr, n_t succ) override;
+  FlowFunctionPtrType getCallFlowFunction(n_t callStmt, f_t destFun) override;
+  FlowFunctionPtrType getRetFlowFunction(n_t callSite, f_t calleeFun,
+                                         n_t exitStmt, n_t retSite) override;
+  FlowFunctionPtrType getCallToRetFlowFunction(n_t callSite, n_t retSite,
+                                               std::set<f_t> callees) override;
+  FlowFunctionPtrType getSummaryFlowFunction(n_t curr, f_t destFun) override;
 
   std::shared_ptr<EdgeFunction<l_t>>
   getNormalEdgeFunction(n_t curr, d_t currNode, n_t succ,

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.h
@@ -14,6 +14,7 @@
 
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSProblem.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Utils/BinaryDomain.h"
 #include "phasar/PhasarLLVM/Utils/Printer.h"
 
@@ -31,19 +32,12 @@ class LLVMPointsToInfo;
 class LLVMTypeHierarchy;
 class ProjectIRDB;
 
-class WPDSSolverTest
-    : public WPDSProblem<const llvm::Instruction *, const llvm::Value *,
-                         const llvm::Function *, const llvm::StructType *,
-                         const llvm::Value *, BinaryDomain, LLVMBasedICFG> {
-public:
-  typedef const llvm::Instruction *n_t;
-  typedef const llvm::Value *d_t;
-  typedef const llvm::Function *f_t;
-  typedef const llvm::StructType *t_t;
-  typedef const llvm::Value *v_t;
-  typedef BinaryDomain l_t;
-  typedef LLVMBasedICFG i_t;
+struct WPDSSolverTestAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = BinaryDomain;
+};
 
+class WPDSSolverTest : public WPDSProblem<WPDSSolverTestAnalysisDomain> {
+public:
   WPDSSolverTest(const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
                  const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                  std::set<std::string> EntryPoints = {"main"});

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
@@ -202,7 +202,7 @@ public:
     EdgeFunctionPtrType f = IDESolver<AnalysisDomainTy>::jumpFunction(edge);
     auto successorInst = IDESolver<AnalysisDomainTy>::ICF->getSuccsOf(n);
     for (auto f : successorInst) {
-      std::shared_ptr<FlowFunction<d_t>> flowFunction =
+      FlowFunctionPtrType flowFunction =
           IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
               .getNormalFlowFunction(n, f);
       INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -274,7 +274,7 @@ public:
     // for each possible callee
     for (f_t sCalledProcN : callees) { // still line 14
       // check if a special summary for the called procedure exists
-      std::shared_ptr<FlowFunction<d_t>> specialSum =
+      FlowFunctionPtrType specialSum =
           IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
               .getSummaryFlowFunction(n, sCalledProcN);
       // if a special summary is available, treat this as a normal flow
@@ -308,7 +308,7 @@ public:
         }
       } else {
         // compute the call-flow function
-        std::shared_ptr<FlowFunction<d_t>> function =
+        FlowFunctionPtrType function =
             IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getCallFlowFunction(n, sCalledProcN);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -363,7 +363,7 @@ public:
               // for each return site
               for (n_t retSiteN : returnSiteNs) {
                 // compute return-flow function
-                std::shared_ptr<FlowFunction<d_t>> retFunction =
+                FlowFunctionPtrType retFunction =
                     IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                         .getRetFlowFunction(n, sCalledProcN, eP, retSiteN);
                 INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -461,7 +461,7 @@ public:
       // line 17-19 of Naeem/Lhotak/Rodriguez
       // process intra-procedural flows along call-to-return flow functions
       for (n_t returnSiteN : returnSiteNs) {
-        std::shared_ptr<FlowFunction<d_t>> callToReturnFlowFunction =
+        FlowFunctionPtrType callToReturnFlowFunction =
             IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getCallToRetFlowFunction(n, returnSiteN, callees);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -543,7 +543,7 @@ public:
       for (n_t retSiteC :
            IDESolver<AnalysisDomainTy>::ICF->getReturnSitesOfCallAt(c)) {
         // compute return-flow function
-        std::shared_ptr<FlowFunction<d_t>> retFunction =
+        FlowFunctionPtrType retFunction =
             IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getRetFlowFunction(c, functionThatNeedsSummary, n, retSiteC);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -639,7 +639,7 @@ public:
       for (n_t c : callers) {
         for (n_t retSiteC :
              IDESolver<AnalysisDomainTy>::ICF->getReturnSitesOfCallAt(c)) {
-          std::shared_ptr<FlowFunction<d_t>> retFunction =
+          FlowFunctionPtrType retFunction =
               IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                   .getRetFlowFunction(c, functionThatNeedsSummary, n, retSiteC);
           INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -673,7 +673,7 @@ public:
       // the flow function has a side effect such as registering a taint;
       // instead we thus call the return flow function will a null caller
       if (callers.empty()) {
-        std::shared_ptr<FlowFunction<d_t>> retFunction =
+        FlowFunctionPtrType retFunction =
             IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getRetFlowFunction(nullptr, functionThatNeedsSummary, n,
                                     nullptr);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
@@ -48,22 +48,32 @@ class CallInst;
 
 namespace psr {
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename L, typename I>
-class WPDSSolver : public IDESolver<N, D, F, T, V, L, I> {
+template <typename AnalysisDomainTy>
+class WPDSSolver : public IDESolver<AnalysisDomainTy> {
+public:
+  using typename IDESolver<AnalysisDomainTy>::EdgeFunctionPtrType;
+
+  using l_t = typename AnalysisDomainTy::l_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+
 private:
-  WPDSProblem<N, D, F, T, V, L, I> &Problem;
+  WPDSProblem<AnalysisDomainTy> &Problem;
   WPDSSolverConfig SolverConf;
-  std::vector<N> Stack;
+  std::vector<n_t> Stack;
   std::unique_ptr<wali::wpds::WPDS> PDS;
-  D ZeroValue;
+  d_t ZeroValue;
   wali::Key ZeroPDSState;
   wali::Key AcceptingState;
-  std::unordered_map<D, wali::Key> DKey;
+  std::unordered_map<d_t, wali::Key> DKey;
   wali::wfa::WFA Query;
   wali::wfa::WFA Answer;
   wali::sem_elem_t SRElem;
-  Table<N, D, std::map<N, std::set<D>>> incomingtab;
+  Table<n_t, d_t, std::map<n_t, std::set<d_t>>> incomingtab;
 
   wali::wpds::WPDS *makePDS(WPDSType Ty, bool Witnesses) {
     wali::wpds::Wrapper *Wrapper =
@@ -89,10 +99,8 @@ private:
   }
 
 public:
-  using typename IDESolver<N, D, F, T, V, L, I>::EdgeFunctionPtrType;
-
-  WPDSSolver(WPDSProblem<N, D, F, T, V, L, I> &Problem)
-      : IDESolver<N, D, F, T, V, L, I>(Problem), Problem(Problem),
+  WPDSSolver(WPDSProblem<AnalysisDomainTy> &Problem)
+      : IDESolver<AnalysisDomainTy>(Problem), Problem(Problem),
         SolverConf(Problem.getWPDSSolverConfig()),
         PDS(makePDS(SolverConf.wpdsty, SolverConf.recordWitnesses)),
         ZeroValue(Problem.getZeroValue()),
@@ -105,7 +113,7 @@ public:
   void solve() override {
 
     // Construct the PDS
-    IDESolver<N, D, F, T, V, L, I>::submitInitalSeeds();
+    IDESolver<AnalysisDomainTy>::submitInitalSeeds();
     std::ofstream pdsfile("pds.dot");
     PDS->print_dot(pdsfile, true);
     pdsfile.flush();
@@ -132,7 +140,7 @@ public:
       // }
     } else {
       auto retnode =
-          wali::getKey(&IDESolver<N, D, F, T, V, L, I>::ICF->getFunction("main")
+          wali::getKey(&IDESolver<AnalysisDomainTy>::ICF->getFunction("main")
                             ->back()
                             .back());
       LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << "BACKWARD");
@@ -142,16 +150,16 @@ public:
       // access the results
       // wali::wfa::Trans goal;
       // // check all data-flow facts
-      // std::cout << "All D(s)" << std::endl;
+      // std::cout << "All d_t(s)" << std::endl;
       // for (auto Entry : DKey) {
       //   if (Answer.find(Entry.second, retnode, AcceptingState, goal)) {
       //     std::cout << "FOUND ANSWER!" << std::endl;
       //     std::cout << llvmIRToString(Entry.first);
       //     goal.weight()->print(std::cout << " :--- weight ---: ");
       //     std::cout << " : --- "
-      //               << static_cast<JoinLatticeToSemiRingElem<L>
+      //               << static_cast<JoinLatticeToSemiRingElem<l_t>
       //               &>(*goal.weight())
-      //                      .F->computeTarget(L{});
+      //                      .F->computeTarget(l_t{});
       //     std::cout << std::endl;
       //   }
       // }
@@ -175,38 +183,38 @@ public:
       // // std::cout << llvmIRToString(alloca1);
       // ret->print(std::cout << " :--- weight ---: ");
       // std::cout << " : --- "
-      //           << static_cast<JoinLatticeToSemiRingElem<L>
-      //           &>(*ret).F->computeTarget(L{});
+      //           << static_cast<JoinLatticeToSemiRingElem<l_t>
+      //           &>(*ret).F->computeTarget(l_t{});
       // std::cout << std::endl;
     }
   }
 
-  void processNormalFlow(PathEdge<N, D> edge) override {
+  void processNormalFlow(PathEdge<n_t, d_t> edge) override {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << "WPDS::processNormal");
     PAMM_GET_INSTANCE;
     INC_COUNTER("Process Normal", 1, PAMM_SEVERITY_LEVEL::Full);
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "Process normal at target: "
                   << this->ideTabulationProblem.NtoString(edge.getTarget()));
-    D d1 = edge.factAtSource();
-    N n = edge.getTarget();
-    D d2 = edge.factAtTarget();
-    EdgeFunctionPtrType f = IDESolver<N, D, F, T, V, L, I>::jumpFunction(edge);
-    auto successorInst = IDESolver<N, D, F, T, V, L, I>::ICF->getSuccsOf(n);
+    d_t d1 = edge.factAtSource();
+    n_t n = edge.getTarget();
+    d_t d2 = edge.factAtTarget();
+    EdgeFunctionPtrType f = IDESolver<AnalysisDomainTy>::jumpFunction(edge);
+    auto successorInst = IDESolver<AnalysisDomainTy>::ICF->getSuccsOf(n);
     for (auto f : successorInst) {
-      std::shared_ptr<FlowFunction<D>> flowFunction =
-          IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+      std::shared_ptr<FlowFunction<d_t>> flowFunction =
+          IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
               .getNormalFlowFunction(n, f);
       INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-      std::set<D> res =
-          IDESolver<N, D, F, T, V, L, I>::computeNormalFlowFunction(
-              flowFunction, d1, d2);
+      std::set<d_t> res =
+          IDESolver<AnalysisDomainTy>::computeNormalFlowFunction(flowFunction,
+                                                                 d1, d2);
       ADD_TO_HISTOGRAM("Data-flow facts", res.size(), 1,
                        PAMM_SEVERITY_LEVEL::Full);
-      IDESolver<N, D, F, T, V, L, I>::saveEdges(n, f, d2, res, false);
-      for (D d3 : res) {
+      IDESolver<AnalysisDomainTy>::saveEdges(n, f, d2, res, false);
+      for (d_t d3 : res) {
         EdgeFunctionPtrType g =
-            IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+            IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getNormalEdgeFunction(n, d2, f, d3);
         // add normal PDS rule
         auto d2_k = wali::getKey(d2);
@@ -215,9 +223,9 @@ public:
         DKey[d3] = d3_k;
         auto n_k = wali::getKey(n);
         auto f_k = wali::getKey(f);
-        wali::ref_ptr<JoinLatticeToSemiRingElem<L>> wptr;
-        wptr = new JoinLatticeToSemiRingElem<L>(
-            g, static_cast<JoinLattice<L> &>(Problem));
+        wali::ref_ptr<JoinLatticeToSemiRingElem<l_t>> wptr;
+        wptr = new JoinLatticeToSemiRingElem<l_t>(
+            g, static_cast<JoinLattice<l_t> &>(Problem));
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "ADD NORMAL RULE: " << Problem.DtoString(d2) << " | "
                       << Problem.NtoString(n) << " --> "
@@ -232,27 +240,27 @@ public:
                       << "Compose: " << g->str() << " * " << f->str());
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
         INC_COUNTER("EF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-        IDESolver<N, D, F, T, V, L, I>::propagate(d1, f, d3, fprime, nullptr,
-                                                  false);
+        IDESolver<AnalysisDomainTy>::propagate(d1, f, d3, fprime, nullptr,
+                                               false);
       }
     }
   }
 
-  void processCall(PathEdge<N, D> edge) override {
+  void processCall(PathEdge<n_t, d_t> edge) override {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << "WPDS::processCall");
     PAMM_GET_INSTANCE;
     INC_COUNTER("Process Call", 1, PAMM_SEVERITY_LEVEL::Full);
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "Process call at target: "
                   << this->ideTabulationProblem.NtoString(edge.getTarget()));
-    D d1 = edge.factAtSource();
-    N n = edge.getTarget(); // a call node; line 14...
-    D d2 = edge.factAtTarget();
-    EdgeFunctionPtrType f = IDESolver<N, D, F, T, V, L, I>::jumpFunction(edge);
-    std::set<N> returnSiteNs =
-        IDESolver<N, D, F, T, V, L, I>::ICF->getReturnSitesOfCallAt(n);
-    std::set<F> callees =
-        IDESolver<N, D, F, T, V, L, I>::ICF->getCalleesOfCallAt(n);
+    d_t d1 = edge.factAtSource();
+    n_t n = edge.getTarget(); // a call node; line 14...
+    d_t d2 = edge.factAtTarget();
+    EdgeFunctionPtrType f = IDESolver<AnalysisDomainTy>::jumpFunction(edge);
+    std::set<n_t> returnSiteNs =
+        IDESolver<AnalysisDomainTy>::ICF->getReturnSitesOfCallAt(n);
+    std::set<f_t> callees =
+        IDESolver<AnalysisDomainTy>::ICF->getCalleesOfCallAt(n);
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << "Possible callees:");
     for (auto callee : callees) {
       LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
@@ -264,29 +272,29 @@ public:
                     << "  " << this->ideTabulationProblem.NtoString(ret));
     }
     // for each possible callee
-    for (F sCalledProcN : callees) { // still line 14
+    for (f_t sCalledProcN : callees) { // still line 14
       // check if a special summary for the called procedure exists
-      std::shared_ptr<FlowFunction<D>> specialSum =
-          IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+      std::shared_ptr<FlowFunction<d_t>> specialSum =
+          IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
               .getSummaryFlowFunction(n, sCalledProcN);
       // if a special summary is available, treat this as a normal flow
       // and use the summary flow and edge functions
       if (specialSum) {
         LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Found and process special summary");
-        for (N returnSiteN : returnSiteNs) {
-          std::set<D> res =
-              IDESolver<N, D, F, T, V, L, I>::computeSummaryFlowFunction(
+        for (n_t returnSiteN : returnSiteNs) {
+          std::set<d_t> res =
+              IDESolver<AnalysisDomainTy>::computeSummaryFlowFunction(
                   specialSum, d1, d2);
           INC_COUNTER("SpecialSummary-FF Application", 1,
                       PAMM_SEVERITY_LEVEL::Full);
           ADD_TO_HISTOGRAM("Data-flow facts", res.size(), 1,
                            PAMM_SEVERITY_LEVEL::Full);
-          IDESolver<N, D, F, T, V, L, I>::saveEdges(n, returnSiteN, d2, res,
-                                                    false);
-          for (D d3 : res) {
+          IDESolver<AnalysisDomainTy>::saveEdges(n, returnSiteN, d2, res,
+                                                 false);
+          for (d_t d3 : res) {
             EdgeFunctionPtrType sumEdgFnE =
-                IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                     .getSummaryEdgeFunction(n, d2, returnSiteN, d3);
             INC_COUNTER("SpecialSummary-EF Queries", 1,
                         PAMM_SEVERITY_LEVEL::Full);
@@ -294,24 +302,24 @@ public:
                           << "Compose: " << sumEdgFnE->str() << " * "
                           << f->str());
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-            IDESolver<N, D, F, T, V, L, I>::propagate(
+            IDESolver<AnalysisDomainTy>::propagate(
                 d1, returnSiteN, d3, f->composeWith(sumEdgFnE), n, false);
           }
         }
       } else {
         // compute the call-flow function
-        std::shared_ptr<FlowFunction<D>> function =
-            IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+        std::shared_ptr<FlowFunction<d_t>> function =
+            IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getCallFlowFunction(n, sCalledProcN);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-        std::set<D> res =
-            IDESolver<N, D, F, T, V, L, I>::computeCallFlowFunction(function,
-                                                                    d1, d2);
+        std::set<d_t> res =
+            IDESolver<AnalysisDomainTy>::computeCallFlowFunction(function, d1,
+                                                                 d2);
         ADD_TO_HISTOGRAM("Data-flow facts", res.size(), 1,
                          PAMM_SEVERITY_LEVEL::Full);
         // for each callee's start point(s)
-        std::set<N> startPointsOf =
-            IDESolver<N, D, F, T, V, L, I>::ICF->getStartPointsOf(sCalledProcN);
+        std::set<n_t> startPointsOf =
+            IDESolver<AnalysisDomainTy>::ICF->getStartPointsOf(sCalledProcN);
         if (startPointsOf.empty()) {
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                         << "Start points of '" +
@@ -319,22 +327,23 @@ public:
                                "' currently not available!");
         }
         // if startPointsOf is empty, the called function is a declaration
-        for (N sP : startPointsOf) {
-          IDESolver<N, D, F, T, V, L, I>::saveEdges(n, sP, d2, res, true);
+        for (n_t sP : startPointsOf) {
+          IDESolver<AnalysisDomainTy>::saveEdges(n, sP, d2, res, true);
           // for each result node of the call-flow function
-          for (D d3 : res) {
+          for (d_t d3 : res) {
             // create initial self-loop
-            IDESolver<N, D, F, T, V, L, I>::propagate(
-                d3, sP, d3, EdgeIdentity<L>::getInstance(), n,
+            IDESolver<AnalysisDomainTy>::propagate(
+                d3, sP, d3, EdgeIdentity<l_t>::getInstance(), n,
                 false); // line 15
             // register the fact that <sp,d3> has an incoming edge from <n,d2>
             // line 15.1 of Naeem/Lhotak/Rodriguez
-            IDESolver<N, D, F, T, V, L, I>::addIncoming(sP, d3, n, d2);
+            IDESolver<AnalysisDomainTy>::addIncoming(sP, d3, n, d2);
             // line 15.2, copy to avoid concurrent modification exceptions by
             // other threads
-            std::set<typename Table<N, D, EdgeFunctionPtrType>::Cell> endSumm =
-                std::set<typename Table<N, D, EdgeFunctionPtrType>::Cell>(
-                    IDESolver<N, D, F, T, V, L, I>::endSummary(sP, d3));
+            std::set<typename Table<n_t, d_t, EdgeFunctionPtrType>::Cell>
+                endSumm = std::set<
+                    typename Table<n_t, d_t, EdgeFunctionPtrType>::Cell>(
+                    IDESolver<AnalysisDomainTy>::endSummary(sP, d3));
             // std::cout << "ENDSUMM" << std::endl;
             // std::cout << "Size: " << endSumm.size() << std::endl;
             // std::cout << "sP: " << ideTabulationProblem.NtoString(sP)
@@ -346,31 +355,31 @@ public:
             // <sP,d3>, create new caller-side jump functions to the return
             // sites because we have observed a potentially new incoming
             // edge into <sP,d3>
-            for (typename Table<N, D, EdgeFunctionPtrType>::Cell entry :
+            for (typename Table<n_t, d_t, EdgeFunctionPtrType>::Cell entry :
                  endSumm) {
-              N eP = entry.getRowKey();
-              D d4 = entry.getColumnKey();
+              n_t eP = entry.getRowKey();
+              d_t d4 = entry.getColumnKey();
               EdgeFunctionPtrType fCalleeSummary = entry.getValue();
               // for each return site
-              for (N retSiteN : returnSiteNs) {
+              for (n_t retSiteN : returnSiteNs) {
                 // compute return-flow function
-                std::shared_ptr<FlowFunction<D>> retFunction =
-                    IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                std::shared_ptr<FlowFunction<d_t>> retFunction =
+                    IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                         .getRetFlowFunction(n, sCalledProcN, eP, retSiteN);
                 INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-                std::set<D> returnedFacts =
-                    IDESolver<N, D, F, T, V, L, I>::computeReturnFlowFunction(
-                        retFunction, d3, d4, n, std::set<D>{d2});
+                std::set<d_t> returnedFacts =
+                    IDESolver<AnalysisDomainTy>::computeReturnFlowFunction(
+                        retFunction, d3, d4, n, std::set<d_t>{d2});
                 ADD_TO_HISTOGRAM("Data-flow facts", returnedFacts.size(), 1,
                                  PAMM_SEVERITY_LEVEL::Full);
-                IDESolver<N, D, F, T, V, L, I>::saveEdges(eP, retSiteN, d4,
-                                                          returnedFacts, true);
+                IDESolver<AnalysisDomainTy>::saveEdges(eP, retSiteN, d4,
+                                                       returnedFacts, true);
                 // for each target value of the function
-                for (D d5 : returnedFacts) {
+                for (d_t d5 : returnedFacts) {
                   // update the caller-side summary function
                   // get call edge function
                   EdgeFunctionPtrType f4 =
-                      IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                      IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                           .getCallEdgeFunction(n, d2, sCalledProcN, d3);
                   // add call PDS rule
                   auto d2_k = wali::getKey(d2);
@@ -379,9 +388,9 @@ public:
                   DKey[d3] = d3_k;
                   auto n_k = wali::getKey(n);
                   auto sP_k = wali::getKey(sP);
-                  wali::ref_ptr<JoinLatticeToSemiRingElem<L>> wptrCall(
-                      new JoinLatticeToSemiRingElem<L>(
-                          f4, static_cast<JoinLattice<L> &>(Problem)));
+                  wali::ref_ptr<JoinLatticeToSemiRingElem<l_t>> wptrCall(
+                      new JoinLatticeToSemiRingElem<l_t>(
+                          f4, static_cast<JoinLattice<l_t> &>(Problem)));
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                                 << "ADD CALL RULE: " << Problem.DtoString(d2)
                                 << ", " << Problem.NtoString(n) << ", "
@@ -394,7 +403,7 @@ public:
                   }
                   // get return edge function
                   EdgeFunctionPtrType f5 =
-                      IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                      IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                           .getReturnEdgeFunction(n, sCalledProcN, eP, d4,
                                                  retSiteN, d5);
                   // add ret PDS rule
@@ -402,18 +411,17 @@ public:
                   DKey[d4] = d4_k;
                   auto d5_k = wali::getKey(d5);
                   DKey[d5] = d5_k;
-                  wali::ref_ptr<JoinLatticeToSemiRingElem<L>> wptrRet(
-                      new JoinLatticeToSemiRingElem<L>(
-                          f5, static_cast<JoinLattice<L> &>(Problem)));
+                  wali::ref_ptr<JoinLatticeToSemiRingElem<l_t>> wptrRet(
+                      new JoinLatticeToSemiRingElem<l_t>(
+                          f5, static_cast<JoinLattice<l_t> &>(Problem)));
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                                 << "ADD RET RULE (CALL): "
                                 << Problem.DtoString(d4) << ", "
                                 << Problem.NtoString(retSiteN) << ", "
                                 << Problem.DtoString(d5) << ", " << *wptrRet);
-                  std::set<N> exitPointsN =
-                      IDESolver<N, D, F, T, V, L, I>::ICF->getExitPointsOf(
-                          IDESolver<N, D, F, T, V, L, I>::ICF->getFunctionOf(
-                              sP));
+                  std::set<n_t> exitPointsN =
+                      IDESolver<AnalysisDomainTy>::ICF->getExitPointsOf(
+                          IDESolver<AnalysisDomainTy>::ICF->getFunctionOf(sP));
                   for (auto exitPointN : exitPointsN) {
                     auto exitPointN_k = wali::getKey(exitPointN);
                     PDS->add_rule(d4_k, exitPointN_k, d5_k, wptrRet);
@@ -433,15 +441,15 @@ public:
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                                 << "       = " << fPrime->str());
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-                  D d5_restoredCtx =
-                      IDESolver<N, D, F, T, V, L,
-                                I>::restoreContextOnReturnedFact(n, d2, d5);
+                  d_t d5_restoredCtx =
+                      IDESolver<AnalysisDomainTy>::restoreContextOnReturnedFact(
+                          n, d2, d5);
                   // propagte the effects of the entire call
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                                 << "Compose: " << fPrime->str() << " * "
                                 << f->str());
                   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-                  IDESolver<N, D, F, T, V, L, I>::propagate(
+                  IDESolver<AnalysisDomainTy>::propagate(
                       d1, retSiteN, d5_restoredCtx, f->composeWith(fPrime), n,
                       false);
                 }
@@ -452,21 +460,21 @@ public:
       }
       // line 17-19 of Naeem/Lhotak/Rodriguez
       // process intra-procedural flows along call-to-return flow functions
-      for (N returnSiteN : returnSiteNs) {
-        std::shared_ptr<FlowFunction<D>> callToReturnFlowFunction =
-            IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+      for (n_t returnSiteN : returnSiteNs) {
+        std::shared_ptr<FlowFunction<d_t>> callToReturnFlowFunction =
+            IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getCallToRetFlowFunction(n, returnSiteN, callees);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-        std::set<D> returnFacts =
-            IDESolver<N, D, F, T, V, L, I>::computeCallToReturnFlowFunction(
+        std::set<d_t> returnFacts =
+            IDESolver<AnalysisDomainTy>::computeCallToReturnFlowFunction(
                 callToReturnFlowFunction, d1, d2);
         ADD_TO_HISTOGRAM("Data-flow facts", returnFacts.size(), 1,
                          PAMM_SEVERITY_LEVEL::Full);
-        IDESolver<N, D, F, T, V, L, I>::saveEdges(n, returnSiteN, d2,
-                                                  returnFacts, false);
-        for (D d3 : returnFacts) {
+        IDESolver<AnalysisDomainTy>::saveEdges(n, returnSiteN, d2, returnFacts,
+                                               false);
+        for (d_t d3 : returnFacts) {
           EdgeFunctionPtrType edgeFnE =
-              IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+              IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                   .getCallToRetEdgeFunction(n, d2, returnSiteN, d3, callees);
           // add calltoret PDS rule
           auto d2_k = wali::getKey(d2);
@@ -475,9 +483,9 @@ public:
           DKey[d3] = d3_k;
           auto n_k = wali::getKey(n);
           auto returnSiteN_k = wali::getKey(returnSiteN);
-          wali::ref_ptr<JoinLatticeToSemiRingElem<L>> wptr(
-              new JoinLatticeToSemiRingElem<L>(
-                  edgeFnE, static_cast<JoinLattice<L> &>(Problem)));
+          wali::ref_ptr<JoinLatticeToSemiRingElem<l_t>> wptr(
+              new JoinLatticeToSemiRingElem<l_t>(
+                  edgeFnE, static_cast<JoinLattice<l_t> &>(Problem)));
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                         << "ADD CALLTORET RULE: " << Problem.DtoString(d2)
                         << " | " << Problem.NtoString(n) << " --> "
@@ -491,81 +499,79 @@ public:
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                         << "Compose: " << edgeFnE->str() << " * " << f->str());
           LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-          IDESolver<N, D, F, T, V, L, I>::propagate(
+          IDESolver<AnalysisDomainTy>::propagate(
               d1, returnSiteN, d3, f->composeWith(edgeFnE), n, false);
         }
       }
     }
   }
 
-  void processExit(PathEdge<N, D> edge) override {
+  void processExit(PathEdge<n_t, d_t> edge) override {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << "WPDS::processExit");
     PAMM_GET_INSTANCE;
     INC_COUNTER("Process Exit", 1, PAMM_SEVERITY_LEVEL::Full);
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "Process exit at target: "
                   << this->ideTabulationProblem.NtoString(edge.getTarget()));
-    N n = edge.getTarget(); // an exit node; line 21...
-    EdgeFunctionPtrType f = IDESolver<N, D, F, T, V, L, I>::jumpFunction(edge);
-    F functionThatNeedsSummary =
-        IDESolver<N, D, F, T, V, L, I>::ICF->getFunctionOf(n);
-    D d1 = edge.factAtSource();
-    D d2 = edge.factAtTarget();
+    n_t n = edge.getTarget(); // an exit node; line 21...
+    EdgeFunctionPtrType f = IDESolver<AnalysisDomainTy>::jumpFunction(edge);
+    f_t functionThatNeedsSummary =
+        IDESolver<AnalysisDomainTy>::ICF->getFunctionOf(n);
+    d_t d1 = edge.factAtSource();
+    d_t d2 = edge.factAtTarget();
     // for each of the method's start points, determine incoming calls
-    std::set<N> startPointsOf =
-        IDESolver<N, D, F, T, V, L, I>::ICF->getStartPointsOf(
+    std::set<n_t> startPointsOf =
+        IDESolver<AnalysisDomainTy>::ICF->getStartPointsOf(
             functionThatNeedsSummary);
-    std::map<N, std::set<D>> inc;
-    for (N sP : startPointsOf) {
+    std::map<n_t, std::set<d_t>> inc;
+    for (n_t sP : startPointsOf) {
       // line 21.1 of Naeem/Lhotak/Rodriguez
       // register end-summary
-      IDESolver<N, D, F, T, V, L, I>::addEndSummary(sP, d1, n, d2, f);
-      for (auto entry : IDESolver<N, D, F, T, V, L, I>::incoming(d1, sP)) {
-        inc[entry.first] = std::set<D>{entry.second};
+      IDESolver<AnalysisDomainTy>::addEndSummary(sP, d1, n, d2, f);
+      for (auto entry : IDESolver<AnalysisDomainTy>::incoming(d1, sP)) {
+        inc[entry.first] = std::set<d_t>{entry.second};
       }
     }
-    IDESolver<N, D, F, T, V, L, I>::printEndSummaryTab();
-    IDESolver<N, D, F, T, V, L, I>::printIncomingTab();
+    IDESolver<AnalysisDomainTy>::printEndSummaryTab();
+    IDESolver<AnalysisDomainTy>::printIncomingTab();
     // for each incoming call edge already processed
     //(see processCall(..))
     for (auto entry : inc) {
       // line 22
-      N c = entry.first;
+      n_t c = entry.first;
       // for each return site
-      for (N retSiteC :
-           IDESolver<N, D, F, T, V, L, I>::ICF->getReturnSitesOfCallAt(c)) {
+      for (n_t retSiteC :
+           IDESolver<AnalysisDomainTy>::ICF->getReturnSitesOfCallAt(c)) {
         // compute return-flow function
-        std::shared_ptr<FlowFunction<D>> retFunction =
-            IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+        std::shared_ptr<FlowFunction<d_t>> retFunction =
+            IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getRetFlowFunction(c, functionThatNeedsSummary, n, retSiteC);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
         // for each incoming-call value
-        for (D d4 : entry.second) {
-          std::set<D> targets =
-              IDESolver<N, D, F, T, V, L, I>::computeReturnFlowFunction(
+        for (d_t d4 : entry.second) {
+          std::set<d_t> targets =
+              IDESolver<AnalysisDomainTy>::computeReturnFlowFunction(
                   retFunction, d1, d2, c, entry.second);
           ADD_TO_HISTOGRAM("Data-flow facts", targets.size(), 1,
                            PAMM_SEVERITY_LEVEL::Full);
-          IDESolver<N, D, F, T, V, L, I>::saveEdges(n, retSiteC, d2, targets,
-                                                    true);
+          IDESolver<AnalysisDomainTy>::saveEdges(n, retSiteC, d2, targets,
+                                                 true);
           std::cout << "RETURN TARGETS: " << targets.size() << std::endl;
           // for each target value at the return site
           // line 23
-          for (D d5 : targets) {
+          for (d_t d5 : targets) {
             // compute composed function
             // get call edge function
             EdgeFunctionPtrType f4 =
-                IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                     .getCallEdgeFunction(
                         c, d4,
-                        IDESolver<N, D, F, T, V, L, I>::ICF->getFunctionOf(n),
-                        d1);
+                        IDESolver<AnalysisDomainTy>::ICF->getFunctionOf(n), d1);
             // get return edge function
             EdgeFunctionPtrType f5 =
-                IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                     .getReturnEdgeFunction(
-                        c,
-                        IDESolver<N, D, F, T, V, L, I>::ICF->getFunctionOf(n),
+                        c, IDESolver<AnalysisDomainTy>::ICF->getFunctionOf(n),
                         n, d2, retSiteC, d5);
             // add ret PDS rule
             auto d1_k = wali::getKey(d1);
@@ -575,9 +581,9 @@ public:
             auto d5_k = wali::getKey(d5);
             DKey[d5] = d5_k;
             auto n_k = wali::getKey(n);
-            wali::ref_ptr<JoinLatticeToSemiRingElem<L>> wptr(
-                new JoinLatticeToSemiRingElem<L>(
-                    f5, static_cast<JoinLattice<L> &>(Problem)));
+            wali::ref_ptr<JoinLatticeToSemiRingElem<l_t>> wptr(
+                new JoinLatticeToSemiRingElem<l_t>(
+                    f5, static_cast<JoinLattice<l_t> &>(Problem)));
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "ADD RET RULE: " << Problem.DtoString(d2) << ", "
                           << Problem.NtoString(n) << ", "
@@ -600,18 +606,18 @@ public:
             // for each jump function coming into the call, propagate to return
             // site using the composed function
             for (auto valAndFunc :
-                 IDESolver<N, D, F, T, V, L, I>::jumpFn->reverseLookup(c, d4)) {
+                 IDESolver<AnalysisDomainTy>::jumpFn->reverseLookup(c, d4)) {
               EdgeFunctionPtrType f3 = valAndFunc.second;
-              if (!f3->equal_to(IDESolver<N, D, F, T, V, L, I>::allTop)) {
-                D d3 = valAndFunc.first;
-                D d5_restoredCtx =
-                    IDESolver<N, D, F, T, V, L,
-                              I>::restoreContextOnReturnedFact(c, d4, d5);
+              if (!f3->equal_to(IDESolver<AnalysisDomainTy>::allTop)) {
+                d_t d3 = valAndFunc.first;
+                d_t d5_restoredCtx =
+                    IDESolver<AnalysisDomainTy>::restoreContextOnReturnedFact(
+                        c, d4, d5);
                 LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                               << "Compose: " << fPrime->str() << " * "
                               << f3->str());
                 LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-                IDESolver<N, D, F, T, V, L, I>::propagate(
+                IDESolver<AnalysisDomainTy>::propagate(
                     d3, retSiteC, d5_restoredCtx, f3->composeWith(fPrime), c,
                     false);
               }
@@ -625,41 +631,40 @@ public:
     // note: we propagate that way only values that originate from ZERO, as
     // conditionally generated values should only
     // be propagated into callers that have an incoming edge for this condition
-    if (IDESolver<N, D, F, T, V, L, I>::SolverConfig.followReturnsPastSeeds &&
+    if (IDESolver<AnalysisDomainTy>::SolverConfig.followReturnsPastSeeds &&
         inc.empty() &&
-        IDESolver<N, D, F, T, V, L, I>::ideTabulationProblem.isZeroValue(d1)) {
-      std::set<N> callers = IDESolver<N, D, F, T, V, L, I>::ICF->getCallersOf(
+        IDESolver<AnalysisDomainTy>::ideTabulationProblem.isZeroValue(d1)) {
+      std::set<n_t> callers = IDESolver<AnalysisDomainTy>::ICF->getCallersOf(
           functionThatNeedsSummary);
-      for (N c : callers) {
-        for (N retSiteC :
-             IDESolver<N, D, F, T, V, L, I>::ICF->getReturnSitesOfCallAt(c)) {
-          std::shared_ptr<FlowFunction<D>> retFunction =
-              IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+      for (n_t c : callers) {
+        for (n_t retSiteC :
+             IDESolver<AnalysisDomainTy>::ICF->getReturnSitesOfCallAt(c)) {
+          std::shared_ptr<FlowFunction<d_t>> retFunction =
+              IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                   .getRetFlowFunction(c, functionThatNeedsSummary, n, retSiteC);
           INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
-          std::set<D> targets =
-              IDESolver<N, D, F, T, V, L, I>::computeReturnFlowFunction(
+          std::set<d_t> targets =
+              IDESolver<AnalysisDomainTy>::computeReturnFlowFunction(
                   retFunction, d1, d2, c,
-                  std::set<D>{IDESolver<N, D, F, T, V, L, I>::zeroValue});
+                  std::set<d_t>{IDESolver<AnalysisDomainTy>::zeroValue});
           ADD_TO_HISTOGRAM("Data-flow facts", targets.size(), 1,
                            PAMM_SEVERITY_LEVEL::Full);
-          IDESolver<N, D, F, T, V, L, I>::saveEdges(n, retSiteC, d2, targets,
-                                                    true);
-          for (D d5 : targets) {
+          IDESolver<AnalysisDomainTy>::saveEdges(n, retSiteC, d2, targets,
+                                                 true);
+          for (d_t d5 : targets) {
             EdgeFunctionPtrType f5 =
-                IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+                IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                     .getReturnEdgeFunction(
-                        c,
-                        IDESolver<N, D, F, T, V, L, I>::ICF->getFunctionOf(n),
+                        c, IDESolver<AnalysisDomainTy>::ICF->getFunctionOf(n),
                         n, d2, retSiteC, d5);
             INC_COUNTER("EF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                           << "Compose: " << f5->str() << " * " << f->str());
             LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG) << ' ');
-            IDESolver<N, D, F, T, V, L, I>::propagteUnbalancedReturnFlow(
+            IDESolver<AnalysisDomainTy>::propagteUnbalancedReturnFlow(
                 retSiteC, d5, f->composeWith(f5), c);
             // register for value processing (2nd IDE phase)
-            IDESolver<N, D, F, T, V, L, I>::unbalancedRetSites.insert(retSiteC);
+            IDESolver<AnalysisDomainTy>::unbalancedRetSites.insert(retSiteC);
           }
         }
       }
@@ -668,8 +673,8 @@ public:
       // the flow function has a side effect such as registering a taint;
       // instead we thus call the return flow function will a null caller
       if (callers.empty()) {
-        std::shared_ptr<FlowFunction<D>> retFunction =
-            IDESolver<N, D, F, T, V, L, I>::cachedFlowEdgeFunctions
+        std::shared_ptr<FlowFunction<d_t>> retFunction =
+            IDESolver<AnalysisDomainTy>::cachedFlowEdgeFunctions
                 .getRetFlowFunction(nullptr, functionThatNeedsSummary, n,
                                     nullptr);
         INC_COUNTER("FF Queries", 1, PAMM_SEVERITY_LEVEL::Full);
@@ -681,7 +686,7 @@ public:
   void doForwardSearch(wali::wfa::WFA &Answer) {
     // Create an automaton to AcceptingState the configuration:
     // <ZeroPDSState, entry>
-    for (auto seed : IDESolver<N, D, F, T, V, L, I>::initialSeeds) {
+    for (auto seed : IDESolver<AnalysisDomainTy>::initialSeeds) {
       wali::Key entry = wali::getKey(seed.first);
       Query.addTrans(ZeroPDSState, entry, AcceptingState, SRElem->one());
     }
@@ -701,9 +706,8 @@ public:
     // Find the set of all return points
     wali::wpds::WpdsStackSymbols syms;
     PDS->for_each(syms);
-    auto alloca1 = &IDESolver<N, D, F, T, V, L, I>::ICF->getFunction("main")
-                        ->front()
-                        .front();
+    auto alloca1 =
+        &IDESolver<AnalysisDomainTy>::ICF->getFunction("main")->front().front();
     auto a1key = wali::getKey(alloca1);
     // the weight is essential here!
     Query.addTrans(a1key, node, AcceptingState, SRElem->one());
@@ -743,8 +747,9 @@ public:
     PDS->prestar(Query, Answer);
   }
 
-  std::unordered_map<D, L> resultsAt(N stmt, bool stripZero = false) override {
-    std::unordered_map<D, L> Results;
+  std::unordered_map<d_t, l_t> resultsAt(n_t stmt,
+                                         bool stripZero = false) override {
+    std::unordered_map<d_t, l_t> Results;
     wali::wfa::Trans goal;
     for (auto Entry : DKey) {
       // Method 1: If query 'stmt' is located within the same function as the
@@ -752,8 +757,8 @@ public:
       if (Answer.find(Entry.second, wali::getKey(stmt), AcceptingState, goal)) {
         Results.insert(std::make_pair(
             Entry.first,
-            static_cast<JoinLatticeToSemiRingElem<L> &>(*goal.weight())
-                .F->computeTarget(L{})));
+            static_cast<JoinLatticeToSemiRingElem<l_t> &>(*goal.weight())
+                .F->computeTarget(l_t{})));
       } else {
         // Method 2: If query 'stmt' is located in a different function
         wali::sem_elem_t ret = SRElem->zero();
@@ -768,8 +773,8 @@ public:
         }
         if (!ret->equal(SRElem->zero())) {
           Results.insert(std::make_pair(
-              Entry.first, static_cast<JoinLatticeToSemiRingElem<L> &>(*ret)
-                               .F->computeTarget(L{})));
+              Entry.first, static_cast<JoinLatticeToSemiRingElem<l_t> &>(*ret)
+                               .F->computeTarget(l_t{})));
         }
       }
     }
@@ -779,12 +784,12 @@ public:
     return Results;
   }
 
-  L resultAt(N stmt, D fact) override {
+  l_t resultAt(n_t stmt, d_t fact) override {
     wali::wfa::Trans goal;
     if (Answer.find(wali::getKey(fact), wali::getKey(stmt), AcceptingState,
                     goal)) {
-      return static_cast<JoinLatticeToSemiRingElem<L> &>(*goal.weight())
-          .F->computeTarget(L{});
+      return static_cast<JoinLatticeToSemiRingElem<l_t> &>(*goal.weight())
+          .F->computeTarget(l_t{});
     }
     wali::sem_elem_t ret = SRElem->zero();
     wali::wfa::TransSet tset;
@@ -797,8 +802,8 @@ public:
       ret = ret->combine(tmp);
     }
     if (!ret->equal(SRElem->zero())) {
-      return static_cast<JoinLatticeToSemiRingElem<L> &>(*ret).F->computeTarget(
-          L{});
+      return static_cast<JoinLatticeToSemiRingElem<l_t> &>(*ret)
+          .F->computeTarget(l_t{});
     }
     throw std::runtime_error("Requested invalid fact!");
   }

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/Solver/WPDSSolver.h
@@ -51,7 +51,10 @@ namespace psr {
 template <typename AnalysisDomainTy>
 class WPDSSolver : public IDESolver<AnalysisDomainTy> {
 public:
-  using typename IDESolver<AnalysisDomainTy>::EdgeFunctionPtrType;
+  using ProblemTy = IDETabulationProblem<AnalysisDomainTy>;
+  using container_type = typename ProblemTy::container_type;
+  using FlowFunctionPtrType = typename ProblemTy::FlowFunctionPtrType;
+  using EdgeFunctionPtrType = typename ProblemTy::EdgeFunctionPtrType;
 
   using l_t = typename AnalysisDomainTy::l_t;
   using n_t = typename AnalysisDomainTy::n_t;

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSProblem.h
@@ -14,7 +14,9 @@
 #include <string>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSSolverConfig.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 
 namespace psr {
 
@@ -22,18 +24,25 @@ class ProjectIRDB;
 template <typename T, typename F> class TypeHierarchy;
 template <typename V, typename N> class PointsToInfo;
 
-template <typename N, typename D, typename F, typename T, typename V,
-          typename L, typename I>
-class WPDSProblem : public IDETabulationProblem<N, D, F, T, V, L, I> {
-  static_assert(std::is_base_of_v<ICFG<N, F>, I>,
+template <typename AnalysisDomainTy>
+class WPDSProblem : public IDETabulationProblem<AnalysisDomainTy> {
+public:
+  using n_t = typename AnalysisDomainTy::n_t;
+  using d_t = typename AnalysisDomainTy::d_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using t_t = typename AnalysisDomainTy::t_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+  using v_t = typename AnalysisDomainTy::v_t;
+  using l_t = typename AnalysisDomainTy::l_t;
+
+  static_assert(std::is_base_of_v<ICFG<n_t, f_t>, i_t>,
                 "I must implement the ICFG interface!");
 
-public:
-  WPDSProblem(const ProjectIRDB *IRDB, const TypeHierarchy<T, F> *TH,
-              const I *ICF, PointsToInfo<V, N> *PT,
+  WPDSProblem(const ProjectIRDB *IRDB, const TypeHierarchy<t_t, f_t> *TH,
+              const i_t *ICF, PointsToInfo<v_t, n_t> *PT,
               std::set<std::string> EntryPoints = {})
-      : IDETabulationProblem<N, D, F, T, V, L, I>(IRDB, TH, ICF, PT,
-                                                  EntryPoints) {}
+      : IDETabulationProblem<AnalysisDomainTy>(IRDB, TH, ICF, PT, EntryPoints) {
+  }
 
   virtual ~WPDSProblem() override = default;
 

--- a/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
+++ b/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
@@ -20,20 +20,52 @@ class StructType;
 namespace psr {
 class LLVMBasedICFG;
 
+// AnalysisDomain - This class should be specialized by different static
+// analyses types... which is why the default version declares all analysis
+// domains as aliases of void.
+//
+// Virtually all of PhASAR's internal analyses are implemented in a generic way
+// using interfaces and template parameters. In order to specify concrete types
+// for the template parameters such that an analysis can compute some useful
+// information on some concrete target code, a configuration template parameter
+// of type AnalysisDomain is passed around to make the necessary information
+// available to the required analyses.
+//
+// If a type is not meant to be used by an analysis it should be left as an
+// alias to void. If any analysis detects that a parameter is required to
+// conduct an analysis but not correctly set, it will statically report an error
+// and ask for the missing piece of information.
 struct AnalysisDomain {
+  // Data-flow fact --- Specifies the type of an individual data-flow fact that
+  // is propagated through the program under analysis.
   using d_t = void;
+  // (Control-flow) Node --- Specifies the type of a node in the
+  // (inter-procedural) control-flow graph and can be though of as an individual
+  // statement or instruction of the program.
   using n_t = void;
+  // Function --- Specifies the type of functions.
   using f_t = void;
+  // (User-defined) type --- Specifies the type of a user-defined (i.e. struct
+  // or class) data type.
   using t_t = void;
+  // (Pointer) value --- Specifies the type of pointers.
   using v_t = void;
+  // Inter-procedural control flow --- Specifies the type of the
+  // inter-procedural control-flow graph to be used.
+  using i_t = void;
 
   // type of the element contained in the sets of edge functions
+  // TODO: we probably wish to remove that here and add it as a local
+  // type alias to the IDEInstInteractionanalysis.
   using e_t = void;
+  // Lattice element --- Specifies the type of the underlying lattice; the value
+  // computation domain IDE's edge functions or WPDS's weights operate on.
   using l_t = void;
-  using i_t = void;
 };
 
 struct LLVMAnalysisDomainDefault : public AnalysisDomain {
+  // TODO we should probably remove d_t here; as it is very likely to be
+  // overwritten by many LLVM-based data-flow analyses
   using d_t = const llvm::Value *;
   using n_t = const llvm::Instruction *;
   using f_t = const llvm::Function *;

--- a/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
+++ b/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
@@ -7,8 +7,8 @@
  *     Philipp Schubert and others
  *****************************************************************************/
 
-#ifndef PHASAR_PHASARLLVM_IFDSIDE_ANALYSISDOMAIN_H_
-#define PHASAR_PHASARLLVM_IFDSIDE_ANALYSISDOMAIN_H_
+#ifndef PHASAR_PHASARLLVM_DOMAIN_ANALYSISDOMAIN_H_
+#define PHASAR_PHASARLLVM_DOMAIN_ANALYSISDOMAIN_H_
 
 namespace llvm {
 class Value;
@@ -18,6 +18,7 @@ class StructType;
 } // namespace llvm
 
 namespace psr {
+class LLVMBasedCFG;
 class LLVMBasedICFG;
 
 // AnalysisDomain - This class should be specialized by different static
@@ -50,28 +51,24 @@ struct AnalysisDomain {
   using t_t = void;
   // (Pointer) value --- Specifies the type of pointers.
   using v_t = void;
+  // Intra-procedural control flow --- Specifies the type of the
+  // control-flow graph to be used.
+  using c_t = void;
   // Inter-procedural control flow --- Specifies the type of the
   // inter-procedural control-flow graph to be used.
   using i_t = void;
-
-  // type of the element contained in the sets of edge functions
-  // TODO: we probably wish to remove that here and add it as a local
-  // type alias to the IDEInstInteractionanalysis.
-  using e_t = void;
   // Lattice element --- Specifies the type of the underlying lattice; the value
   // computation domain IDE's edge functions or WPDS's weights operate on.
   using l_t = void;
 };
 
 struct LLVMAnalysisDomainDefault : public AnalysisDomain {
-  // TODO we should probably remove d_t here; as it is very likely to be
-  // overwritten by many LLVM-based data-flow analyses
   using d_t = const llvm::Value *;
   using n_t = const llvm::Instruction *;
   using f_t = const llvm::Function *;
   using t_t = const llvm::StructType *;
   using v_t = const llvm::Value *;
-
+  using c_t = LLVMBasedCFG;
   using i_t = LLVMBasedICFG;
 };
 

--- a/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
+++ b/include/phasar/PhasarLLVM/Domain/AnalysisDomain.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright (c) 2020 Philipp Schubert, Richard Leer, and Florian Sattler.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+#ifndef PHASAR_PHASARLLVM_IFDSIDE_ANALYSISDOMAIN_H_
+#define PHASAR_PHASARLLVM_IFDSIDE_ANALYSISDOMAIN_H_
+
+namespace llvm {
+class Value;
+class Instruction;
+class Function;
+class StructType;
+} // namespace llvm
+
+namespace psr {
+class LLVMBasedICFG;
+
+struct AnalysisDomain {
+  using d_t = void;
+  using n_t = void;
+  using f_t = void;
+  using t_t = void;
+  using v_t = void;
+
+  // type of the element contained in the sets of edge functions
+  using e_t = void;
+  using l_t = void;
+  using i_t = void;
+};
+
+struct LLVMAnalysisDomainDefault : public AnalysisDomain {
+  using d_t = const llvm::Value *;
+  using n_t = const llvm::Instruction *;
+  using f_t = const llvm::Function *;
+  using t_t = const llvm::StructType *;
+  using v_t = const llvm::Value *;
+
+  using i_t = LLVMBasedICFG;
+};
+
+} // namespace psr
+
+#endif // PHASAR_PHASARLLVM_IFDSIDE_ANALYSISDOMAIN_H_

--- a/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
+++ b/include/phasar/PhasarLLVM/Plugins/Interfaces/IfdsIde/IFDSTabulationProblemPlugin.h
@@ -26,6 +26,7 @@
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/LLVMZeroValue.h"
+#include "phasar/PhasarLLVM/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
@@ -41,10 +42,9 @@ namespace psr {
 class ProjectIRDB;
 
 class IFDSTabulationProblemPlugin
-    : public IFDSTabulationProblem<const llvm::Instruction *,
-                                   const llvm::Value *, const llvm::Function *,
-                                   const llvm::StructType *,
-                                   const llvm::Value *, LLVMBasedICFG> {
+    : public IFDSTabulationProblem<LLVMAnalysisDomainDefault> {
+  using AnalysisDomainTy = LLVMAnalysisDomainDefault;
+
 protected:
   std::vector<std::string> EntryPoints;
 
@@ -53,10 +53,8 @@ public:
                               const LLVMTypeHierarchy *TH,
                               const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                               std::set<std::string> EntryPoints)
-      : IFDSTabulationProblem<const llvm::Instruction *, const llvm::Value *,
-                              const llvm::Function *, const llvm::StructType *,
-                              const llvm::Value *, LLVMBasedICFG>(
-            IRDB, TH, ICF, PT, EntryPoints) {
+      : IFDSTabulationProblem<AnalysisDomainTy>(IRDB, TH, ICF, PT,
+                                                EntryPoints) {
     IFDSTabulationProblem::ZeroValue = createZeroValue();
   }
   ~IFDSTabulationProblemPlugin() override = default;

--- a/include/phasar/PhasarLLVM/Utils/Printer.h
+++ b/include/phasar/PhasarLLVM/Utils/Printer.h
@@ -23,7 +23,9 @@
 
 namespace psr {
 
-template <typename N> struct NodePrinter {
+template <typename AnalysisDomainTy> struct NodePrinter {
+  using N = typename AnalysisDomainTy::n_t;
+
   NodePrinter() = default;
   NodePrinter(const NodePrinter &) = delete;
   NodePrinter &operator=(const NodePrinter &) = delete;
@@ -40,7 +42,9 @@ template <typename N> struct NodePrinter {
   }
 };
 
-template <typename D> struct DataFlowFactPrinter {
+template <typename AnalysisDomainTy> struct DataFlowFactPrinter {
+  using D = typename AnalysisDomainTy::d_t;
+
   DataFlowFactPrinter() = default;
   DataFlowFactPrinter(const DataFlowFactPrinter &) = delete;
   DataFlowFactPrinter &operator=(const DataFlowFactPrinter &) = delete;
@@ -91,7 +95,9 @@ template <typename T> struct TypePrinter {
   }
 };
 
-template <typename L> struct EdgeFactPrinter {
+template <typename AnalysisDomainTy> struct EdgeFactPrinter {
+  using l_t = typename AnalysisDomainTy::l_t;
+
   EdgeFactPrinter() = default;
   EdgeFactPrinter(const EdgeFactPrinter &) = delete;
   EdgeFactPrinter &operator=(const EdgeFactPrinter &) = delete;
@@ -99,16 +105,18 @@ template <typename L> struct EdgeFactPrinter {
   EdgeFactPrinter &operator=(EdgeFactPrinter &&) = delete;
   virtual ~EdgeFactPrinter() = default;
 
-  virtual void printEdgeFact(std::ostream &os, L l) const = 0;
+  virtual void printEdgeFact(std::ostream &os, l_t l) const = 0;
 
-  virtual std::string LtoString(L l) const {
+  [[nodiscard]] virtual std::string LtoString(l_t l) const {
     std::stringstream ss;
     printEdgeFact(ss, l);
     return ss.str();
   }
 };
 
-template <typename F> struct FunctionPrinter {
+template <typename AnalysisDomainTy> struct FunctionPrinter {
+  using F = typename AnalysisDomainTy::f_t;
+
   FunctionPrinter() = default;
   FunctionPrinter(const FunctionPrinter &) = delete;
   FunctionPrinter &operator=(const FunctionPrinter &) = delete;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -64,7 +64,7 @@ IDELinearConstantAnalysis::~IDELinearConstantAnalysis() {
 
 // Start formulating our analysis by specifying the parts required for IFDS
 
-shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
+IDELinearConstantAnalysis::FlowFunctionPtrType
 IDELinearConstantAnalysis::getNormalFlowFunction(
     IDELinearConstantAnalysis::n_t Curr, IDELinearConstantAnalysis::n_t Succ) {
   if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
@@ -119,7 +119,7 @@ IDELinearConstantAnalysis::getNormalFlowFunction(
   return Identity<IDELinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
+IDELinearConstantAnalysis::FlowFunctionPtrType
 IDELinearConstantAnalysis::getCallFlowFunction(
     IDELinearConstantAnalysis::n_t CallStmt,
     IDELinearConstantAnalysis::f_t DestFun) {
@@ -196,7 +196,7 @@ IDELinearConstantAnalysis::getCallFlowFunction(
   return Identity<IDELinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
+IDELinearConstantAnalysis::FlowFunctionPtrType
 IDELinearConstantAnalysis::getRetFlowFunction(
     IDELinearConstantAnalysis::n_t CallSite,
     IDELinearConstantAnalysis::f_t CalleeFun,
@@ -240,7 +240,7 @@ IDELinearConstantAnalysis::getRetFlowFunction(
       });
 }
 
-shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
+IDELinearConstantAnalysis::FlowFunctionPtrType
 IDELinearConstantAnalysis::getCallToRetFlowFunction(
     IDELinearConstantAnalysis::n_t CallSite,
     IDELinearConstantAnalysis::n_t RetSite, set<f_t> Callees) {
@@ -258,7 +258,7 @@ IDELinearConstantAnalysis::getCallToRetFlowFunction(
   return Identity<IDELinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDELinearConstantAnalysis::d_t>>
+IDELinearConstantAnalysis::FlowFunctionPtrType
 IDELinearConstantAnalysis::getSummaryFlowFunction(
     IDELinearConstantAnalysis::n_t CallStmt,
     IDELinearConstantAnalysis::f_t DestFun) {

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEProtoAnalysis.cpp
@@ -43,34 +43,32 @@ IDEProtoAnalysis::IDEProtoAnalysis(const ProjectIRDB *IRDB,
 
 // start formulating our analysis by specifying the parts required for IFDS
 
-shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
+IDEProtoAnalysis::FlowFunctionPtrType
 IDEProtoAnalysis::getNormalFlowFunction(IDEProtoAnalysis::n_t Curr,
                                         IDEProtoAnalysis::n_t Succ) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
+IDEProtoAnalysis::FlowFunctionPtrType
 IDEProtoAnalysis::getCallFlowFunction(IDEProtoAnalysis::n_t CallStmt,
                                       IDEProtoAnalysis::f_t DestFun) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
-IDEProtoAnalysis::getRetFlowFunction(IDEProtoAnalysis::n_t CallSite,
-                                     IDEProtoAnalysis::f_t CalleeFun,
-                                     IDEProtoAnalysis::n_t ExitStmt,
-                                     IDEProtoAnalysis::n_t RetSite) {
+IDEProtoAnalysis::FlowFunctionPtrType IDEProtoAnalysis::getRetFlowFunction(
+    IDEProtoAnalysis::n_t CallSite, IDEProtoAnalysis::f_t CalleeFun,
+    IDEProtoAnalysis::n_t ExitStmt, IDEProtoAnalysis::n_t RetSite) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
+IDEProtoAnalysis::FlowFunctionPtrType
 IDEProtoAnalysis::getCallToRetFlowFunction(IDEProtoAnalysis::n_t CallSite,
                                            IDEProtoAnalysis::n_t RetSite,
                                            set<IDEProtoAnalysis::f_t> Callees) {
   return Identity<IDEProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDEProtoAnalysis::d_t>>
+IDEProtoAnalysis::FlowFunctionPtrType
 IDEProtoAnalysis::getSummaryFlowFunction(IDEProtoAnalysis::n_t CallStmt,
                                          IDEProtoAnalysis::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESecureHeapPropagation.cpp
@@ -28,23 +28,23 @@ IDESecureHeapPropagation::IDESecureHeapPropagation(
   ZeroValue = createZeroValue();
 }
 
-std::shared_ptr<FlowFunction<IDESecureHeapPropagation::d_t>>
+IDESecureHeapPropagation::FlowFunctionPtrType
 IDESecureHeapPropagation::getNormalFlowFunction(n_t Curr, n_t Succ) {
   return Identity<d_t>::getInstance();
 }
 
-std::shared_ptr<FlowFunction<IDESecureHeapPropagation::d_t>>
+IDESecureHeapPropagation::FlowFunctionPtrType
 IDESecureHeapPropagation::getCallFlowFunction(n_t CallStmt, f_t DestMthd) {
   return Identity<d_t>::getInstance();
 }
 
-std::shared_ptr<FlowFunction<IDESecureHeapPropagation::d_t>>
+IDESecureHeapPropagation::FlowFunctionPtrType
 IDESecureHeapPropagation::getRetFlowFunction(n_t CallSite, f_t CalleeMthd,
                                              n_t ExitStmt, n_t RetSite) {
   return Identity<d_t>::getInstance();
 }
 
-std::shared_ptr<FlowFunction<IDESecureHeapPropagation::d_t>>
+IDESecureHeapPropagation::FlowFunctionPtrType
 IDESecureHeapPropagation::getCallToRetFlowFunction(n_t CallSite, n_t RetSite,
                                                    std::set<f_t> Callees) {
 
@@ -57,7 +57,7 @@ IDESecureHeapPropagation::getCallToRetFlowFunction(n_t CallSite, n_t RetSite,
   }
   return Identity<d_t>::getInstance();
 }
-std::shared_ptr<FlowFunction<IDESecureHeapPropagation::d_t>>
+IDESecureHeapPropagation::FlowFunctionPtrType
 IDESecureHeapPropagation::getSummaryFlowFunction(n_t CallStmt, f_t DestMthd) {
   return nullptr;
 }

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDESolverTest.cpp
@@ -42,32 +42,32 @@ IDESolverTest::IDESolverTest(const ProjectIRDB *IRDB,
 
 // start formulating our analysis by specifying the parts required for IFDS
 
-shared_ptr<FlowFunction<IDESolverTest::d_t>>
+IDESolverTest::FlowFunctionPtrType
 IDESolverTest::getNormalFlowFunction(IDESolverTest::n_t Curr,
                                      IDESolverTest::n_t Succ) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDESolverTest::d_t>>
+IDESolverTest::FlowFunctionPtrType
 IDESolverTest::getCallFlowFunction(IDESolverTest::n_t CallStmt,
                                    IDESolverTest::f_t DestFun) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDESolverTest::d_t>> IDESolverTest::getRetFlowFunction(
+IDESolverTest::FlowFunctionPtrType IDESolverTest::getRetFlowFunction(
     IDESolverTest::n_t CallSite, IDESolverTest::f_t CalleeFun,
     IDESolverTest::n_t ExitStmt, IDESolverTest::n_t RetSite) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDESolverTest::d_t>>
+IDESolverTest::FlowFunctionPtrType
 IDESolverTest::getCallToRetFlowFunction(IDESolverTest::n_t CallSite,
                                         IDESolverTest::n_t RetSite,
                                         set<IDESolverTest::f_t> Callees) {
   return Identity<IDESolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDESolverTest::d_t>>
+IDESolverTest::FlowFunctionPtrType
 IDESolverTest::getSummaryFlowFunction(IDESolverTest::n_t CallStmt,
                                       IDESolverTest::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETaintAnalysis.cpp
@@ -43,34 +43,32 @@ IDETaintAnalysis::IDETaintAnalysis(const ProjectIRDB *IRDB,
 
 // start formulating our analysis by specifying the parts required for IFDS
 
-shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
+IDETaintAnalysis::FlowFunctionPtrType
 IDETaintAnalysis::getNormalFlowFunction(IDETaintAnalysis::n_t Curr,
                                         IDETaintAnalysis::n_t Succ) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
+IDETaintAnalysis::FlowFunctionPtrType
 IDETaintAnalysis::getCallFlowFunction(IDETaintAnalysis::n_t CallStmt,
                                       IDETaintAnalysis::f_t DestFun) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
-IDETaintAnalysis::getRetFlowFunction(IDETaintAnalysis::n_t CallSite,
-                                     IDETaintAnalysis::f_t CalleeFun,
-                                     IDETaintAnalysis::n_t ExitStmt,
-                                     IDETaintAnalysis::n_t RetSite) {
+IDETaintAnalysis::FlowFunctionPtrType IDETaintAnalysis::getRetFlowFunction(
+    IDETaintAnalysis::n_t CallSite, IDETaintAnalysis::f_t CalleeFun,
+    IDETaintAnalysis::n_t ExitStmt, IDETaintAnalysis::n_t RetSite) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
+IDETaintAnalysis::FlowFunctionPtrType
 IDETaintAnalysis::getCallToRetFlowFunction(IDETaintAnalysis::n_t CallSite,
                                            IDETaintAnalysis::n_t RetSite,
                                            set<IDETaintAnalysis::f_t> Callees) {
   return Identity<IDETaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETaintAnalysis::d_t>>
+IDETaintAnalysis::FlowFunctionPtrType
 IDETaintAnalysis::getSummaryFlowFunction(IDETaintAnalysis::n_t CallStmt,
                                          IDETaintAnalysis::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -49,7 +49,7 @@ IDETypeStateAnalysis::IDETypeStateAnalysis(const ProjectIRDB *IRDB,
 
 // Start formulating our analysis by specifying the parts required for IFDS
 
-shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
+IDETypeStateAnalysis::FlowFunctionPtrType
 IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t Curr,
                                             IDETypeStateAnalysis::n_t Succ) {
   // Check if Alloca's type matches the target type. If so, generate from zero
@@ -134,7 +134,7 @@ IDETypeStateAnalysis::getNormalFlowFunction(IDETypeStateAnalysis::n_t Curr,
   return Identity<IDETypeStateAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
+IDETypeStateAnalysis::FlowFunctionPtrType
 IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallStmt,
                                           IDETypeStateAnalysis::f_t DestFun) {
   // Kill all data-flow facts if we hit a function of the target API.
@@ -152,7 +152,7 @@ IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallStmt,
   llvm::report_fatal_error("callStmt not a CallInst nor a InvokeInst");
 }
 
-shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
+IDETypeStateAnalysis::FlowFunctionPtrType
 IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t CallSite,
                                          IDETypeStateAnalysis::f_t CalleeFun,
                                          IDETypeStateAnalysis::n_t ExitStmt,
@@ -245,7 +245,7 @@ IDETypeStateAnalysis::getRetFlowFunction(IDETypeStateAnalysis::n_t CallSite,
                                      CalleeFun, ExitStmt, this);
 }
 
-shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
+IDETypeStateAnalysis::FlowFunctionPtrType
 IDETypeStateAnalysis::getCallToRetFlowFunction(
     IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::n_t RetSite,
     set<IDETypeStateAnalysis::f_t> Callees) {
@@ -299,7 +299,7 @@ IDETypeStateAnalysis::getCallToRetFlowFunction(
   return Identity<IDETypeStateAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IDETypeStateAnalysis::d_t>>
+IDETypeStateAnalysis::FlowFunctionPtrType
 IDETypeStateAnalysis::getSummaryFlowFunction(
     IDETypeStateAnalysis::n_t CallStmt, IDETypeStateAnalysis::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -46,7 +46,7 @@ IFDSConstAnalysis::IFDSConstAnalysis(const ProjectIRDB *IRDB,
   IFDSTabulationProblem::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
+IFDSConstAnalysis::FlowFunctionPtrType
 IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t Curr,
                                          IFDSConstAnalysis::n_t Succ) {
   // Check all store instructions.
@@ -123,7 +123,7 @@ IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t Curr,
   return Identity<IFDSConstAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
+IFDSConstAnalysis::FlowFunctionPtrType
 IFDSConstAnalysis::getCallFlowFunction(IFDSConstAnalysis::n_t CallStmt,
                                        IFDSConstAnalysis::f_t DestFun) {
   // Handle one of the three llvm memory intrinsics (memcpy, memmove or memset)
@@ -152,11 +152,9 @@ IFDSConstAnalysis::getCallFlowFunction(IFDSConstAnalysis::n_t CallStmt,
   return Identity<IFDSConstAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
-IFDSConstAnalysis::getRetFlowFunction(IFDSConstAnalysis::n_t CallSite,
-                                      IFDSConstAnalysis::f_t CalleeFun,
-                                      IFDSConstAnalysis::n_t ExitStmt,
-                                      IFDSConstAnalysis::n_t RetSite) {
+IFDSConstAnalysis::FlowFunctionPtrType IFDSConstAnalysis::getRetFlowFunction(
+    IFDSConstAnalysis::n_t CallSite, IFDSConstAnalysis::f_t CalleeFun,
+    IFDSConstAnalysis::n_t ExitStmt, IFDSConstAnalysis::n_t RetSite) {
   // return KillAll<IFDSConstAnalysis::d_t>::getInstance();
   // Map formal parameter back to the actual parameter in the caller.
   return make_shared<MapFactsToCaller<>>(
@@ -170,7 +168,7 @@ IFDSConstAnalysis::getRetFlowFunction(IFDSConstAnalysis::n_t CallSite,
   // All other data-flow facts of the callee function are killed at this point
 }
 
-shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
+IFDSConstAnalysis::FlowFunctionPtrType
 IFDSConstAnalysis::getCallToRetFlowFunction(
     IFDSConstAnalysis::n_t CallSite, IFDSConstAnalysis::n_t RetSite,
     set<IFDSConstAnalysis::f_t> Callees) {
@@ -203,7 +201,7 @@ IFDSConstAnalysis::getCallToRetFlowFunction(
   return Identity<IFDSConstAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSConstAnalysis::d_t>>
+IFDSConstAnalysis::FlowFunctionPtrType
 IFDSConstAnalysis::getSummaryFlowFunction(IFDSConstAnalysis::n_t CallStmt,
                                           IFDSConstAnalysis::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSFieldSensTaintAnalysis.cpp
@@ -48,7 +48,7 @@ IFDSFieldSensTaintAnalysis::IFDSFieldSensTaintAnalysis(
   IFDSFieldSensTaintAnalysis::ZeroValue = createZeroValue();
 }
 
-std::shared_ptr<FlowFunction<ExtendedValue>>
+IFDSFieldSensTaintAnalysis::FlowFunctionPtrType
 IFDSFieldSensTaintAnalysis::getNormalFlowFunction(
     const llvm::Instruction *CurrentInst,
     const llvm::Instruction *SuccessorInst) {
@@ -95,7 +95,7 @@ IFDSFieldSensTaintAnalysis::getNormalFlowFunction(
                                                 getZeroValue());
 }
 
-std::shared_ptr<FlowFunction<ExtendedValue>>
+IFDSFieldSensTaintAnalysis::FlowFunctionPtrType
 IFDSFieldSensTaintAnalysis::getCallFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return std::make_shared<MapTaintedValuesToCallee>(
@@ -103,7 +103,7 @@ IFDSFieldSensTaintAnalysis::getCallFlowFunction(
       getZeroValue());
 }
 
-std::shared_ptr<FlowFunction<ExtendedValue>>
+IFDSFieldSensTaintAnalysis::FlowFunctionPtrType
 IFDSFieldSensTaintAnalysis::getRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Function *CalleeFun,
     const llvm::Instruction *ExitStmt, const llvm::Instruction *RetSite) {
@@ -118,7 +118,7 @@ IFDSFieldSensTaintAnalysis::getRetFlowFunction(
  * previously generated facts. Facts from the returning functions are
  * handled in getRetFlowFunction.
  */
-std::shared_ptr<FlowFunction<ExtendedValue>>
+IFDSFieldSensTaintAnalysis::FlowFunctionPtrType
 IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
     std::set<const llvm::Function *> Callees) {
@@ -149,7 +149,7 @@ IFDSFieldSensTaintAnalysis::getCallToRetFlowFunction(
  * Instead facts according to the defined flow function will be taken into
  * account.
  */
-std::shared_ptr<FlowFunction<ExtendedValue>>
+IFDSFieldSensTaintAnalysis::FlowFunctionPtrType
 IFDSFieldSensTaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   const auto DestFunName = DestFun->getName();

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSLinearConstantAnalysis.cpp
@@ -56,21 +56,21 @@ IFDSLinearConstantAnalysis::IFDSLinearConstantAnalysis(
   IFDSLinearConstantAnalysis::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
+IFDSLinearConstantAnalysis::FlowFunctionPtrType
 IFDSLinearConstantAnalysis::getNormalFlowFunction(
     IFDSLinearConstantAnalysis::n_t Curr,
     IFDSLinearConstantAnalysis::n_t Succ) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
+IFDSLinearConstantAnalysis::FlowFunctionPtrType
 IFDSLinearConstantAnalysis::getCallFlowFunction(
     IFDSLinearConstantAnalysis::n_t CallStmt,
     IFDSLinearConstantAnalysis::f_t DestFun) {
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
+IFDSLinearConstantAnalysis::FlowFunctionPtrType
 IFDSLinearConstantAnalysis::getRetFlowFunction(
     IFDSLinearConstantAnalysis::n_t CallSite,
     IFDSLinearConstantAnalysis::f_t CalleeFun,
@@ -79,7 +79,7 @@ IFDSLinearConstantAnalysis::getRetFlowFunction(
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
+IFDSLinearConstantAnalysis::FlowFunctionPtrType
 IFDSLinearConstantAnalysis::getCallToRetFlowFunction(
     IFDSLinearConstantAnalysis::n_t CallSite,
     IFDSLinearConstantAnalysis::n_t RetSite,
@@ -87,7 +87,7 @@ IFDSLinearConstantAnalysis::getCallToRetFlowFunction(
   return Identity<IFDSLinearConstantAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSLinearConstantAnalysis::d_t>>
+IFDSLinearConstantAnalysis::FlowFunctionPtrType
 IFDSLinearConstantAnalysis::getSummaryFlowFunction(
     IFDSLinearConstantAnalysis::n_t CallStmt,
     IFDSLinearConstantAnalysis::f_t DestFun) {

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSProtoAnalysis.cpp
@@ -37,7 +37,7 @@ IFDSProtoAnalysis::IFDSProtoAnalysis(const ProjectIRDB *IRDB,
   IFDSProtoAnalysis::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
+IFDSProtoAnalysis::FlowFunctionPtrType
 IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t Curr,
                                          IFDSProtoAnalysis::n_t Succ) {
   if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
@@ -47,28 +47,26 @@ IFDSProtoAnalysis::getNormalFlowFunction(IFDSProtoAnalysis::n_t Curr,
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
+IFDSProtoAnalysis::FlowFunctionPtrType
 IFDSProtoAnalysis::getCallFlowFunction(IFDSProtoAnalysis::n_t CallStmt,
                                        IFDSProtoAnalysis::f_t DestFun) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
-IFDSProtoAnalysis::getRetFlowFunction(IFDSProtoAnalysis::n_t CallSite,
-                                      IFDSProtoAnalysis::f_t CalleeFun,
-                                      IFDSProtoAnalysis::n_t ExitStmt,
-                                      IFDSProtoAnalysis::n_t RetSite) {
+IFDSProtoAnalysis::FlowFunctionPtrType IFDSProtoAnalysis::getRetFlowFunction(
+    IFDSProtoAnalysis::n_t CallSite, IFDSProtoAnalysis::f_t CalleeFun,
+    IFDSProtoAnalysis::n_t ExitStmt, IFDSProtoAnalysis::n_t RetSite) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
+IFDSProtoAnalysis::FlowFunctionPtrType
 IFDSProtoAnalysis::getCallToRetFlowFunction(
     IFDSProtoAnalysis::n_t CallSite, IFDSProtoAnalysis::n_t RetSite,
     set<IFDSProtoAnalysis::f_t> Callees) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSProtoAnalysis::d_t>>
+IFDSProtoAnalysis::FlowFunctionPtrType
 IFDSProtoAnalysis::getSummaryFlowFunction(IFDSProtoAnalysis::n_t CallStmt,
                                           IFDSProtoAnalysis::f_t DestFun) {
   return Identity<IFDSProtoAnalysis::d_t>::getInstance();

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSignAnalysis.cpp
@@ -36,34 +36,32 @@ IFDSSignAnalysis::IFDSSignAnalysis(const ProjectIRDB *IRDB,
   IFDSSignAnalysis::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
+IFDSSignAnalysis::FlowFunctionPtrType
 IFDSSignAnalysis::getNormalFlowFunction(IFDSSignAnalysis::n_t Curr,
                                         IFDSSignAnalysis::n_t Succ) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
+IFDSSignAnalysis::FlowFunctionPtrType
 IFDSSignAnalysis::getCallFlowFunction(IFDSSignAnalysis::n_t CallStmt,
                                       IFDSSignAnalysis::f_t DestFun) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
-IFDSSignAnalysis::getRetFlowFunction(IFDSSignAnalysis::n_t CallSite,
-                                     IFDSSignAnalysis::f_t CalleeFun,
-                                     IFDSSignAnalysis::n_t ExitStmt,
-                                     IFDSSignAnalysis::n_t RetSite) {
+IFDSSignAnalysis::FlowFunctionPtrType IFDSSignAnalysis::getRetFlowFunction(
+    IFDSSignAnalysis::n_t CallSite, IFDSSignAnalysis::f_t CalleeFun,
+    IFDSSignAnalysis::n_t ExitStmt, IFDSSignAnalysis::n_t RetSite) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
+IFDSSignAnalysis::FlowFunctionPtrType
 IFDSSignAnalysis::getCallToRetFlowFunction(IFDSSignAnalysis::n_t CallSite,
                                            IFDSSignAnalysis::n_t RetSite,
                                            set<IFDSSignAnalysis::f_t> Callees) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSignAnalysis::d_t>>
+IFDSSignAnalysis::FlowFunctionPtrType
 IFDSSignAnalysis::getSummaryFlowFunction(IFDSSignAnalysis::n_t CallStmt,
                                          IFDSSignAnalysis::f_t DestFun) {
   return Identity<IFDSSignAnalysis::d_t>::getInstance();

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -36,34 +36,32 @@ IFDSSolverTest::IFDSSolverTest(const ProjectIRDB *IRDB,
   IFDSSolverTest::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
+IFDSSolverTest::FlowFunctionPtrType
 IFDSSolverTest::getNormalFlowFunction(IFDSSolverTest::n_t Curr,
                                       IFDSSolverTest::n_t Succ) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
+IFDSSolverTest::FlowFunctionPtrType
 IFDSSolverTest::getCallFlowFunction(IFDSSolverTest::n_t CallStmt,
                                     IFDSSolverTest::f_t DestFun) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
-IFDSSolverTest::getRetFlowFunction(IFDSSolverTest::n_t CallSite,
-                                   IFDSSolverTest::f_t CalleeFun,
-                                   IFDSSolverTest::n_t ExitStmt,
-                                   IFDSSolverTest::n_t RetSite) {
+IFDSSolverTest::FlowFunctionPtrType IFDSSolverTest::getRetFlowFunction(
+    IFDSSolverTest::n_t CallSite, IFDSSolverTest::f_t CalleeFun,
+    IFDSSolverTest::n_t ExitStmt, IFDSSolverTest::n_t RetSite) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
+IFDSSolverTest::FlowFunctionPtrType
 IFDSSolverTest::getCallToRetFlowFunction(IFDSSolverTest::n_t CallSite,
                                          IFDSSolverTest::n_t RetSite,
                                          set<IFDSSolverTest::f_t> Callees) {
   return Identity<IFDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSSolverTest::d_t>>
+IFDSSolverTest::FlowFunctionPtrType
 IFDSSolverTest::getSummaryFlowFunction(IFDSSolverTest::n_t CallStmt,
                                        IFDSSolverTest::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -42,7 +42,7 @@ IFDSTaintAnalysis::IFDSTaintAnalysis(
   IFDSTaintAnalysis::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
+IFDSTaintAnalysis::FlowFunctionPtrType
 IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t Curr,
                                          IFDSTaintAnalysis::n_t Succ) {
   // If a tainted value is stored, the store location must be tainted too
@@ -84,7 +84,7 @@ IFDSTaintAnalysis::getNormalFlowFunction(IFDSTaintAnalysis::n_t Curr,
   return Identity<IFDSTaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
+IFDSTaintAnalysis::FlowFunctionPtrType
 IFDSTaintAnalysis::getCallFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                        IFDSTaintAnalysis::f_t DestFun) {
   string FunctionName = cxxDemangle(DestFun->getName().str());
@@ -106,11 +106,9 @@ IFDSTaintAnalysis::getCallFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
   return Identity<IFDSTaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
-IFDSTaintAnalysis::getRetFlowFunction(IFDSTaintAnalysis::n_t CallSite,
-                                      IFDSTaintAnalysis::f_t CalleeFun,
-                                      IFDSTaintAnalysis::n_t ExitStmt,
-                                      IFDSTaintAnalysis::n_t RetSite) {
+IFDSTaintAnalysis::FlowFunctionPtrType IFDSTaintAnalysis::getRetFlowFunction(
+    IFDSTaintAnalysis::n_t CallSite, IFDSTaintAnalysis::f_t CalleeFun,
+    IFDSTaintAnalysis::n_t ExitStmt, IFDSTaintAnalysis::n_t RetSite) {
   // We must check if the return value and formal parameter are tainted, if so
   // we must taint all user's of the function call. We are only interested in
   // formal parameters of pointer/reference type.
@@ -122,7 +120,7 @@ IFDSTaintAnalysis::getRetFlowFunction(IFDSTaintAnalysis::n_t CallSite,
   // All other stuff is killed at this point
 }
 
-shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
+IFDSTaintAnalysis::FlowFunctionPtrType
 IFDSTaintAnalysis::getCallToRetFlowFunction(
     IFDSTaintAnalysis::n_t CallSite, IFDSTaintAnalysis::n_t RetSite,
     set<IFDSTaintAnalysis::f_t> Callees) {
@@ -218,7 +216,7 @@ IFDSTaintAnalysis::getCallToRetFlowFunction(
   return Identity<IFDSTaintAnalysis::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSTaintAnalysis::d_t>>
+IFDSTaintAnalysis::FlowFunctionPtrType
 IFDSTaintAnalysis::getSummaryFlowFunction(IFDSTaintAnalysis::n_t CallStmt,
                                           IFDSTaintAnalysis::f_t DestFun) {
   SpecialSummaries<IFDSTaintAnalysis::d_t> &SS =

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTypeAnalysis.cpp
@@ -33,7 +33,7 @@ IFDSTypeAnalysis::IFDSTypeAnalysis(const ProjectIRDB *IRDB,
   IFDSTypeAnalysis::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
+IFDSTypeAnalysis::FlowFunctionPtrType
 IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t Curr,
                                         IFDSTypeAnalysis::n_t Succ) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
@@ -45,7 +45,7 @@ IFDSTypeAnalysis::getNormalFlowFunction(IFDSTypeAnalysis::n_t Curr,
   return make_shared<TAFF>();
 }
 
-shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
+IFDSTypeAnalysis::FlowFunctionPtrType
 IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t CallStmt,
                                       IFDSTypeAnalysis::f_t DestFun) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
@@ -57,11 +57,9 @@ IFDSTypeAnalysis::getCallFlowFunction(IFDSTypeAnalysis::n_t CallStmt,
   return make_shared<TAFF>();
 }
 
-shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
-IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
-                                     IFDSTypeAnalysis::f_t CalleeFun,
-                                     IFDSTypeAnalysis::n_t ExitStmt,
-                                     IFDSTypeAnalysis::n_t RetSite) {
+IFDSTypeAnalysis::FlowFunctionPtrType IFDSTypeAnalysis::getRetFlowFunction(
+    IFDSTypeAnalysis::n_t CallSite, IFDSTypeAnalysis::f_t CalleeFun,
+    IFDSTypeAnalysis::n_t ExitStmt, IFDSTypeAnalysis::n_t RetSite) {
   struct TAFF : FlowFunction<IFDSTypeAnalysis::d_t> {
     set<IFDSTypeAnalysis::d_t>
     computeTargets(IFDSTypeAnalysis::d_t Source) override {
@@ -71,7 +69,7 @@ IFDSTypeAnalysis::getRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
   return make_shared<TAFF>();
 }
 
-shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
+IFDSTypeAnalysis::FlowFunctionPtrType
 IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
                                            IFDSTypeAnalysis::n_t RetSite,
                                            set<IFDSTypeAnalysis::f_t> Callees) {
@@ -84,7 +82,7 @@ IFDSTypeAnalysis::getCallToRetFlowFunction(IFDSTypeAnalysis::n_t CallSite,
   return make_shared<TAFF>();
 }
 
-shared_ptr<FlowFunction<IFDSTypeAnalysis::d_t>>
+IFDSTypeAnalysis::FlowFunctionPtrType
 IFDSTypeAnalysis::getSummaryFlowFunction(IFDSTypeAnalysis::n_t Curr,
                                          IFDSTypeAnalysis::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -42,7 +42,7 @@ IFDSUninitializedVariables::IFDSUninitializedVariables(
   IFDSUninitializedVariables::ZeroValue = createZeroValue();
 }
 
-shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
+IFDSUninitializedVariables::FlowFunctionPtrType
 IFDSUninitializedVariables::getNormalFlowFunction(
     IFDSUninitializedVariables::n_t Curr,
     IFDSUninitializedVariables::n_t Succ) {
@@ -234,7 +234,7 @@ IFDSUninitializedVariables::getNormalFlowFunction(
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
+IFDSUninitializedVariables::FlowFunctionPtrType
 IFDSUninitializedVariables::getCallFlowFunction(
     IFDSUninitializedVariables::n_t CallStmt,
     IFDSUninitializedVariables::f_t DestFun) {
@@ -318,7 +318,7 @@ IFDSUninitializedVariables::getCallFlowFunction(
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
+IFDSUninitializedVariables::FlowFunctionPtrType
 IFDSUninitializedVariables::getRetFlowFunction(
     IFDSUninitializedVariables::n_t CallSite,
     IFDSUninitializedVariables::f_t CalleeFun,
@@ -363,7 +363,7 @@ IFDSUninitializedVariables::getRetFlowFunction(
   return KillAll<IFDSUninitializedVariables::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
+IFDSUninitializedVariables::FlowFunctionPtrType
 IFDSUninitializedVariables::getCallToRetFlowFunction(
     IFDSUninitializedVariables::n_t CallSite,
     IFDSUninitializedVariables::n_t RetSite,
@@ -393,7 +393,7 @@ IFDSUninitializedVariables::getCallToRetFlowFunction(
   return Identity<IFDSUninitializedVariables::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<IFDSUninitializedVariables::d_t>>
+IFDSUninitializedVariables::FlowFunctionPtrType
 IFDSUninitializedVariables::getSummaryFlowFunction(
     IFDSUninitializedVariables::n_t CallStmt,
     IFDSUninitializedVariables::f_t DestFun) {

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
@@ -54,7 +54,7 @@ const OpenSSLSecureHeapDescription::OpenSSLSecureHeapState
          OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::ERROR},
 };
 OpenSSLSecureHeapDescription::OpenSSLSecureHeapDescription(
-    IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
+    IDESolver<IDESecureHeapPropagationAnalysisDomain>
         &SecureHeapPropagationResults)
     : secureHeapPropagationResults(SecureHeapPropagationResults) {}
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
@@ -54,9 +54,8 @@ const OpenSSLSecureHeapDescription::OpenSSLSecureHeapState
          OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::ERROR},
 };
 OpenSSLSecureHeapDescription::OpenSSLSecureHeapDescription(
-    IDESolver<const llvm::Instruction *, SecureHeapFact, const llvm::Function *,
-              const llvm::StructType *, const llvm::Value *, SecureHeapValue,
-              LLVMBasedICFG> &SecureHeapPropagationResults)
+    IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>
+        &SecureHeapPropagationResults)
     : secureHeapPropagationResults(SecureHeapPropagationResults) {}
 
 bool OpenSSLSecureHeapDescription::isFactoryFunction(

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoFullConstantPropagation.cpp
@@ -34,12 +34,7 @@ InterMonoFullConstantPropagation::InterMonoFullConstantPropagation(
     const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
     const LLVMBasedICFG *ICF, const LLVMPointsToInfo *PT,
     std::set<std::string> EntryPoints)
-    : InterMonoProblem<InterMonoFullConstantPropagation::n_t,
-                       InterMonoFullConstantPropagation::d_t,
-                       InterMonoFullConstantPropagation::f_t,
-                       InterMonoFullConstantPropagation::t_t,
-                       InterMonoFullConstantPropagation::v_t,
-                       InterMonoFullConstantPropagation::i_t>(
+    : InterMonoProblem<InterMonoFullConstantPropagationAnalysisDomain>(
           IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
 
 BitVectorSet<InterMonoFullConstantPropagation::d_t>

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoSolverTest.cpp
@@ -32,10 +32,8 @@ InterMonoSolverTest::InterMonoSolverTest(const ProjectIRDB *IRDB,
                                          const LLVMBasedICFG *ICF,
                                          const LLVMPointsToInfo *PT,
                                          std::set<std::string> EntryPoints)
-    : InterMonoProblem<InterMonoSolverTest::n_t, InterMonoSolverTest::d_t,
-                       InterMonoSolverTest::f_t, InterMonoSolverTest::t_t,
-                       InterMonoSolverTest::v_t, InterMonoSolverTest::i_t>(
-          IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
+    : InterMonoProblem<LLVMAnalysisDomainDefault>(IRDB, TH, ICF, PT,
+                                                  std::move(EntryPoints)) {}
 
 BitVectorSet<const llvm::Value *>
 InterMonoSolverTest::join(const BitVectorSet<const llvm::Value *> &Lhs,

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/InterMonoTaintAnalysis.cpp
@@ -36,11 +36,8 @@ InterMonoTaintAnalysis::InterMonoTaintAnalysis(
     const LLVMBasedICFG *ICF, const LLVMPointsToInfo *PT,
     const TaintConfiguration<const llvm::Value *> &TSF,
     std::set<std::string> EntryPoints)
-    : InterMonoProblem<InterMonoTaintAnalysis::n_t, InterMonoTaintAnalysis::d_t,
-                       InterMonoTaintAnalysis::f_t, InterMonoTaintAnalysis::t_t,
-                       InterMonoTaintAnalysis::v_t,
-                       InterMonoTaintAnalysis::i_t>(IRDB, TH, ICF, PT,
-                                                    std::move(EntryPoints)),
+    : InterMonoProblem<LLVMAnalysisDomainDefault>(IRDB, TH, ICF, PT,
+                                                  std::move(EntryPoints)),
       TSF(TSF) {}
 
 BitVectorSet<const llvm::Value *>

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.cpp
@@ -16,6 +16,7 @@
 #include "llvm/IR/Value.h"
 
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoFullConstantPropagation.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
@@ -41,12 +42,7 @@ IntraMonoFullConstantPropagation::IntraMonoFullConstantPropagation(
     const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
     const LLVMBasedCFG *CF, const LLVMPointsToInfo *PT,
     std::set<std::string> EntryPoints)
-    : IntraMonoProblem<IntraMonoFullConstantPropagation::n_t,
-                       IntraMonoFullConstantPropagation::d_t,
-                       IntraMonoFullConstantPropagation::f_t,
-                       IntraMonoFullConstantPropagation::t_t,
-                       IntraMonoFullConstantPropagation::v_t,
-                       IntraMonoFullConstantPropagation::i_t>(
+    : IntraMonoProblem<IntraMonoFullConstantPropagationAnalysisDomain>(
           IRDB, TH, CF, PT, std::move(EntryPoints)) {}
 
 BitVectorSet<std::pair<const llvm::Value *, unsigned>>

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.cpp
@@ -23,11 +23,11 @@
 #include "llvm/IR/Value.h"
 
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
+#include "phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
-#include "phasar/PhasarLLVM/DataFlowSolver/Mono/Problems/IntraMonoSolverTest.h"
 using namespace std;
 using namespace psr;
 
@@ -38,9 +38,7 @@ IntraMonoSolverTest::IntraMonoSolverTest(const ProjectIRDB *IRDB,
                                          const LLVMBasedCFG *CF,
                                          const LLVMPointsToInfo *PT,
                                          std::set<std::string> EntryPoints)
-    : IntraMonoProblem<IntraMonoSolverTest::n_t, IntraMonoSolverTest::d_t,
-                       IntraMonoSolverTest::f_t, IntraMonoSolverTest::t_t,
-                       IntraMonoSolverTest::v_t, IntraMonoSolverTest::i_t>(
+    : IntraMonoProblem<IntraMonoSolverTestAnalysisDomain>(
           IRDB, TH, CF, PT, std::move(EntryPoints)) {}
 
 BitVectorSet<const llvm::Value *>

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
@@ -30,11 +30,8 @@ WPDSAliasCollector::WPDSAliasCollector(const ProjectIRDB *IRDB,
                                        const LLVMBasedICFG *ICF,
                                        LLVMPointsToInfo *PT,
                                        std::set<std::string> EntryPoints)
-    : WPDSProblem<WPDSAliasCollector::n_t, WPDSAliasCollector::d_t,
-                  WPDSAliasCollector::f_t, WPDSAliasCollector::t_t,
-                  WPDSAliasCollector::v_t, WPDSAliasCollector::l_t,
-                  WPDSAliasCollector::i_t>(IRDB, TH, ICF, PT,
-                                           std::move(EntryPoints)) {}
+    : WPDSProblem<WPDSAliasCollectorAnalysisDomain>(IRDB, TH, ICF, PT,
+                                                    std::move(EntryPoints)) {}
 
 shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
 WPDSAliasCollector::getNormalFlowFunction(WPDSAliasCollector::n_t Curr,

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSAliasCollector.cpp
@@ -33,34 +33,32 @@ WPDSAliasCollector::WPDSAliasCollector(const ProjectIRDB *IRDB,
     : WPDSProblem<WPDSAliasCollectorAnalysisDomain>(IRDB, TH, ICF, PT,
                                                     std::move(EntryPoints)) {}
 
-shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
+WPDSAliasCollector::FlowFunctionPtrType
 WPDSAliasCollector::getNormalFlowFunction(WPDSAliasCollector::n_t Curr,
                                           WPDSAliasCollector::n_t Succ) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
+WPDSAliasCollector::FlowFunctionPtrType
 WPDSAliasCollector::getCallFlowFunction(WPDSAliasCollector::n_t CallStmt,
                                         WPDSAliasCollector::f_t DestFun) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
-WPDSAliasCollector::getRetFlowFunction(WPDSAliasCollector::n_t CallSite,
-                                       WPDSAliasCollector::f_t CalleeFun,
-                                       WPDSAliasCollector::n_t ExitStmt,
-                                       WPDSAliasCollector::n_t RetSite) {
+WPDSAliasCollector::FlowFunctionPtrType WPDSAliasCollector::getRetFlowFunction(
+    WPDSAliasCollector::n_t CallSite, WPDSAliasCollector::f_t CalleeFun,
+    WPDSAliasCollector::n_t ExitStmt, WPDSAliasCollector::n_t RetSite) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
+WPDSAliasCollector::FlowFunctionPtrType
 WPDSAliasCollector::getCallToRetFlowFunction(
     WPDSAliasCollector::n_t CallSite, WPDSAliasCollector::n_t RetSite,
     set<WPDSAliasCollector::f_t> Callees) {
   return Identity<WPDSAliasCollector::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSAliasCollector::d_t>>
+WPDSAliasCollector::FlowFunctionPtrType
 WPDSAliasCollector::getSummaryFlowFunction(WPDSAliasCollector::n_t Curr,
                                            WPDSAliasCollector::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSLinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSLinearConstantAnalysis.cpp
@@ -21,16 +21,10 @@ WPDSLinearConstantAnalysis::WPDSLinearConstantAnalysis(
     const ProjectIRDB *IRDB, const LLVMTypeHierarchy *TH,
     const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
     const std::set<std::string> &EntryPoints)
-    : WPDSProblem<
-          WPDSLinearConstantAnalysis::n_t, WPDSLinearConstantAnalysis::d_t,
-          WPDSLinearConstantAnalysis::f_t, WPDSLinearConstantAnalysis::t_t,
-          WPDSLinearConstantAnalysis::v_t, WPDSLinearConstantAnalysis::l_t,
-          WPDSLinearConstantAnalysis::i_t>(IRDB, TH, ICF, PT, EntryPoints),
+    : WPDSProblem<WPDSLinearConstantAnalysisDomain>(IRDB, TH, ICF, PT,
+                                                    EntryPoints),
       IDELinearConstantAnalysis(IRDB, TH, ICF, PT, EntryPoints) {
-  WPDSProblem<WPDSLinearConstantAnalysis::n_t, WPDSLinearConstantAnalysis::d_t,
-              WPDSLinearConstantAnalysis::f_t, WPDSLinearConstantAnalysis::t_t,
-              WPDSLinearConstantAnalysis::v_t, WPDSLinearConstantAnalysis::l_t,
-              WPDSLinearConstantAnalysis::i_t>::ZeroValue =
+  WPDSProblem<WPDSLinearConstantAnalysisDomain>::ZeroValue =
       IDELinearConstantAnalysis::createZeroValue();
 }
 

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
@@ -28,10 +28,8 @@ WPDSSolverTest::WPDSSolverTest(const ProjectIRDB *IRDB,
                                const LLVMTypeHierarchy *TH,
                                const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                                std::set<std::string> EntryPoints)
-    : WPDSProblem<WPDSSolverTest::n_t, WPDSSolverTest::d_t, WPDSSolverTest::f_t,
-                  WPDSSolverTest::t_t, WPDSSolverTest::v_t, WPDSSolverTest::l_t,
-                  WPDSSolverTest::i_t>(IRDB, TH, ICF, PT,
-                                       std::move(EntryPoints)) {}
+    : WPDSProblem<WPDSSolverTestAnalysisDomain>(IRDB, TH, ICF, PT,
+                                                std::move(EntryPoints)) {}
 
 shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
 WPDSSolverTest::getNormalFlowFunction(WPDSSolverTest::n_t Curr,

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/Problems/WPDSSolverTest.cpp
@@ -31,34 +31,32 @@ WPDSSolverTest::WPDSSolverTest(const ProjectIRDB *IRDB,
     : WPDSProblem<WPDSSolverTestAnalysisDomain>(IRDB, TH, ICF, PT,
                                                 std::move(EntryPoints)) {}
 
-shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
+WPDSSolverTest::FlowFunctionPtrType
 WPDSSolverTest::getNormalFlowFunction(WPDSSolverTest::n_t Curr,
                                       WPDSSolverTest::n_t Succ) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
+WPDSSolverTest::FlowFunctionPtrType
 WPDSSolverTest::getCallFlowFunction(WPDSSolverTest::n_t CallStmt,
                                     WPDSSolverTest::f_t DestFun) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
-WPDSSolverTest::getRetFlowFunction(WPDSSolverTest::n_t CallSite,
-                                   WPDSSolverTest::f_t CalleeFun,
-                                   WPDSSolverTest::n_t ExitStmt,
-                                   WPDSSolverTest::n_t RetSite) {
+WPDSSolverTest::FlowFunctionPtrType WPDSSolverTest::getRetFlowFunction(
+    WPDSSolverTest::n_t CallSite, WPDSSolverTest::f_t CalleeFun,
+    WPDSSolverTest::n_t ExitStmt, WPDSSolverTest::n_t RetSite) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
+WPDSSolverTest::FlowFunctionPtrType
 WPDSSolverTest::getCallToRetFlowFunction(WPDSSolverTest::n_t CallSite,
                                          WPDSSolverTest::n_t RetSite,
                                          set<WPDSSolverTest::f_t> Callees) {
   return Identity<WPDSSolverTest::d_t>::getInstance();
 }
 
-shared_ptr<FlowFunction<WPDSSolverTest::d_t>>
+WPDSSolverTest::FlowFunctionPtrType
 WPDSSolverTest::getSummaryFlowFunction(WPDSSolverTest::n_t Curr,
                                        WPDSSolverTest::f_t DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.cxx
@@ -51,19 +51,19 @@ IFDSSFB901TaintAnalysis::IFDSSFB901TaintAnalysis(
     std::set<std::string> EntryPoints)
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSFB901TaintAnalysis::FlowFunctionPtrType
 IFDSSFB901TaintAnalysis::getNormalFlowFunction(const llvm::Instruction *Curr,
                                                const llvm::Instruction *Succ) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSFB901TaintAnalysis::FlowFunctionPtrType
 IFDSSFB901TaintAnalysis::getCallFlowFunction(const llvm::Instruction *CallStmt,
                                              const llvm::Function *DestFun) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSFB901TaintAnalysis::FlowFunctionPtrType
 IFDSSFB901TaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
                                             const llvm::Function *CalleeFun,
                                             const llvm::Instruction *ExitStmt,
@@ -71,14 +71,14 @@ IFDSSFB901TaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSFB901TaintAnalysis::FlowFunctionPtrType
 IFDSSFB901TaintAnalysis::getCallToRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
     set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSFB901TaintAnalysis::FlowFunctionPtrType
 IFDSSFB901TaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.h
+++ b/lib/PhasarLLVM/Plugins/IFDSSFB901TaintAnalysis.h
@@ -27,26 +27,26 @@ public:
                           const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                           std::set<std::string> EntryPoints);
   ~IFDSSFB901TaintAnalysis() = default;
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getNormalFlowFunction(const llvm::Instruction *curr,
                         const llvm::Instruction *succ) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallFlowFunction(const llvm::Instruction *callStmt,
                       const llvm::Function *destFun) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getRetFlowFunction(const llvm::Instruction *callSite,
                      const llvm::Function *calleeFun,
                      const llvm::Instruction *exitStmt,
                      const llvm::Instruction *retSite) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallToRetFlowFunction(const llvm::Instruction *callSite,
                            const llvm::Instruction *retSite,
                            std::set<const llvm::Function *> callees) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getSummaryFlowFunction(const llvm::Instruction *callStmt,
                          const llvm::Function *destFun) override;
 

--- a/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.cxx
@@ -56,7 +56,7 @@ IFDSSimpleTaintAnalysis::IFDSSimpleTaintAnalysis(
     std::set<std::string> EntryPoints)
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSimpleTaintAnalysis::FlowFunctionPtrType
 IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *Curr,
                                                const llvm::Instruction *Succ) {
   if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
@@ -76,7 +76,7 @@ IFDSSimpleTaintAnalysis::getNormalFlowFunction(const llvm::Instruction *Curr,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSimpleTaintAnalysis::FlowFunctionPtrType
 IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *CallStmt,
                                              const llvm::Function *DestFun) {
   if (const auto *Call = llvm::dyn_cast<llvm::CallInst>(CallStmt)) {
@@ -89,7 +89,7 @@ IFDSSimpleTaintAnalysis::getCallFlowFunction(const llvm::Instruction *CallStmt,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSimpleTaintAnalysis::FlowFunctionPtrType
 IFDSSimpleTaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
                                             const llvm::Function *CalleeFun,
                                             const llvm::Instruction *ExitStmt,
@@ -97,14 +97,14 @@ IFDSSimpleTaintAnalysis::getRetFlowFunction(const llvm::Instruction *CallSite,
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSimpleTaintAnalysis::FlowFunctionPtrType
 IFDSSimpleTaintAnalysis::getCallToRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
     set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSSimpleTaintAnalysis::FlowFunctionPtrType
 IFDSSimpleTaintAnalysis::getSummaryFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.h
+++ b/lib/PhasarLLVM/Plugins/IFDSSimpleTaintAnalysis.h
@@ -27,26 +27,26 @@ public:
                           const LLVMBasedICFG *ICF, LLVMPointsToInfo *PT,
                           std::set<std::string> EntryPoints = {});
   ~IFDSSimpleTaintAnalysis() = default;
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getNormalFlowFunction(const llvm::Instruction *curr,
                         const llvm::Instruction *succ) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallFlowFunction(const llvm::Instruction *callStmt,
                       const llvm::Function *destFun) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getRetFlowFunction(const llvm::Instruction *callSite,
                      const llvm::Function *calleeFun,
                      const llvm::Instruction *exitStmt,
                      const llvm::Instruction *retSite) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallToRetFlowFunction(const llvm::Instruction *callSite,
                            const llvm::Instruction *retSite,
                            std::set<const llvm::Function *> callees) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getSummaryFlowFunction(const llvm::Instruction *callStmt,
                          const llvm::Function *destFun) override;
 

--- a/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
+++ b/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.cxx
@@ -51,33 +51,33 @@ IFDSTabulationProblemTestPlugin::IFDSTabulationProblemTestPlugin(
     std::set<std::string> EntryPoints)
     : IFDSTabulationProblemPlugin(IRDB, TH, ICF, PT, std::move(EntryPoints)) {}
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSTabulationProblemTestPlugin::FlowFunctionPtrType
 IFDSTabulationProblemTestPlugin::getNormalFlowFunction(
     const llvm::Instruction *Curr, const llvm::Instruction *Succ) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSTabulationProblemTestPlugin::FlowFunctionPtrType
 IFDSTabulationProblemTestPlugin::getCallFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSTabulationProblemTestPlugin::FlowFunctionPtrType
 IFDSTabulationProblemTestPlugin::getRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Function *CalleeFun,
     const llvm::Instruction *ExitStmt, const llvm::Instruction *RetSite) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSTabulationProblemTestPlugin::FlowFunctionPtrType
 IFDSTabulationProblemTestPlugin::getCallToRetFlowFunction(
     const llvm::Instruction *CallSite, const llvm::Instruction *RetSite,
     set<const llvm::Function *> Callees) {
   return Identity<const llvm::Value *>::getInstance();
 }
 
-shared_ptr<FlowFunction<const llvm::Value *>>
+IFDSTabulationProblemTestPlugin::FlowFunctionPtrType
 IFDSTabulationProblemTestPlugin::getSummaryFlowFunction(
     const llvm::Instruction *CallStmt, const llvm::Function *DestFun) {
   return nullptr;

--- a/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.h
+++ b/lib/PhasarLLVM/Plugins/IFDSTabulationProblemTestPlugin.h
@@ -31,26 +31,26 @@ public:
 
   ~IFDSTabulationProblemTestPlugin() = default;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getNormalFlowFunction(const llvm::Instruction *curr,
                         const llvm::Instruction *succ) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallFlowFunction(const llvm::Instruction *callStmt,
                       const llvm::Function *destFun) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getRetFlowFunction(const llvm::Instruction *callSite,
                      const llvm::Function *calleeFun,
                      const llvm::Instruction *exitStmt,
                      const llvm::Instruction *retSite) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getCallToRetFlowFunction(const llvm::Instruction *callSite,
                            const llvm::Instruction *retSite,
                            std::set<const llvm::Function *> callees) override;
 
-  std::shared_ptr<FlowFunction<const llvm::Value *>>
+  FlowFunctionPtrType
   getSummaryFlowFunction(const llvm::Instruction *callStmt,
                          const llvm::Function *destFun) override;
 

--- a/tools/example-tool/myphasartool.cpp
+++ b/tools/example-tool/myphasartool.cpp
@@ -51,20 +51,13 @@ int main(int Argc, const char **Argv) {
     // IFDS template parametrization test
     std::cout << "Testing IFDS:\n";
     IFDSLinearConstantAnalysis L(&DB, &H, &I, &P, {"main"});
-    IFDSSolver<IFDSLinearConstantAnalysis::n_t, IFDSLinearConstantAnalysis::d_t,
-               IFDSLinearConstantAnalysis::f_t, IFDSLinearConstantAnalysis::t_t,
-               IFDSLinearConstantAnalysis::v_t, IFDSLinearConstantAnalysis::i_t>
-        S(L);
+    IFDSSolver S(L);
     S.solve();
     S.dumpResults();
     // IDE template parametrization test
     std::cout << "Testing IDE:\n";
     IDELinearConstantAnalysis M(&DB, &H, &I, &P, {"main"});
-    IDESolver<IDELinearConstantAnalysis::n_t, IDELinearConstantAnalysis::d_t,
-              IDELinearConstantAnalysis::f_t, IDELinearConstantAnalysis::t_t,
-              IDELinearConstantAnalysis::v_t, IDELinearConstantAnalysis::l_t,
-              IDELinearConstantAnalysis::i_t>
-        T(M);
+    IDESolver T(M);
     T.solve();
     T.dumpResults();
   } else {

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -35,11 +35,7 @@ protected:
     LLVMBasedICFG ICFG(*IRDB, CallGraphAnalysisType::OTF, EntryPoints, &TH,
                        &PT);
     IDELinearConstantAnalysis LCAProblem(IRDB, &TH, &ICFG, &PT, EntryPoints);
-    IDESolver<IDELinearConstantAnalysis::n_t, IDELinearConstantAnalysis::d_t,
-              IDELinearConstantAnalysis::f_t, IDELinearConstantAnalysis::t_t,
-              IDELinearConstantAnalysis::v_t, IDELinearConstantAnalysis::l_t,
-              IDELinearConstantAnalysis::i_t>
-        LCASolver(LCAProblem);
+    IDESolver_P<IDELinearConstantAnalysis> LCASolver(LCAProblem);
     LCASolver.solve();
     if (PrintDump) {
       LCASolver.dumpResults();

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
@@ -36,11 +36,7 @@ protected:
     LLVMBasedICFG ICFG(*IRDB, CallGraphAnalysisType::OTF, EntryPoints, &TH,
                        &PT);
     IDELinearConstantAnalysis LCAProblem(IRDB, &TH, &ICFG, &PT, EntryPoints);
-    IDESolver<IDELinearConstantAnalysis::n_t, IDELinearConstantAnalysis::d_t,
-              IDELinearConstantAnalysis::f_t, IDELinearConstantAnalysis::t_t,
-              IDELinearConstantAnalysis::v_t, IDELinearConstantAnalysis::l_t,
-              IDELinearConstantAnalysis::i_t>
-        LCASolver(LCAProblem);
+    IDESolver_P<IDELinearConstantAnalysis> LCASolver(LCAProblem);
     LCASolver.solve();
     if (emitESG) {
       boost::log::core::get()->set_logging_enabled(true);

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisFileIOTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisFileIOTest.cpp
@@ -77,10 +77,7 @@ protected:
    */
   void compareResults(
       const std::map<std::size_t, std::map<std::string, int>> &GroundTruth,
-      IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-                IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-                IDETypeStateAnalysis::i_t> &Solver) {
+      IDESolver_P<IDETypeStateAnalysis> &Solver) {
     for (const auto &InstToGroundTruth : GroundTruth) {
       auto *Inst = IRDB->getInstruction(InstToGroundTruth.first);
       // std::cout << "Handle results at " << InstToGroundTruth.first <<
@@ -100,11 +97,7 @@ protected:
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_01) {
   initialize({PathToLlFiles + "typestate_01_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
       {5, {{"3", IOSTATE::UNINIT}}},
@@ -115,11 +108,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_01) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_02) {
   initialize({PathToLlFiles + "typestate_02_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -129,11 +118,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_02) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_03) {
   initialize({PathToLlFiles + "typestate_03_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   // llvmtssolver.printReport();
@@ -159,11 +144,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_03) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_04) {
   initialize({PathToLlFiles + "typestate_04_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
 
@@ -185,11 +166,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_04) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_05) {
   initialize({PathToLlFiles + "typestate_05_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -208,11 +185,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_05) {
 TEST_F(IDETSAnalysisFileIOTest, DISABLED_HandleTypeState_06) {
   // This test fails due to imprecise points-to information
   initialize({PathToLlFiles + "typestate_06_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -247,11 +220,7 @@ TEST_F(IDETSAnalysisFileIOTest, DISABLED_HandleTypeState_06) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_07) {
   initialize({PathToLlFiles + "typestate_07_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -283,11 +252,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_07) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_08) {
   initialize({PathToLlFiles + "typestate_08_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -300,11 +265,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_08) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_09) {
   initialize({PathToLlFiles + "typestate_09_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -322,11 +283,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_09) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_10) {
   initialize({PathToLlFiles + "typestate_10_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -348,11 +305,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_10) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_11) {
   initialize({PathToLlFiles + "typestate_11_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -379,11 +332,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_11) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_12) {
   initialize({PathToLlFiles + "typestate_12_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -403,11 +352,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_12) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_13) {
   initialize({PathToLlFiles + "typestate_13_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -422,11 +367,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_13) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_14) {
   initialize({PathToLlFiles + "typestate_14_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -449,11 +390,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_14) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_15) {
   initialize({PathToLlFiles + "typestate_15_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -512,11 +449,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_15) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_16) {
   initialize({PathToLlFiles + "typestate_16_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
 
@@ -548,11 +481,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_16) {
 // TODO: Check this case again!
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_17) {
   initialize({PathToLlFiles + "typestate_17_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -579,11 +508,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_17) {
 
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_18) {
   initialize({PathToLlFiles + "typestate_18_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {
@@ -601,11 +526,7 @@ TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_18) {
 // TODO: Check this case again!
 TEST_F(IDETSAnalysisFileIOTest, HandleTypeState_19) {
   initialize({PathToLlFiles + "typestate_19_c.ll"});
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t>
-      Llvmtssolver(*TSProblem);
+  IDESolver_P<IDETypeStateAnalysis> Llvmtssolver(*TSProblem);
 
   Llvmtssolver.solve();
   const std::map<std::size_t, std::map<std::string, int>> Gt = {

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
@@ -61,7 +61,7 @@ protected:
     TSKDFProblem = new IDETypeStateAnalysis(IRDB, TH, ICFG, PT,
                                             *OpenSSLEVPKDFDesc, EntryPoints);
     KdfSolver =
-        new IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain>(*TSKDFProblem);
+        new IDESolver<IDETypeStateAnalysisDomain>(*TSKDFProblem);
 
     OpenSSLEVPKeyDerivationDesc = new OpenSSLEVPKDFCTXDescription(*KdfSolver);
     TSProblem = new IDETypeStateAnalysis(

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
@@ -36,11 +36,7 @@ protected:
   OpenSSLEVPKDFCTXDescription *OpenSSLEVPKeyDerivationDesc{};
   OpenSSLEVPKDFDescription *OpenSSLEVPKDFDesc{};
   IDETypeStateAnalysis *TSProblem{}, *TSKDFProblem{};
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t> *Llvmtssolver{},
-      *KdfSolver{};
+  IDESolver<IDETypeStateAnalysisDomain> *Llvmtssolver{}, *KdfSolver{};
 
   enum OpenSSLEVPKeyDerivationState {
     TOP = 42,
@@ -65,20 +61,13 @@ protected:
     TSKDFProblem = new IDETypeStateAnalysis(IRDB, TH, ICFG, PT,
                                             *OpenSSLEVPKDFDesc, EntryPoints);
     KdfSolver =
-        new IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                      IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-                      IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-                      IDETypeStateAnalysis::i_t>(*TSKDFProblem);
+        new IDESolver<OpenSSLEVPKDFCTXDescriptionAnalysisDomain>(*TSKDFProblem);
 
     OpenSSLEVPKeyDerivationDesc = new OpenSSLEVPKDFCTXDescription(*KdfSolver);
     TSProblem = new IDETypeStateAnalysis(
         IRDB, TH, ICFG, PT, *OpenSSLEVPKeyDerivationDesc, EntryPoints);
 
-    Llvmtssolver =
-        new IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                      IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-                      IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-                      IDETypeStateAnalysis::i_t>(*TSProblem);
+    Llvmtssolver = new IDESolver<IDETypeStateAnalysisDomain>(*TSProblem);
     KdfSolver->solve();
     Llvmtssolver->solve();
   }

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
@@ -60,8 +60,7 @@ protected:
     OpenSSLEVPKDFDesc = new OpenSSLEVPKDFDescription();
     TSKDFProblem = new IDETypeStateAnalysis(IRDB, TH, ICFG, PT,
                                             *OpenSSLEVPKDFDesc, EntryPoints);
-    KdfSolver =
-        new IDESolver<IDETypeStateAnalysisDomain>(*TSKDFProblem);
+    KdfSolver = new IDESolver<IDETypeStateAnalysisDomain>(*TSKDFProblem);
 
     OpenSSLEVPKeyDerivationDesc = new OpenSSLEVPKDFCTXDescription(*KdfSolver);
     TSProblem = new IDETypeStateAnalysis(

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
@@ -35,10 +35,7 @@ protected:
   LLVMPointsToInfo *PT{};
   OpenSSLSecureHeapDescription *Desc{};
   IDETypeStateAnalysis *TSProblem{};
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t> *Llvmtssolver = nullptr;
+  IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain> *Llvmtssolver = nullptr;
   IDESolver<const llvm::Instruction *, SecureHeapFact, const llvm::Function *,
             const llvm::StructType *, const llvm::Value *, SecureHeapValue,
             LLVMBasedICFG> *SecureHeapPropagationResults{};
@@ -74,10 +71,7 @@ protected:
     TSProblem =
         new IDETypeStateAnalysis(IRDB, TH, ICFG, PT, *Desc, EntryPoints);
     Llvmtssolver =
-        new IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                      IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-                      IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-                      IDETypeStateAnalysis::i_t>(*TSProblem);
+        new IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>(*TSProblem);
 
     SecureHeapPropagationResults->solve();
     Llvmtssolver->solve();

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
@@ -36,7 +36,8 @@ protected:
   OpenSSLSecureHeapDescription *Desc{};
   IDETypeStateAnalysis *TSProblem{};
   IDESolver<IDETypeStateAnalysisDomain> *Llvmtssolver{};
-  IDESolver<IDESecureHeapPropagationAnalysisDomain> *SecureHeapPropagationResults{};
+  IDESolver<IDESecureHeapPropagationAnalysisDomain>
+      *SecureHeapPropagationResults{};
   IDESecureHeapPropagation *SecureHeapPropagationProblem{};
   enum OpenSSLSecureHeapState {
     TOP = 42,
@@ -66,8 +67,7 @@ protected:
     Desc = new OpenSSLSecureHeapDescription(*SecureHeapPropagationResults);
     TSProblem =
         new IDETypeStateAnalysis(IRDB, TH, ICFG, PT, *Desc, EntryPoints);
-    Llvmtssolver =
-        new IDESolver<IDETypeStateAnalysisDomain>(*TSProblem);
+    Llvmtssolver = new IDESolver<IDETypeStateAnalysisDomain>(*TSProblem);
 
     SecureHeapPropagationResults->solve();
     Llvmtssolver->solve();

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureHeapTest.cpp
@@ -35,10 +35,8 @@ protected:
   LLVMPointsToInfo *PT{};
   OpenSSLSecureHeapDescription *Desc{};
   IDETypeStateAnalysis *TSProblem{};
-  IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain> *Llvmtssolver = nullptr;
-  IDESolver<const llvm::Instruction *, SecureHeapFact, const llvm::Function *,
-            const llvm::StructType *, const llvm::Value *, SecureHeapValue,
-            LLVMBasedICFG> *SecureHeapPropagationResults{};
+  IDESolver<IDETypeStateAnalysisDomain> *Llvmtssolver{};
+  IDESolver<IDESecureHeapPropagationAnalysisDomain> *SecureHeapPropagationResults{};
   IDESecureHeapPropagation *SecureHeapPropagationProblem{};
   enum OpenSSLSecureHeapState {
     TOP = 42,
@@ -62,16 +60,14 @@ protected:
     SecureHeapPropagationProblem =
         new IDESecureHeapPropagation(IRDB, TH, ICFG, PT, EntryPoints);
     SecureHeapPropagationResults =
-        new IDESolver<const llvm::Instruction *, SecureHeapFact,
-                      const llvm::Function *, const llvm::StructType *,
-                      const llvm::Value *, SecureHeapValue, LLVMBasedICFG>(
+        new IDESolver<IDESecureHeapPropagationAnalysisDomain>(
             *SecureHeapPropagationProblem);
 
     Desc = new OpenSSLSecureHeapDescription(*SecureHeapPropagationResults);
     TSProblem =
         new IDETypeStateAnalysis(IRDB, TH, ICFG, PT, *Desc, EntryPoints);
     Llvmtssolver =
-        new IDESolver<OpenSSLSecureHeapDescriptionAnalysisDomain>(*TSProblem);
+        new IDESolver<IDETypeStateAnalysisDomain>(*TSProblem);
 
     SecureHeapPropagationResults->solve();
     Llvmtssolver->solve();

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureMemoryTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDETSAnalysisOpenSSLSecureMemoryTest.cpp
@@ -33,10 +33,7 @@ protected:
   LLVMPointsToInfo *PT{};
   OpenSSLSecureMemoryDescription *Desc{};
   IDETypeStateAnalysis *TSProblem{};
-  IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-            IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-            IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-            IDETypeStateAnalysis::i_t> *Llvmtssolver = nullptr;
+  IDESolver_P<IDETypeStateAnalysis> *Llvmtssolver = nullptr;
 
   enum OpenSSLSecureMemoryState {
     TOP = 42,
@@ -58,11 +55,7 @@ protected:
     Desc = new OpenSSLSecureMemoryDescription();
     TSProblem =
         new IDETypeStateAnalysis(IRDB, TH, ICFG, PT, *Desc, EntryPoints);
-    Llvmtssolver =
-        new IDESolver<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                      IDETypeStateAnalysis::f_t, IDETypeStateAnalysis::t_t,
-                      IDETypeStateAnalysis::v_t, IDETypeStateAnalysis::l_t,
-                      IDETypeStateAnalysis::i_t>(*TSProblem);
+    Llvmtssolver = new IDESolver_P<IDETypeStateAnalysis>(*TSProblem);
 
     Llvmtssolver->solve();
   }

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
@@ -50,11 +50,8 @@ protected:
     delete Constproblem;
   }
 
-  void compareResults(
-      const std::set<unsigned long> &GroundTruth,
-      IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-                 IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-                 IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t> &Solver) {
+  void compareResults(const std::set<unsigned long> &GroundTruth,
+                      IFDSSolver_P<IFDSConstAnalysis> &Solver) {
     std::set<const llvm::Value *> AllMutableAllocas;
     for (const auto *RR : IRDB->getRetOrResInstructions()) {
       std::set<const llvm::Value *> Facts = Solver.ifdsResultsAt(RR);
@@ -77,40 +74,28 @@ protected:
 /* ============== BASIC TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_01) {
   initialize({PathToLlFiles + "basic/basic_01_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_02) {
   initialize({PathToLlFiles + "basic/basic_02_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_03) {
   initialize({PathToLlFiles + "basic/basic_03_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleBasicTest_04) {
   initialize({PathToLlFiles + "basic/basic_04_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
@@ -118,50 +103,35 @@ TEST_F(IFDSConstAnalysisTest, HandleBasicTest_04) {
 /* ============== CONTROL FLOW TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleCFForTest_01) {
   initialize({PathToLlFiles + "control_flow/cf_for_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCFForTest_02) {
   initialize({PathToLlFiles + "control_flow/cf_for_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_01) {
   initialize({PathToLlFiles + "control_flow/cf_if_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCFIfTest_02) {
   initialize({PathToLlFiles + "control_flow/cf_if_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCFWhileTest_01) {
   initialize({PathToLlFiles + "control_flow/cf_while_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
@@ -169,20 +139,14 @@ TEST_F(IFDSConstAnalysisTest, HandleCFWhileTest_01) {
 /* ============== POINTER TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_01) {
   initialize({PathToLlFiles + "pointer/pointer_01_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_02) {
   initialize({PathToLlFiles + "pointer/pointer_02_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
@@ -191,20 +155,14 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandlePointerTest_03) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "pointer/pointer_03_cpp_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({2, 3}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandlePointerTest_04) {
   initialize({PathToLlFiles + "pointer/pointer_04_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({4}, Llvmconstsolver);
 }
@@ -212,30 +170,21 @@ TEST_F(IFDSConstAnalysisTest, HandlePointerTest_04) {
 /* ============== GLOBAL TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_01) {
   initialize({PathToLlFiles + "global/global_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_02) {
   initialize({PathToLlFiles + "global/global_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0, 1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleGlobalTest_03) {
   initialize({PathToLlFiles + "global/global_03_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
@@ -244,10 +193,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleGlobalTest_04) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "global/global_04_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0, 4}, Llvmconstsolver);
 }
@@ -255,30 +201,21 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleGlobalTest_04) {
 /* ============== CALL TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_01) {
   initialize({PathToLlFiles + "call/param/call_param_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({5}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_02) {
   initialize({PathToLlFiles + "call/param/call_param_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({5}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_03) {
   initialize({PathToLlFiles + "call/param/call_param_03_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
@@ -287,10 +224,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCallParamTest_04) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "call/param/call_param_04_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
@@ -299,70 +233,49 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCallParamTest_05) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "call/param/call_param_05_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({2}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_06) {
   initialize({PathToLlFiles + "call/param/call_param_06_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_07) {
   initialize({PathToLlFiles + "call/param/call_param_07_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({6}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallParamTest_08) {
   initialize({PathToLlFiles + "call/param/call_param_08_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({4}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_01) {
   initialize({PathToLlFiles + "call/return/call_ret_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_02) {
   initialize({PathToLlFiles + "call/return/call_ret_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_03) {
   initialize({PathToLlFiles + "call/return/call_ret_03_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
@@ -370,30 +283,21 @@ TEST_F(IFDSConstAnalysisTest, HandleCallReturnTest_03) {
 /* ============== ARRAY TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_01) {
   initialize({PathToLlFiles + "array/array_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_02) {
   initialize({PathToLlFiles + "array/array_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_03) {
   initialize({PathToLlFiles + "array/array_03_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
@@ -402,30 +306,21 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_04) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "array/array_04_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_05) {
   initialize({PathToLlFiles + "array/array_05_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_06) {
   initialize({PathToLlFiles + "array/array_06_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
@@ -434,30 +329,21 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleArrayTest_07) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "array/array_07_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_08) {
   initialize({PathToLlFiles + "array/array_08_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleArrayTest_09) {
   initialize({PathToLlFiles + "array/array_09_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0}, Llvmconstsolver);
 }
@@ -465,30 +351,21 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_09) {
 /* ============== STL ARRAY TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_01) {
   initialize({PathToLlFiles + "array/stl_array/stl_array_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_02) {
   initialize({PathToLlFiles + "array/stl_array/stl_array_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({1}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_03) {
   initialize({PathToLlFiles + "array/stl_array/stl_array_03_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({2}, Llvmconstsolver);
 }
@@ -497,30 +374,21 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleSTLArrayTest_04) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "array/stl_array/stl_array_04_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_05) {
   initialize({PathToLlFiles + "array/stl_array/stl_array_05_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
 
 TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_06) {
   initialize({PathToLlFiles + "array/stl_array/stl_array_06_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({2}, Llvmconstsolver);
 }
@@ -528,10 +396,7 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_06) {
 /* ============== CSTRING TESTS ============== */
 TEST_F(IFDSConstAnalysisTest, HandleCStringTest_01) {
   initialize({PathToLlFiles + "array/cstring/cstring_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({}, Llvmconstsolver);
 }
@@ -540,10 +405,7 @@ TEST_F(IFDSConstAnalysisTest, DISABLED_HandleCStringTest_02) {
   // Guaranteed to fail - enable, once we have more precise points-to
   // information
   initialize({PathToLlFiles + "array/cstring/cstring_02_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-             IFDSConstAnalysis::f_t, IFDSConstAnalysis::t_t,
-             IFDSConstAnalysis::v_t, IFDSConstAnalysis::i_t>
-      Llvmconstsolver(*Constproblem);
+  IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({2}, Llvmconstsolver);
 }

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
@@ -73,10 +73,7 @@ protected:
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_01) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_01_cpp_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[13] = set<string>{"12"};
@@ -85,10 +82,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_01) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_01_m2r) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_01_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[4] = set<string>{"2"};
@@ -97,10 +91,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_01_m2r) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_02) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_02_cpp_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[9] = set<string>{"8"};
@@ -109,10 +100,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_02) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_03) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_03_cpp_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[18] = set<string>{"17"};
@@ -121,10 +109,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_03) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_04) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_04_cpp_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[19] = set<string>{"18"};
@@ -134,10 +119,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_04) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_05) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_05_cpp_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[22] = set<string>{"21"};
@@ -146,10 +128,7 @@ TEST_F(IFDSTaintAnalysisTest, TaintTest_05) {
 
 TEST_F(IFDSTaintAnalysisTest, TaintTest_06) {
   initialize({PathToLlFiles + "dummy_source_sink/taint_06_cpp_m2r_dbg.ll"});
-  IFDSSolver<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-             IFDSTaintAnalysis::f_t, IFDSTaintAnalysis::t_t,
-             IFDSTaintAnalysis::v_t, IFDSTaintAnalysis::i_t>
-      TaintSolver(*TaintProblem);
+  IFDSSolver_P<IFDSTaintAnalysis> TaintSolver(*TaintProblem);
   TaintSolver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[5] = set<string>{"main.0"};

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
@@ -70,10 +70,7 @@ protected:
 
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_01_SHOULD_NOT_LEAK) {
   initialize({PathToLlFiles + "all_uninit_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // all_uninit.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -82,10 +79,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_01_SHOULD_NOT_LEAK) {
 
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_02_SHOULD_LEAK) {
   initialize({PathToLlFiles + "binop_uninit_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
 
   // binop_uninit uses uninitialized variable i in 'int j = i + 10;'
@@ -99,10 +93,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_02_SHOULD_LEAK) {
 }
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_03_SHOULD_LEAK) {
   initialize({PathToLlFiles + "callnoret_c_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
 
   // callnoret uses uninitialized variable a in 'return a + 10;' of addTen(int)
@@ -124,10 +115,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_03_SHOULD_LEAK) {
 
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_04_SHOULD_NOT_LEAK) {
   initialize({PathToLlFiles + "ctor_default_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // ctor.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -136,10 +124,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_04_SHOULD_NOT_LEAK) {
 
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_05_SHOULD_NOT_LEAK) {
   initialize({PathToLlFiles + "struct_member_init_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // struct_member_init.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -147,10 +132,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_05_SHOULD_NOT_LEAK) {
 }
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_06_SHOULD_NOT_LEAK) {
   initialize({PathToLlFiles + "struct_member_uninit_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // struct_member_uninit.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -177,10 +159,7 @@ Solver(*UninitProblem, false); Solver.solve();
 *****************************************************************************************/
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_08_SHOULD_NOT_LEAK) {
   initialize({PathToLlFiles + "global_variable_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // global_variable.cpp does not contain undef-uses
   map<int, set<string>> GroundTruth;
@@ -205,10 +184,7 @@ Solver(*UninitProblem, false); Solver.solve();
 *****************************************************************************************/
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_10_SHOULD_LEAK) {
   initialize({PathToLlFiles + "return_uninit_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   UninitProblem->emitTextReport(Solver.getSolverResults(), std::cout);
   map<int, set<string>> GroundTruth;
@@ -223,10 +199,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_10_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_11_SHOULD_NOT_LEAK) {
 
   initialize({PathToLlFiles + "sanitizer_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   // all undef-uses are sanitized;
@@ -256,10 +229,7 @@ Solver(*UninitProblem, true); Solver.solve();
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_13_SHOULD_NOT_LEAK) {
 
   initialize({PathToLlFiles + "sanitizer2_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   // The undef-uses do not affect the program behaviour, but are of course still
   // found and reported
@@ -270,10 +240,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_13_SHOULD_NOT_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_14_SHOULD_LEAK) {
 
   initialize({PathToLlFiles + "uninit_c_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
   map<int, set<string>> GroundTruth;
   GroundTruth[14] = {"1"};
@@ -317,10 +284,7 @@ GroundTruth;
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_16_SHOULD_LEAK) {
 
   initialize({PathToLlFiles + "growing_example_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver<LLVMAnalysisDomainDefault> Solver(*UninitProblem);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -390,10 +354,7 @@ Solver(*UninitProblem, false); Solver.solve();
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_20_SHOULD_LEAK) {
 
   initialize({PathToLlFiles + "recursion_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver_P<IFDSUninitializedVariables> Solver(*UninitProblem);
   Solver.solve();
 
   map<int, set<string>> GroundTruth;
@@ -414,10 +375,7 @@ TEST_F(IFDSUninitializedVariablesTest, UninitTest_20_SHOULD_LEAK) {
 TEST_F(IFDSUninitializedVariablesTest, UninitTest_21_SHOULD_LEAK) {
 
   initialize({PathToLlFiles + "virtual_call_cpp_dbg.ll"});
-  IFDSSolver<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-             IFDSUninitializedVariables::f_t, IFDSUninitializedVariables::t_t,
-             IFDSUninitializedVariables::v_t, IFDSUninitializedVariables::i_t>
-      Solver(*UninitProblem);
+  IFDSSolver_P<IFDSUninitializedVariables> Solver(*UninitProblem);
   Solver.solve();
 
   map<int, set<string>> GroundTruth = {

--- a/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoTaintAnalysisTest.cpp
@@ -40,10 +40,7 @@ protected:
     LLVMBasedICFG ICFG(*IRDB, CallGraphAnalysisType::OTF, EntryPoints, &TH, PT);
     TaintConfiguration<InterMonoTaintAnalysis::d_t> TC;
     InterMonoTaintAnalysis TaintProblem(IRDB, &TH, &ICFG, PT, TC, EntryPoints);
-    InterMonoSolver<InterMonoTaintAnalysis::n_t, InterMonoTaintAnalysis::d_t,
-                    InterMonoTaintAnalysis::f_t, InterMonoTaintAnalysis::t_t,
-                    InterMonoTaintAnalysis::v_t, InterMonoTaintAnalysis::i_t, 3>
-        TaintSolver(TaintProblem);
+    InterMonoSolver<LLVMAnalysisDomainDefault, 3> TaintSolver(TaintProblem);
     TaintSolver.solve();
     if (PrintDump) {
       TaintSolver.dumpResults();
@@ -68,10 +65,7 @@ protected:
     LLVMBasedICFG ICFG(*IRDB, CallGraphAnalysisType::OTF, EntryPoints, &TH, PT);
     TaintConfiguration<InterMonoTaintAnalysis::d_t> TC;
     InterMonoTaintAnalysis TaintProblem(IRDB, &TH, &ICFG, PT, TC, EntryPoints);
-    InterMonoSolver<InterMonoTaintAnalysis::n_t, InterMonoTaintAnalysis::d_t,
-                    InterMonoTaintAnalysis::f_t, InterMonoTaintAnalysis::t_t,
-                    InterMonoTaintAnalysis::v_t, InterMonoTaintAnalysis::i_t, 3>
-        TaintSolver(TaintProblem);
+    InterMonoSolver<LLVMAnalysisDomainDefault, 3> TaintSolver(TaintProblem);
     TaintSolver.solve();
     if (PrintDump) {
       TaintSolver.dumpResults();


### PR DESCRIPTION
This reworks phasar analyses to be configured by an AnalysisDomain.  The
AnalysisDomain domain specifies all relevant domain values for the
analysis that where previously specified via individual template
parameters.