### PR TITLE
Reenable clean up of AliasAnalysis data after usage

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMBasedPointsToAnalysis.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMBasedPointsToAnalysis.h
@@ -58,7 +58,7 @@ public:
     return AAInfos.at(F);
   };
 
-  void erase(const llvm::Function *F);
+  void erase(llvm::Function *F);
 
   void clear();
 

--- a/lib/PhasarLLVM/Pointer/LLVMBasedPointsToAnalysis.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMBasedPointsToAnalysis.cpp
@@ -92,12 +92,11 @@ void LLVMBasedPointsToAnalysis::computePointsToInfo(llvm::Function &Fun) {
   AAInfos.insert(std::make_pair(&Fun, &AAR));
 }
 
-void LLVMBasedPointsToAnalysis::erase(const llvm::Function *F) {
-  // TODO
+void LLVMBasedPointsToAnalysis::erase(llvm::Function *F) {
   // after we clear all stuff, we need to set it up for the next function-wise
   // analysis
-  // AAInfos.erase(F);
-  // FAM.clear();
+  AAInfos.erase(F);
+  FAM.clear(*F, F->getName());
 }
 
 void LLVMBasedPointsToAnalysis::clear() {

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
@@ -229,8 +229,7 @@ void LLVMPointsToSet::computeFunctionsPointsToSet(llvm::Function *F) {
     }
   }
   // we no longer need the LLVM representation
-  // TODO
-  // PTA.erase(F);
+  PTA.erase(F);
 }
 
 AliasResult LLVMPointsToSet::alias(const llvm::Value *V1, const llvm::Value *V2,


### PR DESCRIPTION
Reenables erasing of already processed AliasAnalysis data, which is
integrated into phasars internal analysis PointsToSets. Erasing old data
is necessary because, otherwise, the data consumes to much memory when
analyzing on larger programs.