### PR TITLE
Makes memory improvements in FlowEdgeFunctionCache

### DIFF
--- a/include/phasar/Utils/EquivalenceClassMap.h
+++ b/include/phasar/Utils/EquivalenceClassMap.h
@@ -1,0 +1,173 @@
+/******************************************************************************
+ * Copyright (c) 2020 Philipp Schubert and Florian Sattler.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Florian Sattler and others
+ *****************************************************************************/
+
+#ifndef PHASAR_UTILS_EQUIVALENCELCASSMAP_H_
+#define PHASAR_UTILS_EQUIVALENCELCASSMAP_H_
+
+#include "llvm/ADT/iterator_range.h"
+
+#include <initializer_list>
+#include <optional>
+#include <set>
+#include <vector>
+
+namespace psr {
+
+// EquivalenceClassMap is a special map type that splits the keys into
+// equivalence classes regarding their mapped values. Meaning, that all keys
+// that are equivalent are mapped to the same value. Two keys are treated as
+// equivalent and merged into a equivalence class when they refer to Values
+// that compare equal.
+template <typename KeyT, typename ValueT> struct EquivalenceClassMap {
+  template <typename... Ts> using SetType = std::set<Ts...>;
+  using EquivalenceClassBucketT = std::pair<SetType<KeyT>, ValueT>;
+  using StorageT = std::vector<EquivalenceClassBucketT>;
+
+public:
+  using size_type = size_t;
+  using key_type = KeyT;
+  using mapped_type = ValueT;
+  using value_type = EquivalenceClassBucketT;
+
+  using const_iterator = typename StorageT::const_iterator;
+
+  using insert_return_type =
+      std::pair<typename SetType<KeyT>::const_iterator, bool>;
+
+  EquivalenceClassMap(unsigned InitialEquivalenceClasses = 0) {
+    StoredData.reserve(InitialEquivalenceClasses);
+  }
+
+  template <typename InputIt>
+  EquivalenceClassMap(const InputIt &I, const InputIt &End) {
+    this->insert(I, End);
+  }
+
+  EquivalenceClassMap(
+      std::initializer_list<std::pair<key_type, mapped_type>> Vals) {
+    this->insert(Vals.begin(), Vals.end());
+  }
+
+  [[nodiscard]] inline const_iterator begin() const {
+    return StoredData.begin();
+  }
+  [[nodiscard]] inline const_iterator end() const { return StoredData.end(); }
+  [[nodiscard]] inline llvm::iterator_range<const_iterator>
+  equivalenceClasses() const {
+    return llvm::make_range(begin(), end());
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  template <typename ValueType = ValueT>
+  insert_return_type insert(const KeyT &Key, ValueType &&Value) {
+    return try_emplace(Key, std::forward<ValueType>(Value));
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  template <typename ValueType = ValueT>
+  insert_return_type insert(KeyT &&Key, ValueType &&Value) {
+    return try_emplace(std::move(Key), std::forward<ValueType>(Value));
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  insert_return_type insert(const std::pair<KeyT, ValueT> &KVPair) {
+    return try_emplace(KVPair.first, KVPair.second);
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  insert_return_type insert(std::pair<KeyT, ValueT> &&KVPair) {
+    return try_emplace(std::move(KVPair.first), std::move(KVPair.second));
+  }
+
+  // Insert a range of Key Values pairs into the map.
+  template <typename InputIt> void insert(InputIt I, InputIt End) {
+    for (; I != End; ++I) {
+      try_emplace(I->first, I->second);
+    }
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  template <typename... Ts>
+  insert_return_type try_emplace(KeyT &&Key, Ts &&... Args) {
+    ValueT Val{std::forward<Ts...>(Args...)};
+
+    for (auto &KVPair : StoredData) {
+      if (KVPair.second == Val) {
+        return KVPair.first.insert(Key);
+      }
+    }
+
+    StoredData.emplace_back(SetType<KeyT>{std::move(Key)}, std::move(Val));
+    return std::make_pair(StoredData.back().first.begin(), true);
+  }
+
+  // Inserts Key into the corresponding equivalence class for Value. If Value
+  // is not already in the map a new equivalence class is created.
+  template <typename... Ts>
+  insert_return_type try_emplace(const KeyT &Key, Ts &&... Args) {
+    ValueT Val{std::forward<Ts...>(Args...)};
+
+    for (auto &KVPair : StoredData) {
+      if (KVPair.second == Val) {
+        return KVPair.first.insert(Key);
+      }
+    }
+
+    StoredData.emplace_back(SetType<KeyT>{Key}, std::move(Val));
+    return std::make_pair(StoredData.back().first.begin(), true);
+  }
+
+  // Return 1 if the specified key is in the map, 0 otherwise.
+  [[nodiscard]] inline size_type count(const KeyT &Key) const {
+    for (auto &KVPair : StoredData) {
+      if (KVPair.first.count(Key) >= 1) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  [[nodiscard]] inline size_type numEquivalenceClasses() const {
+    return StoredData.size();
+  }
+
+  // Returns the size of the map, i.e., the number of equivalence classes.
+  [[nodiscard]] inline size_type size() const {
+    return numEquivalenceClasses();
+  }
+
+  [[nodiscard]] const_iterator find(key_type Key) const {
+    return find_if(StoredData.begin(), StoredData.end(),
+                   [&Key](const EquivalenceClassBucketT &Val) -> bool {
+                     return Val.first.count(Key) >= 1;
+                   });
+  }
+
+  [[nodiscard]] std::optional<ValueT> findValue(key_type Key) const {
+    auto Search = find(Key);
+    if (Search != StoredData.end()) {
+      return Search->second;
+    }
+    return std::nullopt;
+  }
+
+  inline void clear() { StoredData.clear(); }
+
+private:
+  StorageT StoredData{};
+};
+
+} // namespace psr
+
+#endif // PHASAR_UTILS_EQUIVALENCELCASSMAP_H_

--- a/unittests/Utils/CMakeLists.txt
+++ b/unittests/Utils/CMakeLists.txt
@@ -1,10 +1,11 @@
 set(UtilsSources
-	LLVMShorthandsTest.cpp
-	LLVMIRToSrcTest.cpp
-	PAMMTest.cpp
-	BitVectorSetTest.cpp
+  BitVectorSetTest.cpp
+  EquivalenceClassMapTest.cpp
+  LLVMIRToSrcTest.cpp
+  LLVMShorthandsTest.cpp
+  PAMMTest.cpp
 )
 
 foreach(TEST_SRC ${UtilsSources})
-	add_phasar_unittest(${TEST_SRC})
+  add_phasar_unittest(${TEST_SRC})
 endforeach(TEST_SRC)

--- a/unittests/Utils/EquivalenceClassMapTest.cpp
+++ b/unittests/Utils/EquivalenceClassMapTest.cpp
@@ -1,0 +1,186 @@
+#include "gtest/gtest.h"
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "phasar/Utils/EquivalenceClassMap.h"
+
+using namespace psr;
+using namespace std;
+
+TEST(EquivalenceClassMap, ctorEmpty) {
+  EquivalenceClassMap<int, std::string> M;
+  EXPECT_EQ(M.size(), 0U);
+}
+
+TEST(EquivalenceClassMap, ctorIter) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  std::vector<std::pair<MapTy::key_type, MapTy::mapped_type>> InitValues(
+      {make_pair(42, "foo"), make_pair(21, "bar")});
+
+  MapTy M{InitValues.begin(), InitValues.end()};
+
+  EXPECT_EQ(M.size(), 2U);
+  EXPECT_EQ(M.find(42)->first.count(42), 1U);
+  EXPECT_EQ(M.find(42)->second, "foo");
+  EXPECT_EQ(M.find(21)->first.count(21), 1U);
+  EXPECT_EQ(M.find(21)->second, "bar");
+}
+
+TEST(EquivalenceClassMap, ctorInitList) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar")}};
+
+  EXPECT_EQ(M.size(), 2U);
+  EXPECT_EQ(M.find(42)->first.count(42), 1U);
+  EXPECT_EQ(M.find(42)->second, "foo");
+  EXPECT_EQ(M.find(21)->first.count(21), 1U);
+  EXPECT_EQ(M.find(21)->second, "bar");
+}
+
+TEST(EquivalenceClassMap, iterMap) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar")}};
+
+  auto Iter = M.begin();
+  EXPECT_EQ(Iter->first.count(42), 1U);
+  EXPECT_EQ(Iter->second, "foo");
+  ++Iter;
+  EXPECT_EQ(Iter->first.count(21), 1U);
+  EXPECT_EQ(Iter->second, "bar");
+  ++Iter;
+  EXPECT_EQ(Iter, M.end());
+}
+
+TEST(EquivalenceClassMap, insertKeyRef) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+  int Key = 42;
+  const MapTy::key_type &KeyRef = Key;
+
+  M.insert(42, "foo");
+  EXPECT_EQ(M.findValue(42), "foo");
+}
+
+TEST(EquivalenceClassMap, insertKeyRVal) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+
+  M.insert(42, "foo");
+  EXPECT_EQ(M.findValue(42), "foo");
+}
+
+TEST(EquivalenceClassMap, insertKeyValuePairRef) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+  const std::pair<int, std::string> KVPair{42, "foo"};
+
+  M.insert(KVPair);
+  EXPECT_EQ(M.findValue(42), "foo");
+}
+
+TEST(EquivalenceClassMap, insertKeyValueRVal) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+
+  M.insert(std::make_pair(42, "foo"));
+  EXPECT_EQ(M.findValue(42), "foo");
+}
+
+TEST(EquivalenceClassMap, count) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar"), make_pair(20, "foo")}};
+
+  EXPECT_EQ(M.count(42), 1U);
+  EXPECT_EQ(M.count(21), 1U);
+  EXPECT_EQ(M.count(20), 1U);
+  EXPECT_EQ(M.count(1337), 0U);
+}
+
+TEST(EquivalenceClassMap, numEqClasses) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar"), make_pair(20, "foo")}};
+
+  EXPECT_EQ(M.numEquivalenceClasses(), 2U);
+  EXPECT_EQ(M.size(), 2U);
+}
+
+TEST(EquivalenceClassMap, findEntryForKey) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar"), make_pair(20, "foo")}};
+
+  EXPECT_EQ(M.find(42)->second, "foo");
+  EXPECT_EQ(M.find(21)->second, "bar");
+  EXPECT_EQ(M.find(20)->second, "foo");
+}
+
+TEST(EquivalenceClassMap, findValueForKey) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar"), make_pair(20, "foo")}};
+
+  EXPECT_EQ(M.findValue(42), "foo");
+  EXPECT_EQ(M.findValue(21), "bar");
+  EXPECT_EQ(M.findValue(20), "foo");
+  EXPECT_EQ(M.findValue(1337), std::nullopt);
+}
+
+TEST(EquivalenceClassMap, clear) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M{{make_pair(42, "foo"), make_pair(21, "bar"), make_pair(20, "foo")}};
+
+  EXPECT_EQ(M.numEquivalenceClasses(), 2U);
+  M.clear();
+  EXPECT_EQ(M.numEquivalenceClasses(), 0U);
+}
+
+//===----------------------------------------------------------------------===//
+// Equivalence functionality tests
+TEST(EquivalenceClassMap, threeDifferentValues) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+
+  M.insert(std::make_pair(42, "foo"));
+  M.insert(std::make_pair(21, "bar"));
+  M.insert(std::make_pair(40, "bazz"));
+
+  EXPECT_EQ(M.findValue(42), "foo");
+  EXPECT_EQ(M.findValue(21), "bar");
+  EXPECT_EQ(M.findValue(40), "bazz");
+
+  EXPECT_EQ(M.numEquivalenceClasses(), 3U);
+}
+
+TEST(EquivalenceClassMap, threeEqualValues) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+
+  M.insert(std::make_pair(42, "foo"));
+  M.insert(std::make_pair(21, "foo"));
+  M.insert(std::make_pair(40, "foo"));
+
+  EXPECT_EQ(M.findValue(42), "foo");
+  EXPECT_EQ(M.findValue(21), "foo");
+  EXPECT_EQ(M.findValue(40), "foo");
+
+  EXPECT_EQ(M.numEquivalenceClasses(), 1U);
+}
+
+TEST(EquivalenceClassMap, threeMixedValues) {
+  using MapTy = EquivalenceClassMap<int, std::string>;
+  MapTy M;
+
+  M.insert(std::make_pair(42, "foo"));
+  M.insert(std::make_pair(21, "bar"));
+  M.insert(std::make_pair(40, "foo"));
+
+  EXPECT_EQ(M.findValue(42), "foo");
+  EXPECT_EQ(M.findValue(21), "bar");
+  EXPECT_EQ(M.findValue(40), "foo");
+
+  EXPECT_EQ(M.numEquivalenceClasses(), 2U);
+}
+
+int main(int Argc, char **Argv) {
+  ::testing::InitGoogleTest(&Argc, Argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Improves memory consumption by compressing keys of maps under a huge load and switching certain maps to a new EquivalenceClassMap, which only keeps one representative value for each equivalence class of keys.
Furthermore, unnecessary count checks were removed by direct look up of the keys, which saves one map traversal for every look up.