### PR TITLE
Fix "Uses remain when a value is destroyed!"

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -78,6 +78,8 @@ IFDSConstAnalysis::getNormalFlowFunction(IFDSConstAnalysis::n_t Curr,
             LOG_IF_ENABLE(
                 BOOST_LOG_SEV(lg::get(), DEBUG)
                 << "Store Instruction sets up or updates vtable - ignored!");
+            CFInst->deleteValue();
+            CEInst->deleteValue();
             return Identity<IFDSConstAnalysis::d_t>::getInstance();
           }
         }


### PR DESCRIPTION
F0417 21:53:52.651166   10192 logging.cc:107] assert.h assertion failed at third_party/llvm/llvm-project/llvm/lib/IR/Value.cpp:104 in llvm::Value::~Value(): materialized_use_empty() && "Uses remain when a value is destroyed!"