### PR TITLE
Cleans up getVarAnnotationIntrinsicName

### DIFF
--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -226,8 +226,7 @@ bool isVarAnnotationIntrinsic(const llvm::Function *F);
  * Test the call function be tested by isVarAnnotationIntrinsic
  *
  */
-const llvm::StringRef
-getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst);
+llvm::StringRef getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst);
 } // namespace psr
 
 #endif

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -410,21 +410,22 @@ bool isVarAnnotationIntrinsic(const llvm::Function *F) {
   return F->getName() == kVarAnnotationName;
 }
 
-const llvm::StringRef
-getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst) {
+llvm::StringRef getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst) {
   const int kPointerGlobalStringIdx = 1;
-  llvm::ConstantExpr *ce = llvm::cast<llvm::ConstantExpr>(
+  auto *ce = llvm::cast<llvm::ConstantExpr>(
       CallInst->getOperand(kPointerGlobalStringIdx));
   assert(ce != nullptr);
   assert(ce->getOpcode() == llvm::Instruction::GetElementPtr);
   assert(llvm::dyn_cast<llvm::GlobalVariable>(ce->getOperand(0)) != nullptr);
-  llvm::GlobalVariable *annoteStr =
-      llvm::dyn_cast<llvm::GlobalVariable>(ce->getOperand(0));
+
+  auto *annoteStr = llvm::dyn_cast<llvm::GlobalVariable>(ce->getOperand(0));
   assert(llvm::dyn_cast<llvm::ConstantDataSequential>(
       annoteStr->getInitializer()));
-  llvm::ConstantDataSequential *data =
+
+  auto *data =
       llvm::dyn_cast<llvm::ConstantDataSequential>(annoteStr->getInitializer());
   assert(data->isString());
+
   return data->getAsString();
 }
 


### PR DESCRIPTION
Small clean up. Removes const from the return type, as returning a value
will result in a copy, hence, making it const has no meaning.
Furthermore, relayouts the function a bit so the three parts are easier
understandable.