### PR TITLE
Switch to building Unit Tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ list(GET VERSION_NUMBER_FILE 2 VERSION_NUMBER_PHASAR)
 
 include("phasar_macros")
 
-option(PHASAR_BUILD_UNITTESTS "Build all tests (default is OFF)" OFF)
+option(PHASAR_BUILD_UNITTESTS "Build all tests (default is ON)" ON)
 
 option(PHASAR_BUILD_OPENSSL_TS_UNITTESTS "Build OPENSSL typestate tests (require OpenSSL, default is OFF)" OFF)
 


### PR DESCRIPTION
Switch to building unit tests by default for better code quality.  Right now since tests are not built by default it is easy by default to make a breaking change or not update tests when changing code.