### PR TITLE
Fix points-to information for globals

### DIFF
--- a/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToSet.cpp
@@ -228,6 +228,12 @@ void LLVMPointsToSet::computeFunctionsPointsToSet(llvm::Function *F) {
       }
     }
   }
+  // Consider globals
+  for (auto &Global : F->getParent()->globals()) {
+    if (auto *GlobalVariable = llvm::dyn_cast<llvm::GlobalVariable>(&Global)) {
+      Pointers.insert(GlobalVariable);
+    }
+  }
   // introduce a singleton set for each pointer
   // those sets will be merged as we discover aliases
   for (auto *Pointer : Pointers) {


### PR DESCRIPTION
Previously points-to relations of globals that were not used directly in a function were omitted. If a callee of that function introduces an alias, it was not propagated further up.