### PR TITLE
Fix some bugs in LLVMTypeHierarchy.cpp

### DIFF
--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -163,7 +163,15 @@ LLVMTypeHierarchy::getSubTypes(const llvm::Module &M,
                                const llvm::StructType &Type) {
   // find corresponding type info variable
   std::vector<const llvm::StructType *> SubTypes;
-  if (const auto *TI = ClearNameTIMap[removeStructOrClassPrefix(Type)]) {
+  std::string ClearName = removeStructOrClassPrefix(Type);
+  if (const auto *TI = ClearNameTIMap[ClearName]) {
+
+    if (!TI->hasInitializer()) {
+      LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
+                    << ClearName << " does not have initializer");
+      return SubTypes;
+    }
+
     if (const auto *I =
             llvm::dyn_cast<llvm::ConstantStruct>(TI->getInitializer())) {
       for (const auto &Op : I->operands()) {
@@ -197,6 +205,13 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
   std::vector<const llvm::Function *> VFS;
   if (const auto *TV = ClearNameTVMap[ClearName]) {
     if (const auto *TI = llvm::dyn_cast<llvm::GlobalVariable>(TV)) {
+
+      if (!TI->hasInitializer()) {
+        LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
+                      << ClearName << " does not have initializer");
+        return VFS;
+      }
+
       if (const auto *I =
               llvm::dyn_cast<llvm::ConstantStruct>(TI->getInitializer())) {
         for (const auto &Op : I->operands()) {

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -96,10 +96,10 @@ std::string
 LLVMTypeHierarchy::removeStructOrClassPrefix(const std::string &TypeName) {
   llvm::StringRef SR(TypeName);
   if (SR.startswith(StructPrefix)) {
-    return SR.ltrim(StructPrefix);
+    return SR.drop_front(StructPrefix.size());
   }
   if (SR.startswith(ClassPrefix)) {
-    return SR.ltrim(ClassPrefix);
+    return SR.drop_front(ClassPrefix.size());
   }
   return TypeName;
 }
@@ -107,10 +107,10 @@ LLVMTypeHierarchy::removeStructOrClassPrefix(const std::string &TypeName) {
 std::string LLVMTypeHierarchy::removeTypeInfoPrefix(std::string VarName) {
   llvm::StringRef SR(VarName);
   if (SR.startswith(TypeInfoPrefixDemang)) {
-    return SR.ltrim(TypeInfoPrefixDemang);
+    return SR.drop_front(TypeInfoPrefixDemang.size());
   }
   if (SR.startswith(TypeInfoPrefix)) {
-    return SR.ltrim(TypeInfoPrefix);
+    return SR.drop_front(TypeInfoPrefix.size());
   }
   return VarName;
 }
@@ -118,10 +118,10 @@ std::string LLVMTypeHierarchy::removeTypeInfoPrefix(std::string VarName) {
 std::string LLVMTypeHierarchy::removeVTablePrefix(std::string VarName) {
   llvm::StringRef SR(VarName);
   if (SR.startswith(VTablePrefixDemang)) {
-    return SR.ltrim(VTablePrefixDemang);
+    return SR.drop_front(VTablePrefixDemang.size());
   }
   if (SR.startswith(VTablePrefix)) {
-    return SR.ltrim(VTablePrefix);
+    return SR.drop_front(VTablePrefix.size());
   }
   return VarName;
 }

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -206,8 +206,14 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
                 // caution: getAsInstruction allocates, need to delete later
                 auto *AsI = CE->getAsInstruction();
                 if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(AsI)) {
-                  if (BC->getOperand(0)->hasName()) {
-                    if (auto *F = M.getFunction(BC->getOperand(0)->getName())) {
+                  // if the entry is a GlobalAlias, get its Aliasee
+                  auto *ENTRY = BC->getOperand(0);
+                  while (auto *GA = llvm::dyn_cast<llvm::GlobalAlias>(ENTRY)) {
+                    ENTRY = GA->getAliasee();
+                  }
+
+                  if (ENTRY->hasName()) {
+                    if (auto *F = M.getFunction(ENTRY->getName())) {
                       VFS.push_back(F);
                     }
                   }

--- a/test/llvm_test_code/type_hierarchies/CMakeLists.txt
+++ b/test/llvm_test_code/type_hierarchies/CMakeLists.txt
@@ -16,6 +16,7 @@ set(NoMem2regSources
   type_hierarchy_12_c.cpp
   type_hierarchy_13.cpp
   type_hierarchy_14.cpp
+  type_hierarchy_15.cpp
 )
 
 foreach(TEST_SRC ${NoMem2regSources})

--- a/test/llvm_test_code/type_hierarchies/CMakeLists.txt
+++ b/test/llvm_test_code/type_hierarchies/CMakeLists.txt
@@ -15,6 +15,7 @@ set(NoMem2regSources
   type_hierarchy_12_b.cpp
   type_hierarchy_12_c.cpp
   type_hierarchy_13.cpp
+  type_hierarchy_14.cpp
 )
 
 foreach(TEST_SRC ${NoMem2regSources})

--- a/test/llvm_test_code/type_hierarchies/type_hierarchy_14.cpp
+++ b/test/llvm_test_code/type_hierarchies/type_hierarchy_14.cpp
@@ -1,0 +1,19 @@
+
+// This class has 4 entries in the vtable
+// a construtor, test, 2 destructors
+// for the destructors, see here
+// https://eli.thegreenplace.net/2015/c-deleting-destructors-and-virtual-operator-delete/
+class Base {
+public:
+  virtual void test();
+  virtual ~Base();
+};
+
+void Base::test() {}
+
+Base::~Base() {}
+
+void test() {
+  Base *b = new Base();
+  b->test();
+}

--- a/test/llvm_test_code/type_hierarchies/type_hierarchy_15.cpp
+++ b/test/llvm_test_code/type_hierarchies/type_hierarchy_15.cpp
@@ -1,0 +1,29 @@
+class Base {
+  int x;
+public:
+  virtual void test();
+  virtual ~Base();
+};
+
+class Child: public Base {
+public:
+  virtual ~Child();
+};
+
+// the definition of this method is missing
+// void Base::test() {
+// }
+
+Base::~Base() {
+}
+
+Child::~Child() {
+}
+
+void use() {
+  Child *c = new Child();
+
+  delete c;
+}
+
+

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -52,6 +52,12 @@ TEST(LTHTest, BasicTHReconstruction_1) {
   EXPECT_EQ(ChildReachable.count(LTH.getType("struct.Child")), true);
 }
 
+TEST(LTHTest, THConstructionException) {
+  ProjectIRDB IRDB({unittest::PathToLLTestFiles +
+      "type_hierarchies/type_hierarchy_15_cpp.ll"});
+  LLVMTypeHierarchy LTH(IRDB);
+}
+
 TEST(LTHTest, BasicTHReconstruction_2) {
   ProjectIRDB IRDB({unittest::PathToLLTestFiles +
                     "type_hierarchies/type_hierarchy_2_cpp.ll"});

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -304,6 +304,8 @@ TEST(LTHTest, VTableConstruction) {
                      "type_hierarchies/type_hierarchy_9_cpp.ll"});
   ProjectIRDB IRDB5({unittest::PathToLLTestFiles +
                      "type_hierarchies/type_hierarchy_10_cpp.ll"});
+  ProjectIRDB IRDB6({unittest::PathToLLTestFiles +
+                     "type_hierarchies/type_hierarchy_14_cpp.ll"});
 
   // Creates an empty type hierarchy
   LLVMTypeHierarchy TH1(IRDB1);
@@ -311,6 +313,7 @@ TEST(LTHTest, VTableConstruction) {
   LLVMTypeHierarchy TH3(IRDB3);
   LLVMTypeHierarchy TH4(IRDB4);
   LLVMTypeHierarchy TH5(IRDB5);
+  LLVMTypeHierarchy TH6(IRDB6);
 
   ASSERT_TRUE(TH1.hasVFTable(TH1.getType("struct.Base")));
   ASSERT_TRUE(TH1.hasVFTable(TH1.getType("struct.Child")));
@@ -443,6 +446,7 @@ TEST(LTHTest, VTableConstruction) {
                               ->getFunction(2)
                               ->getName()) == "Child::baz()");
   ASSERT_TRUE(TH5.getVFTable(TH5.getType("struct.Child"))->size() == 3U);
+  ASSERT_TRUE(TH6.getVFTable(TH6.getType("class.Base"))->size() == 3U);
 }
 
 TEST(LTHTest, TransitivelyReachableTypes) {


### PR DESCRIPTION
in methods like removeStructOrClassPrefix, ltrim is used to remove a prefix
from a name, which may be wrong. According to the comments of ltrim, ltrim
removes all chars belonging to the prefix from the target string, instead
of removing the prefix directly. The right way is simply removing the prefix
using drop_front