### PR TITLE
add gerneal cmake --build option (over 3.0 version)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -131,7 +131,7 @@ export CXX=${LLVM_INSTALL_DIR}/bin/clang++
 mkdir -p ${PHASAR_DIR}/build
 cd ${PHASAR_DIR}/build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ${BOOST_PARAMS} -DPHASAR_BUILD_UNITTESTS=${DO_UNIT_TEST} ${PHASAR_DIR}
-cmake --build . -j${num_cores}
+cmake --build . -- -j${num_cores}
 
 if ${DO_UNIT_TEST}; then
    echo "Running PhASAR unit tests..."


### PR DESCRIPTION
cmake --build . -j${num_cores}
==>
cmake --build . -- -j${num_cores}

cmake --build -j option is available over 3.12

but, -- -j option is available over 3.0

i think it is better.

https://stackoverflow.com/questions/36633074/set-the-number-of-threads-in-a-cmake-build
https://cmake.org/cmake/help/v3.0/manual/cmake.1.html