### PR TITLE
Update bootstrap script (set ENV variables & shorten arch installation)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,7 +58,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 echo "installing phasar dependencies..."
 if [ -x "$(command -v pacman)" ]; then
-    yes | sudo pacman -Syu which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc cmake z3 libedit graphviz python-sphinx openmp curl python-pip
+    yes | sudo pacman -Syu --needed which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc cmake z3 libedit graphviz python-sphinx openmp curl python-pip
     ./utils/installBuildEAR.sh
 else
     ./utils/InstallAptDependencies.sh
@@ -74,7 +74,7 @@ else
 
 	if [ -z $BOOST_VERSION ] ;then
         if [ -x "$(command -v pacman)" ]; then
-            yes | sudo pacman -S boost-libs boost
+            yes | sudo pacman -Syu --needed boost-libs boost
         else
             if [ -z $DESIRED_BOOST_VERSION ] ;then
                 sudo apt install libboost-all-dev -y

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -148,3 +148,7 @@ sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
 sudo ldconfig
 cd ..
 echo "phasar successfully installed to ${PHASAR_INSTALL_DIR}"
+
+
+echo "Set environment variables"
+./utils/setEnvironmentVariables.sh ${LLVM_INSTALL_DIR} ${PHASAR_INSTALL_DIR}

--- a/utils/setEnvironmentVariables.sh
+++ b/utils/setEnvironmentVariables.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+readonly LLVM_INSTALL_DIR=${1}
+readonly PHASAR_INSTALL_DIR="${2}"
+if [ "$#" -ne 2 ] || [ -z "${LLVM_INSTALL_DIR}" ] || [ -z "${PHASAR_INSTALL_DIR}" ]; 
+then
+	echo "usage: ./setEnvironmentVariables.sh <LLVM_INSTALL_DIR> <PHASAR_INSTALL_DIR>" >&2
+	exit 1
+fi
+
+RCPATH=~/.$(basename $SHELL)rc
+EXPORTGUARD="# PhASAR export guard"
+
+# Check whether the SHELLrc file contains the EXPORTGUARD 
+if grep -Fxq "$EXPORTGUARD" $RCPATH
+the
+    echo "Environment variables have been already set"
+else
+    echo 'Add environment variables to' $(basename $SHELL)'rc'
+    # LLVM exports
+    echo '' >> $RCPATH
+    echo '# LLVM' >> $RCPATH
+    echo 'export PATH=${PATH}:'${LLVM_INSTALL_DIR}'/bin' >> $RCPATH
+    echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:'${LLVM_INSTALL_DIR}'/lib' >> $RCPATH
+    echo 'export LIBRARY_PATH=${LIBRARY_PATH}:'${LLVM_INSTALL_DIR}'/include' >> $RCPATH
+    # PhASAR exports
+    echo '# PhASAR' >> $RCPATH
+    echo 'export PATH=${PATH}:'${PHASAR_INSTALL_DIR}'/bin' >> $RCPATH
+    echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:'${PHASAR_INSTALL_DIR}'/lib' >> $RCPATH
+    echo 'export LIBRARY_PATH=${LIBRARY_PATH}:'${PHASAR_INSTALL_DIR}'/include' >> $RCPATH
+    echo 'export PHASAR_INCLUDE_DIR='${PHASAR_INSTALL_DIR}'/include' >> $RCPATH
+    echo 'export PHASAR_LIBRARY_DIR='${PHASAR_INSTALL_DIR}'/lib' >> $RCPATH
+    # Add the export guard 
+    echo $EXPORTGUARD >> $RCPATH
+    # Open a new shell to ensure that the ENV variables are loaded
+    $SHELL
+fi

--- a/utils/setEnvironmentVariables.sh
+++ b/utils/setEnvironmentVariables.sh
@@ -12,7 +12,7 @@ EXPORTGUARD="# PhASAR export guard"
 
 # Check whether the SHELLrc file contains the EXPORTGUARD 
 if grep -Fxq "$EXPORTGUARD" $RCPATH
-the
+then
     echo "Environment variables have been already set"
 else
     echo 'Add environment variables to' $(basename $SHELL)'rc'

--- a/utils/setEnvironmentVariables.sh
+++ b/utils/setEnvironmentVariables.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 readonly LLVM_INSTALL_DIR=${1}
 readonly PHASAR_INSTALL_DIR="${2}"
-if [ "$#" -ne 2 ] || [ -z "${LLVM_INSTALL_DIR}" ] || [ -z "${PHASAR_INSTALL_DIR}" ]; 
+if [ "$#" -ne 2 ] || [ -z "${LLVM_INSTALL_DIR}" ] || [ -z "${PHASAR_INSTALL_DIR}" ];
 then
 	echo "usage: ./setEnvironmentVariables.sh <LLVM_INSTALL_DIR> <PHASAR_INSTALL_DIR>" >&2
 	exit 1
@@ -10,10 +10,10 @@ fi
 RCPATH=~/.$(basename $SHELL)rc
 EXPORTGUARD="# PhASAR export guard"
 
-# Check whether the SHELLrc file contains the EXPORTGUARD 
+# Check whether the SHELLrc file contains the EXPORTGUARD
 if grep -Fxq "$EXPORTGUARD" $RCPATH
 then
-    echo "Environment variables have been already set"
+    echo "Environment variables have already been set"
 else
     echo 'Add environment variables to' $(basename $SHELL)'rc'
     # LLVM exports
@@ -29,7 +29,7 @@ else
     echo 'export LIBRARY_PATH=${LIBRARY_PATH}:'${PHASAR_INSTALL_DIR}'/include' >> $RCPATH
     echo 'export PHASAR_INCLUDE_DIR='${PHASAR_INSTALL_DIR}'/include' >> $RCPATH
     echo 'export PHASAR_LIBRARY_DIR='${PHASAR_INSTALL_DIR}'/lib' >> $RCPATH
-    # Add the export guard 
+    # Add the export guard
     echo $EXPORTGUARD >> $RCPATH
     # Open a new shell to ensure that the ENV variables are loaded
     $SHELL


### PR DESCRIPTION
# Environment variables
Add a bash script to the `utils` folder which sets the environment variables after the PhASAR installation. It appends the export commands to the `~/.$(basename $SHELL)rc` file.

# Arch update
Install (`--needed`) packages if they are not already installed.