### PR TITLE
Only add TSAN for testing when compatible

### DIFF
--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/CMakeLists.txt
@@ -12,9 +12,13 @@ set(ThreadedIfdsIdeSources
   EdgeFunctionSingletonFactoryTest.cpp
 )
 
-if(UNIX)
-  # Append -fno-omit-frame-pointer to get better stack traces.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
+if(UNIX AND CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+  # Only add thread sanitizer for the test if asan is disabled because both
+  # cannot be active at the same time.
+  if (NOT "${LLVM_USE_SANITIZER}" MATCHES ".*Address.*")
+    # Append -fno-omit-frame-pointer to get better stack traces.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
+  endif()
 endif()
 
 foreach(TEST_SRC ${ThreadedIfdsIdeSources})


### PR DESCRIPTION
Only add TSAN when compiled with clang and ASAN is not active.