### PR TITLE
Moves const_cast out of retrieveFunction

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h
@@ -13,6 +13,7 @@
 #include "phasar/PhasarLLVM/Pointer/PointsToInfo.h"
 
 namespace llvm {
+class Function;
 class Instruction;
 class Value;
 } // namespace llvm
@@ -24,7 +25,7 @@ class LLVMPointsToInfo
 public:
   ~LLVMPointsToInfo() override = default;
 
-  static llvm::Function *retrieveFunction(const llvm::Value *V);
+  static const llvm::Function *retrieveFunction(const llvm::Value *V);
 };
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToInfo.cpp
@@ -16,20 +16,20 @@ using namespace psr;
 
 namespace psr {
 
-llvm::Function *LLVMPointsToInfo::retrieveFunction(const llvm::Value *V) {
+const llvm::Function *LLVMPointsToInfo::retrieveFunction(const llvm::Value *V) {
   const llvm::Function *Fun = nullptr;
   if (V) {
-    if (auto Inst = llvm::dyn_cast<llvm::Instruction>(V)) {
+    if (const auto *Inst = llvm::dyn_cast<llvm::Instruction>(V)) {
       Fun = Inst->getFunction();
     }
-    if (auto BB = llvm::dyn_cast<llvm::BasicBlock>(V)) {
+    if (const auto *BB = llvm::dyn_cast<llvm::BasicBlock>(V)) {
       Fun = BB->getParent();
     }
-    if (auto Arg = llvm::dyn_cast<llvm::Argument>(V)) {
+    if (const auto *Arg = llvm::dyn_cast<llvm::Argument>(V)) {
       Fun = Arg->getParent();
     }
   }
-  return const_cast<llvm::Function *>(Fun);
+  return Fun;
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
@@ -83,8 +83,8 @@ void LLVMPointsToSet::computeValuesPointsToSet(const llvm::Value *V) {
       }
     }
   } else {
-    auto *VF = retrieveFunction(V);
-    computeFunctionsPointsToSet(VF);
+    const auto *VF = retrieveFunction(V);
+    computeFunctionsPointsToSet(const_cast<llvm::Function *>(VF));
   }
 }
 


### PR DESCRIPTION
The implementation of retrieveFunction does not need to include a const_cast
since it's implementation does not require non const accesses. Hence, we
should push the burden of const casting to callers that require non
const functions, preserving constness for callers that don't.