### PR TITLE
Adds a query method for possible allocation sites to PointsToInfo

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
@@ -146,12 +146,9 @@ public:
 
   [[nodiscard]] bool
   isInReachableAllocationSites(const llvm::Value *V,
-                              const llvm::Value *PotentialValue,
-                              bool IntraProcOnly = false,
-                              const llvm::Instruction *I = nullptr) override {
-    // TODO(sattlerf): implement
-    return false;
-  }
+                               const llvm::Value *PotentialValue,
+                               bool IntraProcOnly = false,
+                               const llvm::Instruction *I = nullptr) override;
 
   void mergeWith(const PointsToInfo<const llvm::Value *,
                                     const llvm::Instruction *> &PTI) override;

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
@@ -144,6 +144,15 @@ public:
   getReachableAllocationSites(const llvm::Value *V, bool IntraProcOnly = false,
                               const llvm::Instruction *I = nullptr) override;
 
+  [[nodiscard]] bool
+  isInReachableAllocationSites(const llvm::Value *V,
+                              const llvm::Value *PotentialValue,
+                              bool IntraProcOnly = false,
+                              const llvm::Instruction *I = nullptr) override {
+    // TODO(sattlerf): implement
+    return false;
+  }
+
   void mergeWith(const PointsToInfo<const llvm::Value *,
                                     const llvm::Instruction *> &PTI) override;
 

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -54,11 +54,13 @@ private:
 
   void mergePointsToSets(const llvm::Value *V1, const llvm::Value *V2);
 
-  // TODO (sattlerf): rename
-  bool interFoobar(const llvm::Value *V, const llvm::Value *P);
+  bool interIsReachableAllocationSiteTy(const llvm::Value *V,
+                                        const llvm::Value *P);
 
-  // TODO (sattlerf): rename
-  bool intraFoobar(const llvm::Value *V, const llvm::Value *P);
+  bool intraIsReachableAllocationSiteTy(const llvm::Value *V,
+                                        const llvm::Value *P,
+                                        const llvm::Function *VFun,
+                                        const llvm::GlobalObject *VG);
 
 public:
   /**

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -54,6 +54,12 @@ private:
 
   void mergePointsToSets(const llvm::Value *V1, const llvm::Value *V2);
 
+  // TODO (sattlerf): rename
+  bool interFoobar(const llvm::Value *V, const llvm::Value *P);
+
+  // TODO (sattlerf): rename
+  bool intraFoobar(const llvm::Value *V, const llvm::Value *P);
+
 public:
   /**
    * Creates points-to set(s) based on the computed alias results.
@@ -89,6 +95,13 @@ public:
   [[nodiscard]] std::shared_ptr<std::unordered_set<const llvm::Value *>>
   getReachableAllocationSites(const llvm::Value *V, bool IntraProcOnly = false,
                               const llvm::Instruction *I = nullptr) override;
+
+  // Checks if PotentialValue is in the reachable allocation sites of V.
+  [[nodiscard]] bool
+  isInReachableAllocationSites(const llvm::Value *V,
+                               const llvm::Value *PotentialValue,
+                               bool IntraProcOnly = false,
+                               const llvm::Instruction *I = nullptr) override;
 
   void mergeWith(const PointsToInfo &PTI) override;
 

--- a/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToInfo.h
@@ -54,6 +54,11 @@ public:
   virtual std::shared_ptr<std::unordered_set<V>>
   getReachableAllocationSites(V V1, bool IntraProcOnly = false, N I = N{}) = 0;
 
+  // Checks if V2 is a reachable allocation in the points to set of V1.
+  virtual bool isInReachableAllocationSites(V V1, V V2,
+                                            bool IntraProcOnly = false,
+                                            N I = N{}) = 0;
+
   virtual void print(std::ostream &OS = std::cout) const = 0;
 
   virtual nlohmann::json getAsJson() const = 0;

--- a/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMPointsToGraph.cpp
@@ -279,6 +279,13 @@ LLVMPointsToGraph::getReachableAllocationSites(const llvm::Value *V,
   return AllocSites;
 }
 
+[[nodiscard]] bool LLVMPointsToGraph::isInReachableAllocationSites(
+    const llvm::Value *V, const llvm::Value *PotentialValue, bool IntraProcOnly,
+    const llvm::Instruction *I) {
+  return getReachableAllocationSites(V, IntraProcOnly, I)
+      ->count(PotentialValue);
+}
+
 void LLVMPointsToGraph::mergeWith(
     const LLVMPointsToGraph::PointsToInfo<const llvm::Value *,
                                           const llvm::Instruction *> &PTI) {


### PR DESCRIPTION
Extends the PointsToInfo interface with a query method
`isInReachableAllocationSites`. This enables users to simply query if a
value is in the set of reachable allocation sites without needing to
return a copy of the set.