### PR TITLE
F additional result iface for llvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PhASAR a LLVM-based Static Analysis Framework
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c944f18c7960488798a0728db9380eb5)](https://app.codacy.com/app/pdschubert/phasar?utm_source=github.com&utm_medium=referral&utm_content=secure-software-engineering/phasar&utm_campaign=Badge_Grade_Dashboard)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/secure-software-engineering/phasar/master/LICENSE.txt)
 
-Version 0320
+Version 1220
 
 Secure Software Engineering Group
 ---------------------------------

--- a/include/phasar/Config/Version.h
+++ b/include/phasar/Config/Version.h
@@ -1,1 +1,1 @@
-#define PHASAR_VERSION v0320
+#define PHASAR_VERSION v1220

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -75,11 +75,11 @@ template <typename AnalysisDomainTy, typename Container> struct IFDSExtension {
       TransformedProblem;
 };
 
-/**
- * Solves the given IDETabulationProblem as described in the 1996 paper by
- * Sagiv, Horwitz and Reps. To solve the problem, call solve(). Results
- * can then be queried by using resultAt() and resultsAt().
- */
+///
+/// Solves the given IDETabulationProblem as described in the 1996 paper by
+/// Sagiv, Horwitz and Reps. To solve the problem, call solve(). Results
+/// can then be queried by using resultAt() and resultsAt().
+///
 template <typename AnalysisDomainTy,
           typename Container = std::set<typename AnalysisDomainTy::d_t>,
           bool = is_analysis_domain_extensions<AnalysisDomainTy>::value>
@@ -146,9 +146,9 @@ public:
     return J;
   }
 
-  /**
-   * @brief Runs the solver on the configured problem. This can take some time.
-   */
+  ///
+  /// @brief Runs the solver on the configured problem. This can take some time.
+  ///
   virtual void solve() {
     PAMM_GET_INSTANCE;
     REG_COUNTER("Gen facts", 0, PAMM_SEVERITY_LEVEL::Core);
@@ -197,22 +197,90 @@ public:
     }
   }
 
-  /**
-   * Returns the V-type result for the given value at the given statement.
-   * TOP values are never returned.
-   */
+  ///
+  /// Returns the L-type result for the given value at the given statement.
+  ///
   [[nodiscard]] virtual l_t resultAt(n_t stmt, d_t value) {
     return valtab.get(stmt, value);
   }
 
-  /**
-   * Returns the resulting environment for the given statement.
-   * The artificial zero value can be automatically stripped.
-   * TOP values are never returned.
-   */
+  ///
+  /// Returns the L-type result at the given statement for the given data-flow
+  /// fact while respecting LLVM's SSA semantics.
+  ///
+  /// An example: when a value is loaded and the location loaded from, here
+  /// variable 'i', is a data-flow fact that holds, then the loaded value '%0'
+  /// will usually be generated and also holds. However, due to the underlying
+  /// theory (and respective implementation) this load instruction causes the
+  /// loaded value to be generated and thus, it will be valid only AFTER the
+  /// load instruction, i.e., at the successor instruction.
+  ///
+  ///   %0 = load i32, i32* %i, align 4
+  ///
+  /// This result accessor function returns the results at the successor
+  /// instruction(s) reflecting that the expression on the left-hand side holds
+  /// if the expression on the right-hand side holds.
+  ///
+  template <typename NTy = n_t>
+  [[nodiscard]]
+  typename std::enable_if_t<std::is_same_v<NTy, const llvm::Instruction *>, l_t>
+  resultAtInLLVMSSA(NTy stmt, d_t value) {
+    if (stmt->getType()->isVoidTy()) {
+      return valtab.get(stmt, value);
+    } else {
+      return valtab.get(stmt->getNextNode(), value);
+    }
+  }
+
+  ///
+  /// Returns the resulting environment for the given statement.
+  /// The artificial zero value can be automatically stripped.
+  /// TOP values are never returned.
+  ///
   [[nodiscard]] virtual std::unordered_map<d_t, l_t>
   resultsAt(n_t stmt, bool stripZero = false) /*TODO const*/ {
     std::unordered_map<d_t, l_t> result = valtab.row(stmt);
+    if (stripZero) {
+      for (auto it = result.begin(); it != result.end();) {
+        if (IDEProblem.isZeroValue(it->first)) {
+          it = result.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+    return result;
+  }
+
+  ///
+  /// Returns the data-flow results at the given statement while respecting
+  /// LLVM's SSA semantics.
+  ///
+  /// An example: when a value is loaded and the location loaded from, here
+  /// variable 'i', is a data-flow fact that holds, then the loaded value '%0'
+  /// will usually be generated and also holds. However, due to the underlying
+  /// theory (and respective implementation) this load instruction causes the
+  /// loaded value to be generated and thus, it will be valid only AFTER the
+  /// load instruction, i.e., at the successor instruction.
+  ///
+  ///   %0 = load i32, i32* %i, align 4
+  ///
+  /// This result accessor function returns the results at the successor
+  /// instruction(s) reflecting that the expression on the left-hand side holds
+  /// if the expression on the right-hand side holds.
+  ///
+  template <typename NTy = n_t>
+  [[nodiscard]]
+  typename std::enable_if_t<std::is_same_v<NTy, const llvm::Instruction *>,
+                            std::unordered_map<d_t, l_t>>
+  resultsAtInLLVMSSA(NTy stmt, bool stripZero = false) {
+    std::unordered_map<d_t, l_t> result = [&valtabe, stmt]() {
+      if (stmt->getType()->isVoidTy()) {
+        return valtab.row(stmt);
+      } else {
+        return valtab.row(stmt->getNextNode());
+      }
+    }();
     if (stripZero) {
       for (auto it = result.begin(); it != result.end();) {
         if (IDEProblem.isZeroValue(it->first)) {

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IDESolver.h
@@ -75,11 +75,9 @@ template <typename AnalysisDomainTy, typename Container> struct IFDSExtension {
       TransformedProblem;
 };
 
-///
 /// Solves the given IDETabulationProblem as described in the 1996 paper by
 /// Sagiv, Horwitz and Reps. To solve the problem, call solve(). Results
 /// can then be queried by using resultAt() and resultsAt().
-///
 template <typename AnalysisDomainTy,
           typename Container = std::set<typename AnalysisDomainTy::d_t>,
           bool = is_analysis_domain_extensions<AnalysisDomainTy>::value>
@@ -146,9 +144,7 @@ public:
     return J;
   }
 
-  ///
-  /// @brief Runs the solver on the configured problem. This can take some time.
-  ///
+  /// \brief Runs the solver on the configured problem. This can take some time.
   virtual void solve() {
     PAMM_GET_INSTANCE;
     REG_COUNTER("Gen facts", 0, PAMM_SEVERITY_LEVEL::Core);
@@ -197,14 +193,11 @@ public:
     }
   }
 
-  ///
   /// Returns the L-type result for the given value at the given statement.
-  ///
   [[nodiscard]] virtual l_t resultAt(n_t stmt, d_t value) {
     return valtab.get(stmt, value);
   }
 
-  ///
   /// Returns the L-type result at the given statement for the given data-flow
   /// fact while respecting LLVM's SSA semantics.
   ///
@@ -220,23 +213,20 @@ public:
   /// This result accessor function returns the results at the successor
   /// instruction(s) reflecting that the expression on the left-hand side holds
   /// if the expression on the right-hand side holds.
-  ///
   template <typename NTy = n_t>
-  [[nodiscard]]
-  typename std::enable_if_t<std::is_same_v<NTy, const llvm::Instruction *>, l_t>
+  [[nodiscard]] typename std::enable_if_t<
+      std::is_same_v<std::remove_reference_t<NTy>, llvm::Instruction *>, l_t>
   resultAtInLLVMSSA(NTy stmt, d_t value) {
     if (stmt->getType()->isVoidTy()) {
       return valtab.get(stmt, value);
-    } else {
-      return valtab.get(stmt->getNextNode(), value);
     }
+    assert(stmt->getNextNode() && "Expected to find a valid successor node!");
+    return valtab.get(stmt->getNextNode(), value);
   }
 
-  ///
   /// Returns the resulting environment for the given statement.
   /// The artificial zero value can be automatically stripped.
   /// TOP values are never returned.
-  ///
   [[nodiscard]] virtual std::unordered_map<d_t, l_t>
   resultsAt(n_t stmt, bool stripZero = false) /*TODO const*/ {
     std::unordered_map<d_t, l_t> result = valtab.row(stmt);
@@ -252,7 +242,6 @@ public:
     return result;
   }
 
-  ///
   /// Returns the data-flow results at the given statement while respecting
   /// LLVM's SSA semantics.
   ///
@@ -268,20 +257,19 @@ public:
   /// This result accessor function returns the results at the successor
   /// instruction(s) reflecting that the expression on the left-hand side holds
   /// if the expression on the right-hand side holds.
-  ///
   template <typename NTy = n_t>
-  [[nodiscard]]
-  typename std::enable_if_t<std::is_same_v<NTy, const llvm::Instruction *>,
-                            std::unordered_map<d_t, l_t>>
+  [[nodiscard]] typename std::enable_if_t<
+      std::is_same_v<std::remove_reference_t<NTy>, llvm::Instruction *>,
+      std::unordered_map<d_t, l_t>>
   resultsAtInLLVMSSA(NTy stmt, bool stripZero = false) {
-    std::unordered_map<d_t, l_t> result = [&valtabe, stmt]() {
+    std::unordered_map<d_t, l_t> result = [this, stmt]() {
       if (stmt->getType()->isVoidTy()) {
         return valtab.row(stmt);
-      } else {
-        return valtab.row(stmt->getNextNode());
       }
+      return valtab.row(stmt->getNextNode());
     }();
     if (stripZero) {
+      // TODO: replace with std::erase_if (C++20)
       for (auto it = result.begin(); it != result.end();) {
         if (IDEProblem.isZeroValue(it->first)) {
           it = result.erase(it);

--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSSolver.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Solver/IFDSSolver.h
@@ -19,6 +19,8 @@
 
 #include <memory>
 #include <set>
+#include <type_traits>
+#include <unordered_map>
 
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSTabulationProblem.h"
 #include "phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSSolverTest.h"
@@ -37,16 +39,58 @@ public:
   using D = typename AnalysisDomainTy::d_t;
   using N = typename AnalysisDomainTy::n_t;
 
-  IFDSSolver(IFDSTabulationProblem<AnalysisDomainTy> &ifdsProblem)
-      : IDESolver<AnalysisDomainExtender<AnalysisDomainTy>>(ifdsProblem) {}
+  IFDSSolver(IFDSTabulationProblem<AnalysisDomainTy> &IFDSProblem)
+      : IDESolver<AnalysisDomainExtender<AnalysisDomainTy>>(IFDSProblem) {}
 
   ~IFDSSolver() override = default;
 
-  std::set<D> ifdsResultsAt(N stmt) {
+  ///
+  /// Returns the data-flow results at the given statement.
+  ///
+  std::set<D> ifdsResultsAt(N Inst) {
     std::set<D> KeySet;
-    std::unordered_map<D, BinaryDomain> ResultMap = this->resultsAt(stmt);
+    std::unordered_map<D, BinaryDomain> ResultMap = this->resultsAt(Inst);
     for (auto FlowFact : ResultMap) {
       KeySet.insert(FlowFact.first);
+    }
+    return KeySet;
+  }
+
+  ///
+  /// Returns the data-flow results at the given statement while respecting
+  /// LLVM's SSA semantics.
+  ///
+  /// An example: when a value is loaded and the location loaded from, here
+  /// variable 'i', is a data-flow fact that holds, then the loaded value '%0'
+  /// will usually be generated and also holds. However, due to the underlying
+  /// theory (and respective implementation) this load instruction causes the
+  /// loaded value to be generated and thus, it will be valid only AFTER the
+  /// load instruction, i.e., at the successor instruction.
+  ///
+  ///   %0 = load i32, i32* %i, align 4
+  ///
+  /// This result accessor function returns the results at the successor
+  /// instruction(s) reflecting that the expression on the left-hand side holds
+  /// if the expression on the right-hand side holds.
+  ///
+  template <typename NTy = N>
+  typename std::enable_if_t<std::is_same_v<NTy, const llvm::Instruction *>,
+                            std::set<D>>
+  ifdsResultsAtInLLVMSSA(NTy Inst) {
+    std::unordered_map<D, BinaryDomain> ResultMap = [this, Inst]() {
+      if (Inst->getType()->isVoidTy()) {
+        return this->resultsAt(Inst);
+      } else {
+        // In this case we have a value on the left-hand side and must return
+        // the results at the successor instruction. Note that terminator
+        // instructions are always of void type.
+        return this->resultsAt(Inst->getNextNode());
+        assert("Expected to find a successor instruction!");
+      }
+    }();
+    std::set<D> KeySet;
+    for (auto &[FlowFact, LatticeValue] : ResultMap) {
+      KeySet.insert(FlowFact);
     }
     return KeySet;
   }


### PR DESCRIPTION
Hi Flo,

please check out if you can make use of this additional API to query the data-flow results respecting LLVM's SSA representation. I did not yet test it extensively, but it should do the trick (at least for some minor test programs).

Cheers
Philipp