### PR TITLE
Add ability to get a set of all functions in the callgraph.

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "boost/graph/adjacency_list.hpp"
+#include "boost/container/flat_set.hpp"
 
 #include "phasar/PhasarLLVM/ControlFlow/ICFG.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
@@ -103,7 +104,7 @@ private:
   /// The call graph.
   bidigraph_t CallGraph;
 
-  /// Maps function names to the corresponding vertex id.
+  /// Maps functions to the corresponding vertex id.
   std::unordered_map<const llvm::Function *, vertex_t> FunctionVertexMap;
 
   void constructionWalker(const llvm::Function *F, Resolver &Resolver);
@@ -133,8 +134,21 @@ public:
 
   ~LLVMBasedICFG() override;
 
+  /**
+   * \return all of the functions in the IRDB, this may include some not in the callgraph
+   */
   [[nodiscard]] std::set<const llvm::Function *>
   getAllFunctions() const override;
+
+  /**
+   * A boost flat_set is used here because we already have the functions in order,
+   * so building it is fast since we can always add to the end.  We get the performance
+   * and space benefits of array-backed storage and all the functionality of a set.
+   *
+   * \return all of the functions which are represented by a vertex in the callgraph.
+   */
+  [[nodiscard]] boost::container::flat_set<const llvm::Function *>
+  getAllVertexFunctions() const;
 
   bool isIndirectFunctionCall(const llvm::Instruction *N) const override;
 

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -289,6 +289,15 @@ set<const llvm::Function *> LLVMBasedICFG::getAllFunctions() const {
   return IRDB.getAllFunctions();
 }
 
+boost::container::flat_set<const llvm::Function *> LLVMBasedICFG::getAllVertexFunctions() const {
+  boost::container::flat_set<const llvm::Function *> vertexFuncs;
+  vertexFuncs.reserve(FunctionVertexMap.size());
+  for (auto v : FunctionVertexMap) {
+    vertexFuncs.insert(v.first);
+  }
+  return vertexFuncs;
+}
+
 std::vector<const llvm::Instruction *>
 LLVMBasedICFG::getOutEdges(const llvm::Function *F) const {
   auto FunctionMapIt = FunctionVertexMap.find(F);


### PR DESCRIPTION
An existing function, getDependencyOrderedFunctions(), does have the
ability to get all of the functions from the callgraph. However, this
does extra work to walk the graph such that the functions are returned
in a particular order.  This new function returns the functions in a set
so that we can quickly identify if a given function from the input is
within the graph.  A flat set was chosen for efficiency of space and
speed of lookups.