### PR TITLE
Link stdc++fs for tools that require it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,12 @@ include_directories(
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+if (LLVM_ENABLE_LIBCXX)
+  set(PHASAR_STD_FILESYSTEM c++fs)
+else()
+  set(PHASAR_STD_FILESYSTEM stdc++fs)
+endif()
+
 ### Adding external libraries
 # Threads
 find_package(Threads)

--- a/tools/boomerang/CMakeLists.txt
+++ b/tools/boomerang/CMakeLists.txt
@@ -30,6 +30,8 @@ target_link_libraries(boomerang
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
+  LINK_PRIVATE
+  ${PHASAR_STD_FILESYSTEM}
 )
 
 if(USE_LLVM_FAT_LIB)

--- a/tools/example-tool/CMakeLists.txt
+++ b/tools/example-tool/CMakeLists.txt
@@ -30,6 +30,8 @@ target_link_libraries(myphasartool
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
+  LINK_PRIVATE
+  ${PHASAR_STD_FILESYSTEM}
 )
 
 if(USE_LLVM_FAT_LIB)

--- a/tools/phasar-clang/CMakeLists.txt
+++ b/tools/phasar-clang/CMakeLists.txt
@@ -39,6 +39,8 @@ target_link_libraries(phasar-clang
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
   # ${CLANG_LIBRARY}
+  LINK_PRIVATE
+  ${PHASAR_STD_FILESYSTEM}
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/tools/phasar-llvm/CMakeLists.txt
+++ b/tools/phasar-llvm/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries(phasar-llvm
   ${Boost_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
+  LINK_PRIVATE
+  ${PHASAR_STD_FILESYSTEM}
 )
 
 if(USE_LLVM_FAT_LIB)


### PR DESCRIPTION
Some phasar tools started to switch from boost::filesystem to
std::filesystem, so we need to link these targets against the std
filesystem library.