### PR TITLE
Fixes config file generation location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
 endif()
 
 configure_file(config.h.in config.h @ONLY)
-include_directories(${CMAKE_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 
 include_directories(


### PR DESCRIPTION
The generated config file needs to placed in the CURRENT_BINARY_DIR not
just the BINARY_DIR. In cases where phasar is embedded, e.g., in the case of an llvm in-tree build, the binary dirs differ and break the build.