### PR TITLE
Small speed improvements for BitVector and Table

### DIFF
--- a/include/phasar/Utils/BitVectorSet.h
+++ b/include/phasar/Utils/BitVectorSet.h
@@ -17,6 +17,7 @@
 #include "boost/bimap/unordered_set_of.hpp"
 
 #include "llvm/ADT/BitVector.h"
+#include "llvm/Support/Compiler.h"
 
 namespace psr {
 namespace internal {
@@ -37,10 +38,9 @@ inline bool isLess(const llvm::BitVector &Lhs, const llvm::BitVector &Rhs) {
   // Compare every bit on both sides because Lhs and Rhs either have the same
   // amount of bits or all other upper bits of the larger one are zero.
   for (int i = static_cast<int>(std::min(LhsBits, RhsBits)) - 1; i >= 0; --i) {
-    if (Lhs[i] == Rhs[i]) {
-      continue;
+    if (LLVM_UNLIKELY(Lhs[i] != Rhs[i])) {
+      return Rhs[i];
     }
-    return Rhs[i];
   }
   return false;
 }

--- a/include/phasar/Utils/Table.h
+++ b/include/phasar/Utils/Table.h
@@ -142,8 +142,8 @@ public:
   [[nodiscard]] bool contains(R rowKey, C columnKey) const {
     // Returns true if the table contains a mapping with the specified row and
     // column keys.
-    if (table.count(rowKey)) {
-      return table.at(rowKey).count(columnKey);
+    if (auto RowIter = table.find(rowKey); RowIter != table.end()) {
+      return RowIter->second.find(columnKey) != RowIter->second.end();
     }
     return false;
   }


### PR DESCRIPTION
Add branch likleyhood information because the condition will only be
true once, in the case where we exit the function.