### PR TITLE
User config refs so the solver and problem share the same config

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h
@@ -104,7 +104,7 @@ public:
     SolverConfig = Config;
   }
 
-  [[nodiscard]] IFDSIDESolverConfig getIFDSIDESolverConfig() const {
+  [[nodiscard]] IFDSIDESolverConfig &getIFDSIDESolverConfig() {
     return SolverConfig;
   }
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -330,7 +330,7 @@ protected:
   IDETabulationProblem<AnalysisDomainTy, Container> &IDEProblem;
   d_t ZeroValue;
   const i_t *ICF;
-  IFDSIDESolverConfig SolverConfig;
+  IFDSIDESolverConfig &SolverConfig;
   unsigned PathEdgeCount = 0;
 
   FlowEdgeFunctionCache<AnalysisDomainTy, Container> cachedFlowEdgeFunctions;


### PR DESCRIPTION
This allows users to adapt the problem/solver config after creating a
solver from the config.