### PR TITLE
Implements EdgeFunctionSingletonFactory

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
@@ -17,6 +17,7 @@
 #ifndef PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONS_H_
 #define PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONS_H_
 
+#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Compiler.h"
 
 #include <atomic>
@@ -585,8 +586,10 @@ private:
         : CleanerThread(&EdgeFactoryStorageCleaner::runCleaner, this,
                         std::reference_wrapper<EFStorageData>(
                             EdgeFunctionSingletonFactory::getCacheData())) {
+#ifdef LLVM_ON_UNIX
       pthread_setname_np(CleanerThread.native_handle(),
                          "EdgeFactoryStorageCleanerThread");
+#endif
     }
     EdgeFactoryStorageCleaner(const EdgeFactoryStorageCleaner &) = delete;
     EdgeFactoryStorageCleaner &

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
@@ -17,13 +17,20 @@
 #ifndef PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONS_H_
 #define PHASAR_PHASARLLVM_IFDSIDE_EDGEFUNCTIONS_H_
 
+#include "llvm/Support/Compiler.h"
+
+#include <atomic>
 #include <iosfwd>
 #include <iostream>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <set>
 #include <sstream>
 #include <string>
+#include <thread>
+#include <utility>
 
 namespace psr {
 
@@ -470,6 +477,148 @@ public:
   //
   virtual EdgeFunctionPtrType
   getSummaryEdgeFunction(n_t Curr, d_t CurrNode, n_t Succ, d_t SuccNode) = 0;
+};
+
+// This class can be used as a singleton factory for EdgeFunctions that only
+// have constant data.
+//
+// EdgeFunction that have constant data only need to be allocated once and can
+// be turned into a singleton, which save large amounts of memory. The
+// automatic singleton creation can be enbaled for a EdgeFunction class by
+// inheriting from EdgeFunctionSingletonFactory and only allocating
+// EdgeFunction throught the provided createEdgeFunction method.
+//
+// Old unused EdgeFunction that were deallocated need to/should be clean from
+// the factory by either calling cleanExpiredEdgeFunctions or initializing the
+// automatic cleaner thread with initEdgeFunctionCleaner.
+template <typename EdgeFunctionType, typename CtorArgT>
+class EdgeFunctionSingletonFactory {
+public:
+  EdgeFunctionSingletonFactory() = default;
+  EdgeFunctionSingletonFactory(const EdgeFunctionSingletonFactory &) = default;
+  EdgeFunctionSingletonFactory &
+  operator=(const EdgeFunctionSingletonFactory &) = default;
+  EdgeFunctionSingletonFactory(EdgeFunctionSingletonFactory &&) noexcept =
+      default;
+  EdgeFunctionSingletonFactory &
+  operator=(EdgeFunctionSingletonFactory &&) noexcept = default;
+
+  virtual ~EdgeFunctionSingletonFactory() {
+    std::lock_guard<std::mutex> DataLock(getCacheData().DataMutex);
+  }
+
+  // Creates a new EdgeFunction of type EdgeFunctionType, reusing the previous
+  // allocation if an EdgeFunction with the same values was already created.
+  static inline std::shared_ptr<EdgeFunctionType>
+  createEdgeFunction(CtorArgT K) {
+    std::lock_guard<std::mutex> DataLock(getCacheData().DataMutex);
+
+    auto &Storage = getCacheData().Storage;
+    auto SearchVal = Storage.find(K);
+    if (SearchVal != Storage.end() && !SearchVal->second.expired()) {
+      return SearchVal->second.lock();
+    } else {
+      auto NewEdgeFunc = std::make_shared<EdgeFunctionType>(K);
+      Storage[K] = NewEdgeFunc;
+      return NewEdgeFunc;
+    }
+  }
+
+  // Initialize a cleaner thread to automatically remove unused/expired
+  // EdgeFunctions. The thread is only started the first time this function is
+  // called.
+  static inline void initEdgeFunctionCleaner() { getCleaner(); }
+
+  static inline void stopEdgeFunctionCleaner() { getCleaner().stop(); }
+
+  // Clean all unused/expired EdgeFunctions from the internal storage.
+  static inline void cleanExpiredEdgeFunctions() {
+    cleanExpiredMapEntries(getCacheData());
+  }
+
+  LLVM_DUMP_METHOD
+  static void dump(bool PrintElements = false) {
+    std::lock_guard<std::mutex> DataLock(getCacheData().DataMutex);
+
+    std::cout << "Elements in cache: " << getCacheData().Storage.size();
+
+    if (PrintElements) {
+      std::cout << "\n";
+      for (auto &KVPair : getCacheData().Storage) {
+        std::cout << "(" << KVPair.first << ") -> " << std::boolalpha
+                  << KVPair.second.expired() << std::endl;
+      }
+    }
+    std::cout << std::endl;
+  }
+
+private:
+  struct EFStorageData {
+    std::map<CtorArgT, std::weak_ptr<EdgeFunctionType>> Storage{};
+    std::mutex DataMutex;
+  };
+
+  static inline EFStorageData &getCacheData() {
+    static EFStorageData StoredData{};
+    return StoredData;
+  }
+
+  static void cleanExpiredMapEntries(EFStorageData &CData) {
+    std::lock_guard<std::mutex> DataLock(CData.DataMutex);
+
+    auto &Storage = CData.Storage;
+    for (auto Iter = Storage.begin(); Iter != Storage.end();) {
+      if (Iter->second.expired()) {
+        Iter = Storage.erase(Iter);
+      } else {
+        ++Iter;
+      }
+    }
+  }
+
+  class EdgeFactoryStorageCleaner {
+  public:
+    EdgeFactoryStorageCleaner()
+        : CleanerThread(&EdgeFactoryStorageCleaner::runCleaner, this,
+                        std::reference_wrapper<EFStorageData>(
+                            EdgeFunctionSingletonFactory::getCacheData())) {
+      pthread_setname_np(CleanerThread.native_handle(),
+                         "EdgeFactoryStorageCleanerThread");
+    }
+    EdgeFactoryStorageCleaner(const EdgeFactoryStorageCleaner &) = delete;
+    EdgeFactoryStorageCleaner &
+    operator=(const EdgeFactoryStorageCleaner &) = delete;
+    EdgeFactoryStorageCleaner(EdgeFactoryStorageCleaner &&) = delete;
+    EdgeFactoryStorageCleaner &operator=(EdgeFactoryStorageCleaner &&) = delete;
+    ~EdgeFactoryStorageCleaner() { stop(); }
+
+    // Stops the cleaning thread running in the background.
+    void stop() {
+      KeepRunning = false;
+      if (CleanerThread.joinable()) {
+        CleanerThread.join();
+      }
+    }
+
+  private:
+    void runCleaner(EFStorageData &CData) {
+      while (KeepRunning) {
+        std::this_thread::sleep_for(CleaningPauseTime);
+        // std::cout << "Cleaning...\n";
+        cleanExpiredMapEntries(CData);
+      }
+    }
+
+    static constexpr auto CleaningPauseTime = std::chrono::seconds(2);
+
+    std::atomic_bool KeepRunning{true};
+    std::thread CleanerThread;
+  };
+
+  static inline EdgeFactoryStorageCleaner &getCleaner() {
+    static EdgeFactoryStorageCleaner EdgeFunctionCleaner{};
+    return EdgeFunctionCleaner;
+  }
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
@@ -33,6 +33,9 @@
 #include <utility>
 
 namespace psr {
+namespace internal {
+struct TestEdgeFunction;
+} // namespace internal
 
 //
 // This class models an edge function for distributive data-flow problems.
@@ -619,6 +622,8 @@ private:
     static EdgeFactoryStorageCleaner EdgeFunctionCleaner{};
     return EdgeFunctionCleaner;
   }
+
+  friend internal::TestEdgeFunction;
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h
@@ -607,7 +607,6 @@ private:
     void runCleaner(EFStorageData &CData) {
       while (KeepRunning) {
         std::this_thread::sleep_for(CleaningPauseTime);
-        // std::cout << "Cleaning...\n";
         cleanExpiredMapEntries(CData);
       }
     }

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
@@ -1,9 +1,22 @@
 add_subdirectory(Problems)
 
 set(IfdsIdeSources
-	EdgeFunctionComposerTest.cpp
+  EdgeFunctionComposerTest.cpp
 )
 
 foreach(TEST_SRC ${IfdsIdeSources})
-	add_phasar_unittest(${TEST_SRC})
+  add_phasar_unittest(${TEST_SRC})
+endforeach(TEST_SRC)
+
+set(ThreadedIfdsIdeSources
+  EdgeFunctionSingletonFactoryTest.cpp
+)
+
+if(LLVM_ON_UNIX)
+  append_common_sanitizer_flags()
+  append("-fsanitize=thread" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+endif()
+
+foreach(TEST_SRC ${ThreadedIfdsIdeSources})
+  add_phasar_unittest(${TEST_SRC})
 endforeach(TEST_SRC)

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposerTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposerTest.cpp
@@ -1,6 +1,8 @@
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionComposer.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.h"
+
 #include "gtest/gtest.h"
+
 #include <iostream>
 #include <memory>
 #include <string>

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionSingletonFactoryTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctionSingletonFactoryTest.cpp
@@ -1,0 +1,125 @@
+#include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/EdgeFunctions.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <thread>
+
+namespace psr::internal {
+struct TestEdgeFunction
+    : public EdgeFunction<int>,
+      public std::enable_shared_from_this<TestEdgeFunction>,
+      public EdgeFunctionSingletonFactory<TestEdgeFunction, int> {
+
+  TestEdgeFunction(int Val) : Val(Val) {}
+
+  static decltype(auto) getTestCacheData() {
+    return EdgeFunctionSingletonFactory<TestEdgeFunction, int>::getCacheData();
+  }
+
+  int computeTarget(int Source) override { return 42; }
+
+  EdgeFunctionPtrType composeWith(EdgeFunctionPtrType secondFunction) override {
+    return this->shared_from_this();
+  };
+
+  EdgeFunctionPtrType joinWith(EdgeFunctionPtrType OtherFunction) override {
+    return this->shared_from_this();
+  }
+
+  bool equal_to(EdgeFunctionPtrType OtherFunction) const override {
+    return false;
+  };
+
+  int Val;
+};
+} // namespace psr::internal
+
+using namespace psr;
+using namespace psr::internal;
+
+//===----------------------------------------------------------------------===//
+// Direct api usage tests
+
+TEST(EdgeFunctionSingletonFactoryTest, createEdgeFunctions) {
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 2);
+}
+
+TEST(EdgeFunctionSingletonFactoryTest, createEdgeFunctionsWithCorrectData) {
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+
+  EXPECT_EQ(EF1->Val, 42);
+  EXPECT_EQ(EF2->Val, 1337);
+}
+
+TEST(EdgeFunctionSingletonFactoryTest, createEdgeFunctionsTwice) {
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+  auto EF3 = TestEdgeFunction::createEdgeFunction(42);
+
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 2);
+  EXPECT_EQ(EF1.get(), EF3.get());
+}
+
+TEST(EdgeFunctionSingletonFactoryTest, selfCleanExpiredEdgeFunctions) {
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  {
+    auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+  } // EF2 deleted after scope
+
+  TestEdgeFunction::cleanExpiredEdgeFunctions();
+
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 1);
+}
+
+//===----------------------------------------------------------------------===//
+// Threaded tests
+
+TEST(EdgeFunctionSingletonFactoryTest, createEdgeFunctionsThreaded) {
+  TestEdgeFunction::initEdgeFunctionCleaner();
+
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+
+  std::lock_guard<std::mutex> DataLock(
+      TestEdgeFunction::getTestCacheData().DataMutex);
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 2);
+}
+
+TEST(EdgeFunctionSingletonFactoryTest, createEdgeFunctionsTwiceThreaded) {
+  TestEdgeFunction::initEdgeFunctionCleaner();
+
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+  auto EF3 = TestEdgeFunction::createEdgeFunction(42);
+
+  std::lock_guard<std::mutex> DataLock(
+      TestEdgeFunction::getTestCacheData().DataMutex);
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 2);
+  EXPECT_EQ(EF1.get(), EF3.get());
+}
+
+TEST(EdgeFunctionSingletonFactoryTest, selfCleanExpiredEdgeFunctionsThreaded) {
+  TestEdgeFunction::initEdgeFunctionCleaner();
+
+  auto EF1 = TestEdgeFunction::createEdgeFunction(42);
+  {
+    auto EF2 = TestEdgeFunction::createEdgeFunction(1337);
+  } // EF2 deleted after scope
+
+  std::this_thread::sleep_for(std::chrono::seconds{3});
+
+  std::lock_guard<std::mutex> DataLock(
+      TestEdgeFunction::getTestCacheData().DataMutex);
+  EXPECT_EQ(TestEdgeFunction::getTestCacheData().Storage.size(), 1);
+}
+
+// main function for the test case
+int main(int Argc, char **Argv) {
+  ::testing::InitGoogleTest(&Argc, Argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Some EdgeFunctions are allocated very often during analysis but only hold constant data, to reduce the memory consumption of these EdgeFunctions this commit introduces a SingletonFactory. With the SingletonFactory EdgeFunction implements can automatically reuse previously allocated EdgeFunctions that have the same internal data, saving large amounts of memory in cases where an EdgeFunction would be allocated many times.