### PR TITLE
InterMonoFullConstantPropagation : code review

### DIFF
--- a/test/llvm_test_code/full_constant/advanced_04.cpp
+++ b/test/llvm_test_code/full_constant/advanced_04.cpp
@@ -1,0 +1,14 @@
+int sqar(int baz){
+    return baz * baz;
+}
+int foo(int bar, int x){
+    int baz = x;
+    int lbaz = sqar(baz);
+    return lbaz*bar;
+}
+ 
+int main(){
+    int x = 5;
+    int i = foo(13,x);
+    return 0;
+}

--- a/test/llvm_test_code/full_constant/advanced_05.cpp
+++ b/test/llvm_test_code/full_constant/advanced_05.cpp
@@ -1,0 +1,20 @@
+int sqar(int baz){
+    return baz * baz;
+}
+
+int mul(int baz){
+    return 100 * baz;
+}
+int foo(int bar, int x){
+    int baz = x;
+    int lbaz = mul(sqar(baz));
+    return lbaz*bar;
+}
+ 
+int main(){
+    int x = 5;
+    int i = foo(13,x);
+    int y = 0;
+    int z = 0;
+    return 0;
+}

--- a/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoFullConstantPropagationTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/Mono/InterMonoFullConstantPropagationTest.cpp
@@ -95,67 +95,76 @@ protected:
 }; // Test Fixture
 
 // Test for Case I of Store
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_01) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 5, "i", 13));
-//   doAnalysisAndCompareResults("basic_01_cpp.ll", GroundTruth, true);
-// }
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_01) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 5, "i", 13));
+  doAnalysisAndCompareResults("basic_01_cpp.ll", GroundTruth, true);
+}
 
-// // Test for Case II of Store and Load Inst
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_02) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 8, "i", 13));
-//   doAnalysisAndCompareResults("basic_02_cpp.ll", GroundTruth, true);
-// }
+// Test for Case II of Store and Load Inst
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_02) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 8, "i", 13));
+  doAnalysisAndCompareResults("basic_02_cpp.ll", GroundTruth, true);
+}
 
-// // Test for Operators
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_03) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 9, "i", 13));
-//   doAnalysisAndCompareResults("basic_03_cpp.ll", GroundTruth, true);
-// }
+// Test for Operators
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_03) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 9, "i", 13));
+  doAnalysisAndCompareResults("basic_03_cpp.ll", GroundTruth, true);
+}
 
-// // Test for Operators
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_04) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 12, "i", 13));
-//   doAnalysisAndCompareResults("basic_04_cpp.ll", GroundTruth,
-//                               true);
-// }
+// Test for Operators
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_04) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 12, "i", 13));
+  doAnalysisAndCompareResults("basic_04_cpp.ll", GroundTruth,
+                              true);
+}
 
-// // Test for Operators
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_05) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 9, "i", 13));
-//   doAnalysisAndCompareResults("basic_05_cpp.ll", GroundTruth,
-//                               true);
-// }
+// Test for Operators
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_05) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 9, "i", 13));
+  doAnalysisAndCompareResults("basic_05_cpp.ll", GroundTruth,
+                              true);
+}
 
-// // Test for Operators
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_06) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 8, "i", 9));
-//   doAnalysisAndCompareResults("basic_06_cpp.ll", GroundTruth,
-//                               true);
-// }
+// Test for Operators
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_06) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 8, "i", 9));
+  doAnalysisAndCompareResults("basic_06_cpp.ll", GroundTruth,
+                              true);
+}
+
+TEST_F(InterMonoFullConstantPropagationTest, BasicTest_07) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 9, "i", 42));
+  doAnalysisAndCompareResults("basic_07_cpp.ll", GroundTruth, true);
+}
 
 // Test for return Flow
 TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_01) {
@@ -167,34 +176,45 @@ TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_01) {
   doAnalysisAndCompareResults("advanced_01_cpp.ll", GroundTruth, true);
 }
 
-// // Test for Call Flow
-// TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_02) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 14, "i", 14));
-//   doAnalysisAndCompareResults("advanced_02_cpp.ll", GroundTruth, true);
-// }
+// Test for Call Flow
+TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_02) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 7, "i", 14));
+  doAnalysisAndCompareResults("advanced_02_cpp.ll", GroundTruth, true);
+}
 
-// // Test for Call Flow
-// TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_03) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 9, "i", 5));
-//   doAnalysisAndCompareResults("advanced_03_cpp.ll", GroundTruth, true);
-// }
+// Test for Call Flow
+TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_03) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 9, "i", 5));
+  doAnalysisAndCompareResults("advanced_03_cpp.ll", GroundTruth, true);
+}
 
-// TEST_F(InterMonoFullConstantPropagationTest, BasicTest_07) {
-//   std::set<IMFCPCompactResult_t> GroundTruth;
-//   GroundTruth.emplace(
-//       std::tuple<std::string, size_t, std::string,
-//                  LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
-//           "main", 9, "i", 42));
-//   doAnalysisAndCompareResults("basic_07_cpp.ll", GroundTruth, true);
-// }
+// Test for Call Flow
+TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_04) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 9, "i", 325));
+  doAnalysisAndCompareResults("advanced_04_cpp.ll", GroundTruth, true);
+}
+
+// Test for Call Flow
+TEST_F(InterMonoFullConstantPropagationTest, AdvancedTest_05) {
+  std::set<IMFCPCompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string,
+                 LatticeDomain<InterMonoFullConstantPropagation::plain_d_t>>(
+          "main", 11, "i", 32500));
+  doAnalysisAndCompareResults("advanced_05_cpp.ll", GroundTruth, true);
+}
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
InterMonoSolver.h			 : modified addCalleesToWorklist method to place call statements at the right place in the worklist.

advanced_04.cpp  			 : additional test case
advanced_05.cpp  			 : additional test case
InterMonoFullConstantPropagationTest.cpp : added 2 new test cases.