### PR TITLE
fix search for boost when using phasar as library

### DIFF
--- a/lib/Config/CMakeLists.txt
+++ b/lib/Config/CMakeLists.txt
@@ -16,8 +16,11 @@ else()
   )
 endif()
 
+find_package(Boost COMPONENTS filesystem REQUIRED)
+
 target_link_libraries(phasar_config
   LINK_PUBLIC
+  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_config

--- a/lib/Config/CMakeLists.txt
+++ b/lib/Config/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 
 target_link_libraries(phasar_config
   LINK_PUBLIC
-  ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_config

--- a/lib/Config/CMakeLists.txt
+++ b/lib/Config/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
   )
 endif()
 
-find_package(Boost COMPONENTS filesystem REQUIRED)
+find_package(Boost COMPONENTS filesystem program_options REQUIRED)
 
 target_link_libraries(phasar_config
   LINK_PUBLIC

--- a/lib/Config/phasar_config-config.cmake
+++ b/lib/Config/phasar_config-config.cmake
@@ -4,4 +4,4 @@ list(APPEND
   PHASAR_LLVM_DEPS
   Support)
 
-find_package(Boost COMPONENTS filesystem REQUIRED)
+find_package(Boost COMPONENTS filesystem program_options REQUIRED)

--- a/lib/Config/phasar_config-config.cmake
+++ b/lib/Config/phasar_config-config.cmake
@@ -4,3 +4,4 @@ list(APPEND
   PHASAR_LLVM_DEPS
   Support)
 
+find_package(Boost COMPONENTS filesystem REQUIRED)

--- a/lib/Controller/phasar_controller-config.cmake
+++ b/lib/Controller/phasar_controller-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_controller_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log REQUIRED)
+
 list(APPEND
   LLVM_DEPS
   Support

--- a/lib/DB/CMakeLists.txt
+++ b/lib/DB/CMakeLists.txt
@@ -43,7 +43,6 @@ endif()
 
 target_link_libraries(phasar_db
   LINK_PUBLIC
-  ${Boost_LIBRARIES}
   ${SQLITE3_LIBRARY}
 )
 

--- a/lib/PhasarClang/phasar_clang-config.cmake
+++ b/lib/PhasarClang/phasar_clang-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_clang_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
@@ -1,5 +1,7 @@
 file(GLOB_RECURSE IFDSIDE_SRC *.h *.cpp)
 
+find_package(Boost COMPONENTS program_options REQUIRED)
+
 set(PHASAR_LINK_LIBS
   phasar_config
   phasar_utils
@@ -8,6 +10,7 @@ set(PHASAR_LINK_LIBS
   phasar_controlflow
   phasar_phasarllvm_utils
   phasar_db
+  ${Boost_LIBRARIES}
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/phasar_ifdside-config.cmake
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/phasar_ifdside-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_ifdside_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS program_options REQUIRED)
+
 list(APPEND
   LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/DataFlowSolver/WPDS/phasar_wpds-config.cmake
+++ b/lib/PhasarLLVM/DataFlowSolver/WPDS/phasar_wpds-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_wpds_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS filesystem program_options REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/Passes/phasar_passes-config.cmake
+++ b/lib/PhasarLLVM/Passes/phasar_passes-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_passes_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log filesystem REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/Plugins/phasar_plugins-config.cmake
+++ b/lib/PhasarLLVM/Plugins/phasar_plugins-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_plugins_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log filesystem program_options REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/Pointer/phasar_pointer-config.cmake
+++ b/lib/PhasarLLVM/Pointer/phasar_pointer-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_pointer_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log filesystem graph REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Core

--- a/lib/PhasarLLVM/TypeHierarchy/phasar_typehierarchy-config.cmake
+++ b/lib/PhasarLLVM/TypeHierarchy/phasar_typehierarchy-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_typehierarchy_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log filesystem graph REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarLLVM/Utils/phasar_phasarllvm_utils-config.cmake
+++ b/lib/PhasarLLVM/Utils/phasar_phasarllvm_utils-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_phasarllvm_utils_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS filesystem REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/PhasarPass/phasar_pass-config.cmake
+++ b/lib/PhasarPass/phasar_pass-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_pass_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log filesystem graph program_options REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support

--- a/lib/Utils/phasar_utils-config.cmake
+++ b/lib/Utils/phasar_utils-config.cmake
@@ -1,5 +1,7 @@
 set(PHASAR_utils_COMPONENT_FOUND 1)
 
+find_package(Boost COMPONENTS log REQUIRED)
+
 list(APPEND
   PHASAR_LLVM_DEPS
   Support


### PR DESCRIPTION
On ubuntu 20 using phasar as a library was broken:

CMake Error at CMakeLists.txt:12 (add_executable):
 Target "myphasartool" links to target "Boost::graph" but the target was not
 found. Perhaps a find_package() call is missing for an IMPORTED target, or
 an ALIAS target is missing?
…

this PR should fix this by triggering searches for the dependent boost components through phasar_*-config.cmake.

@vulder Please check whether this breaks the in-tree build in vara. I was unable to build vara with the current state of the phasar development branch.