### PR TITLE
Integrates phasar testing into cmake

### DIFF
--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -4,6 +4,7 @@ function(add_phasar_unittest test_name)
   add_executable(${test}
     ${test_name}
   )
+  add_dependencies(PhasarUnitTests ${test})
 
   if(USE_LLVM_FAT_LIB)
     llvm_config(${test} USE_SHARED ${LLVM_LINK_COMPONENTS})
@@ -40,6 +41,7 @@ function(add_phasar_unittest test_name)
 
   add_test(NAME "${test}"
     COMMAND ${test} ${CATCH_TEST_FILTER}
+    WORKING_DIRECTORY ${PHASAR_UNITTEST_DIR}
   )
   set_tests_properties("${test}" PROPERTIES LABELS "all")
   set(CTEST_OUTPUT_ON_FAILURE ON)

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -34,6 +34,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+#include "phasar/Config/Configuration.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowEdgeFunctionCache.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/FlowFunctions.h"
@@ -1618,7 +1619,9 @@ protected:
 public:
   void enableESGAsDot() { SolverConfig.setEmitESG(); }
 
-  void emitESGAsDot(std::ostream &OS = std::cout) {
+  void
+  emitESGAsDot(std::ostream &OS = std::cout,
+               std::string DotConfigDir = PhasarConfig::PhasarDirectory()) {
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                       << "Emit Exploded super-graph (ESG) as DOT graph";
                   BOOST_LOG_SEV(lg::get(), DEBUG)
@@ -1626,7 +1629,7 @@ public:
                   BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "=============================================");
     DOTGraph<d_t> G;
-    DOTConfig::importDOTConfig();
+    DOTConfig::importDOTConfig(std::move(DotConfigDir));
     DOTFunctionSubGraph *FG = nullptr;
 
     // Sort intra-procedural path edges

--- a/include/phasar/PhasarLLVM/Utils/DOTGraph.h
+++ b/include/phasar/PhasarLLVM/Utils/DOTGraph.h
@@ -22,6 +22,7 @@
 #include <set>
 #include <string>
 
+#include "phasar/Config/Configuration.h"
 #include "phasar/Utils/Utilities.h"
 
 namespace psr {
@@ -41,7 +42,8 @@ public:
   static const std::string LambdaIDEdgeAttr() { return LambdaIDEdge; }
   static const std::string LambdaInterEdgeAttr() { return LambdaInterEdge; }
 
-  static void importDOTConfig();
+  static void
+  importDOTConfig(std::string ConfigPath = PhasarConfig::PhasarDirectory());
 
   static DOTConfig &getDOTConfig();
   ~DOTConfig() = default;

--- a/lib/PhasarLLVM/Utils/DOTGraph.cpp
+++ b/lib/PhasarLLVM/Utils/DOTGraph.cpp
@@ -23,7 +23,6 @@
 
 #include "nlohmann/json.hpp"
 
-#include "phasar/Config/Configuration.h"
 #include "phasar/PhasarLLVM/Utils/DOTGraph.h"
 
 namespace psr {
@@ -247,8 +246,8 @@ DOTConfig &DOTConfig::getDOTConfig() {
   return DC;
 }
 
-void DOTConfig::importDOTConfig() {
-  boost::filesystem::path FilePath(PhasarConfig::PhasarDirectory());
+void DOTConfig::importDOTConfig(std::string ConfigPath) {
+  boost::filesystem::path FilePath(ConfigPath);
   FilePath /= boost::filesystem::path("config/DOTGraphConfig.json");
   if (boost::filesystem::exists(FilePath) &&
       !boost::filesystem::is_directory(FilePath)) {

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,26 @@
-add_custom_target(UnitTests)
-set_target_properties(UnitTests PROPERTIES FOLDER "Tests")
-add_dependencies(UnitTests LLFileGeneration)
+add_custom_target(PhasarUnitTests)
+set_target_properties(PhasarUnitTests PROPERTIES FOLDER "Unittests")
+add_dependencies(PhasarUnitTests LLFileGeneration)
+
+set(PHASAR_UNITTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(check-phasar-unittests
+  COMMAND ${CMAKE_CTEST_COMMAND} --progress --output-on-failure -j 8
+  WORKING_DIRECTORY ${PHASAR_UNITTEST_DIR}
+  DEPENDS PhasarUnitTests
+)
+
+# Provide config files for unit tests
+file(MAKE_DIRECTORY ${PHASAR_UNITTEST_DIR}/config/)
+set(PHASAR_CONFIG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../config/")
+function(test_require_config_file file_name)
+  configure_file("${PHASAR_CONFIG_DIR}${file_name}"
+    "${PHASAR_UNITTEST_DIR}/config/."
+    COPYONLY
+  )
+endfunction()
+
+include_directories(TestUtils)
 
 add_subdirectory(Config)
 add_subdirectory(Controller)

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFGTest.cpp
@@ -9,19 +9,15 @@
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedBackwardCFGTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedBackwardCFGTest, BranchTargetTest) {
+TEST(LLVMBasedBackwardCFGTest, BranchTargetTest) {
   LLVMBasedBackwardCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   const auto *Term = getNthTermInstruction(F, 1);
   const auto *A = getNthInstruction(F, 10);
@@ -33,9 +29,10 @@ TEST_F(LLVMBasedBackwardCFGTest, BranchTargetTest) {
   ASSERT_FALSE(Cfg.isBranchTarget(C, Term));
 }
 
-TEST_F(LLVMBasedBackwardCFGTest, HandlesMulitplePredeccessors) {
+TEST(LLVMBasedBackwardCFGTest, HandlesMulitplePredeccessors) {
   LLVMBasedBackwardCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING CONDITIONAL BRANCH
@@ -59,9 +56,10 @@ TEST_F(LLVMBasedBackwardCFGTest, HandlesMulitplePredeccessors) {
   ASSERT_EQ(PredsOfBrInst, Predeccessors);
 }
 
-TEST_F(LLVMBasedBackwardCFGTest, HandlesSingleOrEmptyPredeccessor) {
+TEST(LLVMBasedBackwardCFGTest, HandlesSingleOrEmptyPredeccessor) {
   LLVMBasedBackwardCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/function_call_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/function_call_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING SINGLE PREDECCESSOR
@@ -81,9 +79,10 @@ TEST_F(LLVMBasedBackwardCFGTest, HandlesSingleOrEmptyPredeccessor) {
   ASSERT_EQ(PredsOfTermInst, Predeccessor);
 }
 
-TEST_F(LLVMBasedBackwardCFGTest, HandlesMultipleSuccessors) {
+TEST(LLVMBasedBackwardCFGTest, HandlesMultipleSuccessors) {
   LLVMBasedBackwardCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // ret i32 0
@@ -98,9 +97,10 @@ TEST_F(LLVMBasedBackwardCFGTest, HandlesMultipleSuccessors) {
   ASSERT_EQ(SuccsOfTermInst, Successor);
 }
 
-TEST_F(LLVMBasedBackwardCFGTest, HandlesSingleOrEmptySuccessor) {
+TEST(LLVMBasedBackwardCFGTest, HandlesSingleOrEmptySuccessor) {
   LLVMBasedBackwardCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING SINGLE SUCCESSOR

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
@@ -8,19 +8,15 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedCFGTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedCFGTest, FallThroughSuccTest) {
+TEST(LLVMBasedCFGTest, FallThroughSuccTest) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING CONDITIONAL BRANCH
@@ -40,9 +36,10 @@ TEST_F(LLVMBasedCFGTest, FallThroughSuccTest) {
       Cfg.isFallThroughSuccessor(BranchInst, getNthTermInstruction(F, 4)));
 }
 
-TEST_F(LLVMBasedCFGTest, BranchTargetTest) {
+TEST(LLVMBasedCFGTest, BranchTargetTest) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/switch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/switch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING SWITCH INSTRUCTION
@@ -75,9 +72,10 @@ TEST_F(LLVMBasedCFGTest, BranchTargetTest) {
   ASSERT_TRUE(Cfg.isBranchTarget(BranchInst, getNthTermInstruction(F, 6)));
 }
 
-TEST_F(LLVMBasedCFGTest, HandlesMulitplePredeccessors) {
+TEST(LLVMBasedCFGTest, HandlesMulitplePredeccessors) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // ret i32 0
@@ -91,9 +89,10 @@ TEST_F(LLVMBasedCFGTest, HandlesMulitplePredeccessors) {
   ASSERT_EQ(PredsOfTermInst, Predeccessor);
 }
 
-TEST_F(LLVMBasedCFGTest, HandlesSingleOrEmptyPredeccessor) {
+TEST(LLVMBasedCFGTest, HandlesSingleOrEmptyPredeccessor) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING SINGLE PREDECCESSOR
@@ -122,9 +121,10 @@ TEST_F(LLVMBasedCFGTest, HandlesSingleOrEmptyPredeccessor) {
   ASSERT_EQ(PredsOfInst, Predeccessor);
 }
 
-TEST_F(LLVMBasedCFGTest, HandlesMultipleSuccessors) {
+TEST(LLVMBasedCFGTest, HandlesMultipleSuccessors) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/branch_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/branch_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING CONDITIONAL BRANCH
@@ -148,9 +148,10 @@ TEST_F(LLVMBasedCFGTest, HandlesMultipleSuccessors) {
   ASSERT_EQ(SuccsOfBrInst, Successors);
 }
 
-TEST_F(LLVMBasedCFGTest, HandlesSingleOrEmptySuccessor) {
+TEST(LLVMBasedCFGTest, HandlesSingleOrEmptySuccessor) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/function_call_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/function_call_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING SINGLE SUCCESSOR
@@ -170,9 +171,10 @@ TEST_F(LLVMBasedCFGTest, HandlesSingleOrEmptySuccessor) {
   ASSERT_EQ(SuccsOfTermInst, Successors);
 }
 
-TEST_F(LLVMBasedCFGTest, HandlesCallSuccessor) {
+TEST(LLVMBasedCFGTest, HandlesCallSuccessor) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/function_call_cpp.ll"});
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/function_call_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
 
   // HANDLING CALL INSTRUCTION SUCCESSOR
@@ -185,9 +187,9 @@ TEST_F(LLVMBasedCFGTest, HandlesCallSuccessor) {
   ASSERT_EQ(SuccsOfCallInst, Successors);
 }
 
-TEST_F(LLVMBasedCFGTest, HandleFieldLoadsArray) {
+TEST(LLVMBasedCFGTest, HandleFieldLoadsArray) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "fields/array_1_cpp.ll"});
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "fields/array_1_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   const auto *Inst = getNthInstruction(F, 1);
   ASSERT_FALSE(Cfg.isFieldLoad(Inst));
@@ -195,9 +197,9 @@ TEST_F(LLVMBasedCFGTest, HandleFieldLoadsArray) {
   ASSERT_TRUE(Cfg.isFieldLoad(Inst));
 }
 
-TEST_F(LLVMBasedCFGTest, HandleFieldStoreArray) {
+TEST(LLVMBasedCFGTest, HandleFieldStoreArray) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "fields/array_1_cpp.ll"});
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "fields/array_1_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   const auto *Inst = getNthInstruction(F, 1);
   ASSERT_FALSE(Cfg.isFieldStore(Inst));
@@ -205,9 +207,9 @@ TEST_F(LLVMBasedCFGTest, HandleFieldStoreArray) {
   ASSERT_TRUE(Cfg.isFieldStore(Inst));
 }
 
-TEST_F(LLVMBasedCFGTest, HandleFieldLoadsField) {
+TEST(LLVMBasedCFGTest, HandleFieldLoadsField) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "fields/field_1_cpp.ll"});
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "fields/field_1_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   const auto *Inst = getNthInstruction(F, 1);
   ASSERT_FALSE(Cfg.isFieldLoad(Inst));
@@ -219,9 +221,9 @@ TEST_F(LLVMBasedCFGTest, HandleFieldLoadsField) {
   ASSERT_TRUE(Cfg.isFieldLoad(Inst));
 }
 
-TEST_F(LLVMBasedCFGTest, HandleFieldStoreField) {
+TEST(LLVMBasedCFGTest, HandleFieldStoreField) {
   LLVMBasedCFG Cfg;
-  ProjectIRDB IRDB({PathToLlFiles + "fields/field_1_cpp.ll"});
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "fields/field_1_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   const auto *Inst = getNthInstruction(F, 1);
   ASSERT_FALSE(Cfg.isFieldStore(Inst));

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFGTest.cpp
@@ -13,19 +13,15 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedICFGTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedICFGTest, StaticCallSite_1) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_1_c.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_1) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_1_c.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -43,9 +39,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_1) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_2) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_2_c.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_2) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_2_c.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -67,9 +64,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_2) {
   ASSERT_EQ(CallsFromWithin.size(), 2U);
 }
 
-TEST_F(LLVMBasedICFGTest, VirtualCallSite_1) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_1_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, VirtualCallSite_1) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_1_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -86,9 +84,10 @@ TEST_F(LLVMBasedICFGTest, VirtualCallSite_1) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, FunctionPointer_1) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/function_pointer_1_c.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, FunctionPointer_1) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/function_pointer_1_c.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -104,9 +103,10 @@ TEST_F(LLVMBasedICFGTest, FunctionPointer_1) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_3) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_3_c.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_3) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_3_c.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *Factorial = IRDB.getFunctionDefinition("factorial");
@@ -123,9 +123,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_3) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_4) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_4_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_4) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_4_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -157,9 +158,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_4) {
   ASSERT_EQ(CountFunc, 2);
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_5) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_5_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_5) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_5_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -179,9 +181,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_5) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_6) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_6_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_6) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_6_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -203,9 +206,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_6) {
   }
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_7) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_7_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_7) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_7_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *Main = IRDB.getFunctionDefinition("main");
@@ -226,9 +230,10 @@ TEST_F(LLVMBasedICFGTest, StaticCallSite_7) {
   ASSERT_TRUE(AllMethods.count(F));
 }
 
-TEST_F(LLVMBasedICFGTest, StaticCallSite_8) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_8_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFGTest, StaticCallSite_8) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_8_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_CHATest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_CHATest.cpp
@@ -10,19 +10,15 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedICFG_CHATest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedICFG_CHATest, StaticCallSite_1) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_1_c.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_CHATest, StaticCallSite_1) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_1_c.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -42,9 +38,10 @@ TEST_F(LLVMBasedICFG_CHATest, StaticCallSite_1) {
   }
 }
 
-TEST_F(LLVMBasedICFG_CHATest, VirtualCallSite_2) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_2_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_CHATest, VirtualCallSite_2) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_2_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -63,9 +60,10 @@ TEST_F(LLVMBasedICFG_CHATest, VirtualCallSite_2) {
   }
 }
 
-TEST_F(LLVMBasedICFG_CHATest, VirtualCallSite_9) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_9_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_CHATest, VirtualCallSite_9) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_9_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -90,9 +88,10 @@ TEST_F(LLVMBasedICFG_CHATest, VirtualCallSite_9) {
   }
 }
 
-TEST_F(LLVMBasedICFG_CHATest, VirtualCallSite_7) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_7_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_CHATest, VirtualCallSite_7) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_7_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::CHA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_DTATest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_DTATest.cpp
@@ -5,19 +5,15 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedICFG_DTATest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedICFG_DTATest, VirtualCallSite_5) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_5_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_DTATest, VirtualCallSite_5) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_5_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::DTA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -42,9 +38,10 @@ TEST_F(LLVMBasedICFG_DTATest, VirtualCallSite_5) {
   }
 }
 
-TEST_F(LLVMBasedICFG_DTATest, VirtualCallSite_6) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_6_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_DTATest, VirtualCallSite_6) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_6_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::DTA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_OTFTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_OTFTest.cpp
@@ -7,19 +7,15 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedICFG_OTFTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedICFG_OTFTest, VirtualCallSite_7) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_7_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_OTFTest, VirtualCallSite_7) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_7_cpp.ll"},
+      IRDBOptions::WPA);
   IRDB.emitPreprocessedIR();
   LLVMTypeHierarchy TH(IRDB);
   LLVMPointsToSet PT(IRDB, false);
@@ -47,7 +43,7 @@ TEST_F(LLVMBasedICFG_OTFTest, VirtualCallSite_7) {
   ASSERT_TRUE(ICFG.getCallersOf(VFuncB).count(CallToBFunc));
 }
 
-// TEST_F(LLVMBasedICFG_OTFTest, VirtualCallSite_8) {
+// TEST(LLVMBasedICFG_OTFTest, VirtualCallSite_8) {
 //   ProjectIRDB IRDB({pathToLLFiles + "call_graphs/virtual_call_8_cpp.ll"},
 //                    IRDBOptions::WPA);
 //   LLVMTypeHierarchy TH(IRDB);

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_RTATest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFG_RTATest.cpp
@@ -6,19 +6,15 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMBasedICFG_RTATest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMBasedICFG_RTATest, VirtualCallSite_9) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_9_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_RTATest, VirtualCallSite_9) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_9_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::RTA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -42,9 +38,10 @@ TEST_F(LLVMBasedICFG_RTATest, VirtualCallSite_9) {
   }
 }
 
-TEST_F(LLVMBasedICFG_RTATest, VirtualCallSite_3) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/virtual_call_3_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_RTATest, VirtualCallSite_3) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/virtual_call_3_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::RTA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");
@@ -61,9 +58,10 @@ TEST_F(LLVMBasedICFG_RTATest, VirtualCallSite_3) {
   }
 }
 
-TEST_F(LLVMBasedICFG_RTATest, StaticCallSite_13) {
-  ProjectIRDB IRDB({PathToLlFiles + "call_graphs/static_callsite_13_cpp.ll"},
-                   IRDBOptions::WPA);
+TEST(LLVMBasedICFG_RTATest, StaticCallSite_13) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "call_graphs/static_callsite_13_cpp.ll"},
+      IRDBOptions::WPA);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICFG(IRDB, CallGraphAnalysisType::RTA, {"main"}, &TH);
   const llvm::Function *F = IRDB.getFunctionDefinition("main");

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/CMakeLists.txt
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
   )
 endif(PHASAR_BUILD_OPENSSL_TS_UNITTESTS)
 
+test_require_config_file("DOTGraphConfig.json")
 
 foreach(TEST_SRC ${IfdsIdeProblemSources})
 	add_phasar_unittest(${TEST_SRC})

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -25,14 +25,15 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Logger.h"
 
+#include "TestConfig.h"
+
 using namespace psr;
 
 /* ============== TEST FIXTURE ============== */
 class IDEInstInteractionAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/inst_interaction/";
+      unittest::PathToLLTestFiles + "inst_interaction/";
   const std::set<std::string> EntryPoints = {"main"};
 
   // Function - Line Nr - Variable - Values

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -7,6 +7,8 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 #include <tuple>
 
 using namespace psr;
@@ -15,8 +17,7 @@ using namespace psr;
 class IDELinearConstantAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/linear_constant/";
+      unittest::PathToLLTestFiles + "linear_constant/";
   const std::set<std::string> EntryPoints = {"main"};
 
   // Function - Line Nr - Variable - Value

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis_DotTest.cpp
@@ -5,7 +5,10 @@
 #include "phasar/PhasarLLVM/Passes/ValueAnnotationPass.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+#include "TestConfig.h"
 
 #include <tuple>
 
@@ -15,8 +18,8 @@ using namespace psr;
 class IDELinearConstantAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/linear_constant/";
+      unittest::PathToLLTestFiles + "linear_constant/";
+
   const std::set<std::string> EntryPoints = {"main"};
 
   // Function - Line Nr - Variable - Value
@@ -40,7 +43,7 @@ protected:
     LCASolver.solve();
     if (emitESG) {
       boost::log::core::get()->set_logging_enabled(true);
-      LCASolver.emitESGAsDot();
+      LCASolver.emitESGAsDot(std::cout, "");
       boost::log::core::get()->set_logging_enabled(false);
     }
     if (PrintDump) {

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
@@ -7,6 +7,8 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
@@ -14,9 +16,7 @@ using namespace psr;
 
 class IFDSConstAnalysisTest : public ::testing::Test {
 protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/constness/";
+  const std::string PathToLlFiles = unittest::PathToLLTestFiles + "constness/";
   const std::set<std::string> EntryPoints = {"main"};
 
   ProjectIRDB *IRDB{};

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysisTest.cpp
@@ -7,6 +7,8 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
@@ -15,8 +17,7 @@ using namespace psr;
 class IFDSTaintAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/taint_analysis/";
+      unittest::PathToLLTestFiles + "taint_analysis/";
   const std::set<std::string> EntryPoints = {"main"};
 
   ProjectIRDB *IRDB{};

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSUninitializedVariablesTest.cpp
@@ -8,6 +8,8 @@
 #include "llvm/IR/Module.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
@@ -16,8 +18,7 @@ using namespace psr;
 class IFDSUninitializedVariablesTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/uninitialized_variables/";
+      unittest::PathToLLTestFiles + "uninitialized_variables/";
   const std::set<std::string> EntryPoints = {"main"};
 
   ProjectIRDB *IRDB{};

--- a/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoFullConstantPropagationTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoFullConstantPropagationTest.cpp
@@ -27,14 +27,15 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Logger.h"
 
+#include "TestConfig.h"
+
 using namespace psr;
 
 /* ============== TEST FIXTURE ============== */
 class InterMonoTaintAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/full_constant/";
+      unittest::PathToLLTestFiles + "full_constant/";
   const std::set<std::string> EntryPoints = {"main"};
 
   using IMFCPCompactResult_t =

--- a/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoTaintAnalysisTest.cpp
@@ -13,14 +13,15 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Logger.h"
 
+#include "TestConfig.h"
+
 using namespace psr;
 
 /* ============== TEST FIXTURE ============== */
 class InterMonoTaintAnalysisTest : public ::testing::Test {
 protected:
   const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/taint_analysis/";
+      unittest::PathToLLTestFiles + "taint_analysis/";
   const std::set<std::string> EntryPoints = {"main"};
 
   ProjectIRDB *IRDB = nullptr;

--- a/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
+++ b/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
@@ -8,21 +8,18 @@
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 
+#include "TestConfig.h"
+
 using namespace psr;
 
-class LLVMBasedICFGTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
+TEST(LLVMPointsToSet, Intra_01) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "pointers/basic_01_cpp_dbg.ll"});
 
-TEST_F(LLVMBasedICFGTest, Intra_01) {
-  ProjectIRDB IRDB({PathToLlFiles + "pointers/basic_01_cpp_dbg.ll"});
   LLVMPointsToSet PTS(IRDB, false);
-  auto *Main = IRDB.getFunctionDefinition("main");
-  for (auto &BB : *Main) {
-    for (auto &I : BB) {
+  const auto *Main = IRDB.getFunctionDefinition("main");
+  for (const auto &BB : *Main) {
+    for (const auto &I : BB) {
       auto S = PTS.getPointsToSet(&I);
     }
   }
@@ -30,14 +27,15 @@ TEST_F(LLVMBasedICFGTest, Intra_01) {
   std::cout << '\n';
 }
 
-TEST_F(LLVMBasedICFGTest, Inter_01) {
-  ProjectIRDB IRDB({PathToLlFiles + "pointers/call_01_cpp_dbg.ll"});
+TEST(LLVMPointsToSet, Inter_01) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "pointers/call_01_cpp_dbg.ll"});
   LLVMPointsToSet PTS(IRDB, false);
   LLVMTypeHierarchy TH(IRDB);
   LLVMBasedICFG ICF(IRDB, CallGraphAnalysisType::OTF, {"main"}, &TH, &PTS);
-  auto *Main = IRDB.getFunctionDefinition("main");
-  for (auto &BB : *Main) {
-    for (auto &I : BB) {
+  const auto *Main = IRDB.getFunctionDefinition("main");
+  for (const auto &BB : *Main) {
+    for (const auto &I : BB) {
       auto S = PTS.getPointsToSet(&I);
     }
   }

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -12,21 +12,17 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Utilities.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
 namespace psr {
-class LTHTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
 
 // Check basic type hierarchy construction
-TEST_F(LTHTest, BasicTHReconstruction_1) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_1_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_1) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_1_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -56,9 +52,9 @@ TEST_F(LTHTest, BasicTHReconstruction_1) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_2) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_2_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_2) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_2_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -88,9 +84,9 @@ TEST_F(LTHTest, BasicTHReconstruction_2) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_3) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_3_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_3) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_3_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -126,9 +122,9 @@ TEST_F(LTHTest, BasicTHReconstruction_3) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_4) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_4_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_4) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_4_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -167,9 +163,9 @@ TEST_F(LTHTest, BasicTHReconstruction_4) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_5) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_5_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_5) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_5_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -231,9 +227,9 @@ TEST_F(LTHTest, BasicTHReconstruction_5) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_6) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_12_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_6) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_12_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("class.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -263,9 +259,9 @@ TEST_F(LTHTest, BasicTHReconstruction_6) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
-TEST_F(LTHTest, BasicTHReconstruction_7) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_11_cpp.ll"});
+TEST(LTHTest, BasicTHReconstruction_7) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_11_cpp.ll"});
   LLVMTypeHierarchy LTH(IRDB);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Base")), true);
   EXPECT_EQ(LTH.hasType(LTH.getType("struct.Child")), true);
@@ -297,17 +293,17 @@ TEST_F(LTHTest, BasicTHReconstruction_7) {
 }
 
 // check if the vtables are constructed correctly in more complex scenarios
-TEST_F(LTHTest, VTableConstruction) {
-  ProjectIRDB IRDB1(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_1_cpp.ll"});
-  ProjectIRDB IRDB2(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_7_cpp.ll"});
-  ProjectIRDB IRDB3(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_8_cpp.ll"});
-  ProjectIRDB IRDB4(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_9_cpp.ll"});
-  ProjectIRDB IRDB5(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_10_cpp.ll"});
+TEST(LTHTest, VTableConstruction) {
+  ProjectIRDB IRDB1({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_1_cpp.ll"});
+  ProjectIRDB IRDB2({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_7_cpp.ll"});
+  ProjectIRDB IRDB3({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_8_cpp.ll"});
+  ProjectIRDB IRDB4({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_9_cpp.ll"});
+  ProjectIRDB IRDB5({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_10_cpp.ll"});
 
   // Creates an empty type hierarchy
   LLVMTypeHierarchy TH1(IRDB1);
@@ -449,17 +445,17 @@ TEST_F(LTHTest, VTableConstruction) {
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Child"))->size() == 3U);
 }
 
-TEST_F(LTHTest, TransitivelyReachableTypes) {
-  ProjectIRDB IRDB1(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_1_cpp.ll"});
-  ProjectIRDB IRDB2(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_7_cpp.ll"});
-  ProjectIRDB IRDB3(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_8_cpp.ll"});
-  ProjectIRDB IRDB4(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_9_cpp.ll"});
-  ProjectIRDB IRDB5(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_10_cpp.ll"});
+TEST(LTHTest, TransitivelyReachableTypes) {
+  ProjectIRDB IRDB1({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_1_cpp.ll"});
+  ProjectIRDB IRDB2({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_7_cpp.ll"});
+  ProjectIRDB IRDB3({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_8_cpp.ll"});
+  ProjectIRDB IRDB4({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_9_cpp.ll"});
+  ProjectIRDB IRDB5({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_10_cpp.ll"});
   // Creates an empty type hierarchy
   LLVMTypeHierarchy TH1(IRDB1);
   LLVMTypeHierarchy TH2(IRDB2);
@@ -552,7 +548,7 @@ TEST_F(LTHTest, TransitivelyReachableTypes) {
   ASSERT_TRUE(ReachableTypesChild5.size() == 1U);
 }
 
-// TEST_F(LTHTest, HandleLoadAndPrintOfNonEmptyGraph) {
+// TEST(LTHTest, HandleLoadAndPrintOfNonEmptyGraph) {
 //   ProjectIRDB IRDB(
 //       {pathToLLFiles + "type_hierarchies/type_hierarchy_1_cpp.ll"});
 //   LLVMTypeHierarchy TH(IRDB);
@@ -575,7 +571,7 @@ TEST_F(LTHTest, TransitivelyReachableTypes) {
 //   //   ASSERT_TRUE(boost::isomorphism(G, TH.TypeGraph));
 // }
 
-// // TEST_F(LTHTest, HandleLoadAndPrintOfEmptyGraph) {
+// // TEST(LTHTest, HandleLoadAndPrintOfEmptyGraph) {
 // //   ProjectIRDB IRDB({pathToLLFiles +
 // //   "taint_analysis/growing_example_cpp.ll"}); LLVMTypeHierarchy TH(IRDB);
 // //   std::ostringstream oss;
@@ -595,7 +591,7 @@ TEST_F(LTHTest, TransitivelyReachableTypes) {
 // //   ASSERT_EQ(oss.str(), oss2.str());
 // // }
 
-// // TEST_F(LTHTest, HandleMerge_1) {
+// // TEST(LTHTest, HandleMerge_1) {
 // //   ProjectIRDB IRDB(
 // //       {pathToLLFiles + "type_hierarchies/type_hierarchy_12_cpp.ll",
 // //        pathToLLFiles + "type_hierarchies/type_hierarchy_12_b_cpp.ll"});
@@ -653,9 +649,9 @@ TEST_F(LTHTest, TransitivelyReachableTypes) {
 // //   EXPECT_TRUE(ChildsChildReachable.count("struct.ChildsChild"));
 // // }
 
-TEST_F(LTHTest, HandleSTLString) {
-  ProjectIRDB IRDB(
-      {PathToLlFiles + "type_hierarchies/type_hierarchy_13_cpp.ll"});
+TEST(LTHTest, HandleSTLString) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+                    "type_hierarchies/type_hierarchy_13_cpp.ll"});
   LLVMTypeHierarchy TH(IRDB);
   EXPECT_EQ(TH.getAllTypes().size(), 4U);
   EXPECT_TRUE(TH.hasType(TH.getType("class.std::__cxx11::basic_string")));

--- a/unittests/PhasarLLVM/TypeHierarchy/TypeGraphTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/TypeGraphTest.cpp
@@ -8,21 +8,17 @@
 #include "phasar/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Utilities.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
 namespace psr {
 
-class TypeGraphTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(TypeGraphTest, AddType) {
-  ProjectIRDB IRDB({PathToLlFiles + "basic/two_structs_cpp.ll"});
-  llvm::Module *M = IRDB.getModule(PathToLlFiles + "basic/two_structs_cpp.ll");
+TEST(TypeGraphTest, AddType) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "basic/two_structs_cpp.ll"});
+  llvm::Module *M =
+      IRDB.getModule(unittest::PathToLLTestFiles + "basic/two_structs_cpp.ll");
 
   unsigned int NbStruct = 0;
 
@@ -49,10 +45,11 @@ TEST_F(TypeGraphTest, AddType) {
   ASSERT_TRUE(NbStruct >= 2);
 }
 
-TEST_F(TypeGraphTest, ReverseTypePropagation) {
-  ProjectIRDB IRDB({PathToLlFiles + "basic/seven_structs_cpp.ll"});
-  llvm::Module *M =
-      IRDB.getModule(PathToLlFiles + "basic/seven_structs_cpp.ll");
+TEST(TypeGraphTest, ReverseTypePropagation) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "basic/seven_structs_cpp.ll"});
+  llvm::Module *M = IRDB.getModule(unittest::PathToLLTestFiles +
+                                   "basic/seven_structs_cpp.ll");
 
   unsigned int NbStruct = 0;
   llvm::StructType *StructA = nullptr;
@@ -194,9 +191,10 @@ TEST_F(TypeGraphTest, ReverseTypePropagation) {
   ASSERT_TRUE(Tg.g[VertexE].types.size() == 3);
 }
 
-TEST_F(TypeGraphTest, AddLinkSimple) {
-  ProjectIRDB IRDB({PathToLlFiles + "basic/two_structs_cpp.ll"});
-  llvm::Module *M = IRDB.getModule(PathToLlFiles + "basic/two_structs_cpp.ll");
+TEST(TypeGraphTest, AddLinkSimple) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles + "basic/two_structs_cpp.ll"});
+  llvm::Module *M =
+      IRDB.getModule(unittest::PathToLLTestFiles + "basic/two_structs_cpp.ll");
 
   unsigned int NbStruct = 0;
   llvm::StructType *StructA = nullptr;
@@ -262,10 +260,11 @@ TEST_F(TypeGraphTest, AddLinkSimple) {
   ASSERT_TRUE(NumberEdge == 1);
 }
 
-TEST_F(TypeGraphTest, TypeAggregation) {
-  ProjectIRDB IRDB({PathToLlFiles + "basic/seven_structs_cpp.ll"});
-  llvm::Module *M =
-      IRDB.getModule(PathToLlFiles + "basic/seven_structs_cpp.ll");
+TEST(TypeGraphTest, TypeAggregation) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "basic/seven_structs_cpp.ll"});
+  llvm::Module *M = IRDB.getModule(unittest::PathToLLTestFiles +
+                                   "basic/seven_structs_cpp.ll");
 
   unsigned int NbStruct = 0;
   llvm::StructType *StructA = nullptr;

--- a/unittests/PhasarLLVM/Utils/CMakeLists.txt
+++ b/unittests/PhasarLLVM/Utils/CMakeLists.txt
@@ -2,6 +2,8 @@ set(UtilsSources
 	TaintConfigurationTest.cpp
 )
 
+test_require_config_file("phasar-source-sink-function.json")
+
 foreach(TEST_SRC ${UtilsSources})
 	add_phasar_unittest(${TEST_SRC})
 endforeach(TEST_SRC)

--- a/unittests/PhasarLLVM/Utils/TaintConfigurationTest.cpp
+++ b/unittests/PhasarLLVM/Utils/TaintConfigurationTest.cpp
@@ -1,10 +1,16 @@
 #include "phasar/PhasarLLVM/Utils/TaintConfiguration.h"
+#include "phasar/Config/Configuration.h"
+
+#include "llvm/ADT/StringRef.h"
+
 #include "gtest/gtest.h"
+
+#include "TestConfig.h"
 
 using namespace psr;
 
 TEST(TaintConfigurationTest, HandleSSImport) {
-  TaintConfiguration<int> TSF(PhasarConfig::DefaultSourceSinkFunctionsPath());
+  TaintConfiguration<int> TSF("config/phasar-source-sink-function.json");
   std::cout << TSF;
   EXPECT_EQ(TaintConfiguration<int>::SourceFunction(
                 "read", false, std::vector<unsigned>({0, 1, 3})),

--- a/unittests/TestUtils/TestConfig.h
+++ b/unittests/TestUtils/TestConfig.h
@@ -1,0 +1,12 @@
+#ifndef UNITTEST_TESTUTILS_TESTCONFIG_H_
+#define UNITTEST_TESTUTILS_TESTCONFIG_H_
+
+#include <string>
+
+namespace psr::unittest {
+
+inline const std::string PathToLLTestFiles("../test/llvm_test_code/");
+
+} // namespace psr::unittest
+
+#endif // UNITTEST_TESTUTILS_TESTCONFIG_H_

--- a/unittests/Utils/LLVMShorthandsTest.cpp
+++ b/unittests/Utils/LLVMShorthandsTest.cpp
@@ -6,18 +6,14 @@
 #include "llvm/IR/Instructions.h"
 #include "gtest/gtest.h"
 
+#include "TestConfig.h"
+
 using namespace std;
 using namespace psr;
 
-class LLVMGetterTest : public ::testing::Test {
-protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::getPhasarConfig().PhasarDirectory() +
-      "build/test/llvm_test_code/";
-};
-
-TEST_F(LLVMGetterTest, HandlesLLVMStoreInstruction) {
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/global_stmt_cpp.ll"});
+TEST(LLVMGetterTest, HandlesLLVMStoreInstruction) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/global_stmt_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   ASSERT_EQ(getNthStoreInstruction(F, 0), nullptr);
   const auto *I = getNthInstruction(F, 4);
@@ -29,8 +25,9 @@ TEST_F(LLVMGetterTest, HandlesLLVMStoreInstruction) {
   ASSERT_EQ(getNthStoreInstruction(F, 4), nullptr);
 }
 
-TEST_F(LLVMGetterTest, HandlesLLVMTermInstruction) {
-  ProjectIRDB IRDB({PathToLlFiles + "control_flow/if_else_cpp.ll"});
+TEST(LLVMGetterTest, HandlesLLVMTermInstruction) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "control_flow/if_else_cpp.ll"});
   const auto *F = IRDB.getFunctionDefinition("main");
   ASSERT_EQ(getNthTermInstruction(F, 0), nullptr);
   const auto *I = getNthInstruction(F, 14);
@@ -44,11 +41,12 @@ TEST_F(LLVMGetterTest, HandlesLLVMTermInstruction) {
   ASSERT_EQ(getNthTermInstruction(F, 5), nullptr);
 }
 
-TEST_F(LLVMGetterTest, HandlesCppStandardType) {
-  ProjectIRDB IRDB({PathToLlFiles + "name_mangling/special_members_2_cpp.ll"});
+TEST(LLVMGetterTest, HandlesCppStandardType) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "name_mangling/special_members_2_cpp.ll"});
 
-  auto *F =
-      IRDB.getModule(PathToLlFiles + "name_mangling/special_members_2_cpp.ll");
+  auto *F = IRDB.getModule(unittest::PathToLLTestFiles +
+                           "name_mangling/special_members_2_cpp.ll");
   auto &M = *F->getFunction("_ZNSt8ios_base4InitC1Ev");
   ASSERT_EQ(specialMemberFunctionType(M.getName()),
             SpecialMemberFunctionTy::CTOR);
@@ -61,11 +59,12 @@ TEST_F(LLVMGetterTest, HandlesCppStandardType) {
             SpecialMemberFunctionTy::DTOR);
 }
 
-TEST_F(LLVMGetterTest, HandlesCppUserDefinedType) {
-  ProjectIRDB IRDB({PathToLlFiles + "name_mangling/special_members_1_cpp.ll"});
+TEST(LLVMGetterTest, HandlesCppUserDefinedType) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "name_mangling/special_members_1_cpp.ll"});
 
-  auto *F =
-      IRDB.getModule(PathToLlFiles + "name_mangling/special_members_1_cpp.ll");
+  auto *F = IRDB.getModule(unittest::PathToLLTestFiles +
+                           "name_mangling/special_members_1_cpp.ll");
   auto &M = *F->getFunction("_ZN7MyClassC2Ev");
   ASSERT_EQ(specialMemberFunctionType(M.getName()),
             SpecialMemberFunctionTy::CTOR);
@@ -77,21 +76,23 @@ TEST_F(LLVMGetterTest, HandlesCppUserDefinedType) {
             SpecialMemberFunctionTy::MVASSIGNOP);
 }
 
-TEST_F(LLVMGetterTest, HandlesCppNonStandardFunctions) {
-  ProjectIRDB IRDB({PathToLlFiles + "name_mangling/special_members_3_cpp.ll"});
+TEST(LLVMGetterTest, HandlesCppNonStandardFunctions) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "name_mangling/special_members_3_cpp.ll"});
 
-  auto *F =
-      IRDB.getModule(PathToLlFiles + "name_mangling/special_members_3_cpp.ll");
+  auto *F = IRDB.getModule(unittest::PathToLLTestFiles +
+                           "name_mangling/special_members_3_cpp.ll");
   auto &M = *F->getFunction("_ZN9testspace3foo3barES0_");
   ASSERT_EQ(specialMemberFunctionType(M.getName()),
             SpecialMemberFunctionTy::NONE);
 }
 
-TEST_F(LLVMGetterTest, HandleFunctionsContainingCodesInName) {
-  ProjectIRDB IRDB({PathToLlFiles + "name_mangling/special_members_4_cpp.ll"});
+TEST(LLVMGetterTest, HandleFunctionsContainingCodesInName) {
+  ProjectIRDB IRDB(
+      {unittest::PathToLLTestFiles + "name_mangling/special_members_4_cpp.ll"});
 
-  auto *M =
-      IRDB.getModule(PathToLlFiles + "name_mangling/special_members_4_cpp.ll");
+  auto *M = IRDB.getModule(unittest::PathToLLTestFiles +
+                           "name_mangling/special_members_4_cpp.ll");
   auto *F = M->getFunction("_ZN8C0C1C2C12D1C2Ev"); // C0C1C2C1::D1::D1()
   std::cout << "VALUE IS: "
             << static_cast<std::underlying_type_t<SpecialMemberFunctionTy>>(


### PR DESCRIPTION
Adds extra cmake target check-phasar-unittests, for running all
unittests. Refactors tests access to test ll files and extracts direct config usage, making config values easier exchangeable for testing.