### PR TITLE
Revert "Update StoreInstFlowFunction.cpp"

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/StoreInstFlowFunction.cpp
@@ -47,7 +47,7 @@ StoreInstFlowFunction::computeTargetsExt(ExtendedValue &Fact) {
     bool PatchMemLocation = !DstMemLocationSeq.empty();
     if (PatchMemLocation) {
       bool IsArgCoerced =
-          SrcMemLocationMatr->getName().str().contains_lower("coerce");
+          SrcMemLocationMatr->getName().contains_lower("coerce");
       if (IsArgCoerced) {
         assert(DstMemLocationSeq.size() > 1);
         DstMemLocationSeq.pop_back();


### PR DESCRIPTION
Reverts secure-software-engineering/phasar#358

kinda conflicts with #360 
also, std::basic_string doesn't have contains until C++23, currently in phasar we're at C++17.