### PR TITLE
Fix llvm::Value::~Value(): materialized_use_empty() && "Uses remain..

### DIFF
--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -187,8 +187,8 @@ LLVMTypeHierarchy::getSubTypes(const llvm::Module &M,
                 }
               }
             }
-            AsI->deleteValue();
           }
+          AsI->deleteValue();          
         }
       }
     }

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -228,8 +228,8 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
                       VFS.push_back(F);
                     }
                   }
-                  AsI->deleteValue();
                 }
+                AsI->deleteValue();
               }
             }
           }


### PR DESCRIPTION
…hen a value is destroyed!" due to incorrect nesting for deleteValue()