### PR TITLE
Fixed boundary-value-bug of erase() in BitVectorSet.h

### DIFF
--- a/include/phasar/Utils/BitVectorSet.h
+++ b/include/phasar/Utils/BitVectorSet.h
@@ -258,7 +258,7 @@ public:
   void erase(const T &Data) noexcept {
     auto Search = Position.left.find(Data);
     if (Search != Position.left.end()) {
-      if (!(Bits.size() < Search->second - 1)) {
+      if (Bits.size() > Search->second) {
         Bits[Search->second] = false;
       }
     }


### PR DESCRIPTION
I found a boundary-value-bug at l.261 of erase() in BitVectorSet.h.
In this code, we cannot erase the first element because of underflow.
So change the condition check to the same as that at l.278 of count() in BitVectorSet.h.

Please review this change.