### PR TITLE
Fixes signed integer overflow in LinearConstantAnalysis 

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -743,10 +743,6 @@ IDELinearConstantAnalysis::l_t IDELinearConstantAnalysis::executeBinOperation(
     const unsigned Op, IDELinearConstantAnalysis::l_t Lop,
     IDELinearConstantAnalysis::l_t Rop) {
 
-  if (Rop == TOP || Lop == TOP) {
-    return TOP;
-  }
-
   // default initialize with BOTTOM (all information)
   IDELinearConstantAnalysis::l_t Res = BOTTOM;
   switch (Op) {
@@ -770,6 +766,11 @@ IDELinearConstantAnalysis::l_t IDELinearConstantAnalysis::executeBinOperation(
 
   case llvm::Instruction::UDiv:
   case llvm::Instruction::SDiv:
+    if (Lop == std::numeric_limits<IDELinearConstantAnalysis::l_t>::min() &&
+        Rop == -1) { // Would produce and overflow, as the complement of min is
+                     // not representable in a signed type.
+      return TOP;
+    }
     Res = Lop / Rop;
     break;
 

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "phasar/DB/ProjectIRDB.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
@@ -745,15 +746,21 @@ IDELinearConstantAnalysis::l_t IDELinearConstantAnalysis::executeBinOperation(
   IDELinearConstantAnalysis::l_t Res = BOTTOM;
   switch (Op) {
   case llvm::Instruction::Add:
-    Res = Lop + Rop;
+    if (llvm::AddOverflow(Lop, Rop, Res)) {
+      Res = TOP;
+    }
     break;
 
   case llvm::Instruction::Sub:
-    Res = Lop - Rop;
+    if (llvm::SubOverflow(Lop, Rop, Res)) {
+      Res = TOP;
+    }
     break;
 
   case llvm::Instruction::Mul:
-    Res = Lop * Rop;
+    if (llvm::MulOverflow(Lop, Rop, Res)) {
+      Res = TOP;
+    }
     break;
 
   case llvm::Instruction::UDiv:

--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -742,6 +742,11 @@ bool IDELinearConstantAnalysis::isEntryPoint(
 IDELinearConstantAnalysis::l_t IDELinearConstantAnalysis::executeBinOperation(
     const unsigned Op, IDELinearConstantAnalysis::l_t Lop,
     IDELinearConstantAnalysis::l_t Rop) {
+
+  if (Rop == TOP || Lop == TOP) {
+    return TOP;
+  }
+
   // default initialize with BOTTOM (all information)
   IDELinearConstantAnalysis::l_t Res = BOTTOM;
   switch (Op) {

--- a/test/llvm_test_code/linear_constant/overflow_add.cpp
+++ b/test/llvm_test_code/linear_constant/overflow_add.cpp
@@ -1,0 +1,7 @@
+#include <cstdint>
+
+int main() {
+  int64_t i = 9223372036854775806; // std::numeric_limits<int64_t>::max() - 1
+  int64_t j = i + 8;
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/overflow_div_min_by_neg_one.cpp
+++ b/test/llvm_test_code/linear_constant/overflow_div_min_by_neg_one.cpp
@@ -1,0 +1,8 @@
+#include <cstdint>
+
+int main() {
+  int64_t i = -9223372036854775807; // std::numeric_limits<int64_t>::min() + 1
+  int64_t j = i - 8;
+  int64_t k = j / -1;
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/overflow_mul.cpp
+++ b/test/llvm_test_code/linear_constant/overflow_mul.cpp
@@ -1,0 +1,7 @@
+#include <cstdint>
+
+int main() {
+  int64_t i = 9223372036854775806; // std::numeric_limits<int64_t>::max() - 1
+  int64_t j = i * 8;
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/overflow_sub.cpp
+++ b/test/llvm_test_code/linear_constant/overflow_sub.cpp
@@ -1,0 +1,7 @@
+#include <cstdint>
+
+int main() {
+  int64_t i = -9223372036854775807; // std::numeric_limits<int64_t>::min() + 1
+  int64_t j = i - 8;
+  return 0;
+}

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -747,38 +747,35 @@ TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_16) {
 /* ============== OVERFLOW TESTS ============== */
 
 TEST_F(IDELinearConstantAnalysisTest, HandleAddOverflow) {
-  auto Results = doAnalysis("overflow_add.ll");
+  auto Results = doAnalysis("overflow_add_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 6, "i", 9223372036854775806);
+  GroundTruth.emplace("main", 6, "j", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 
 TEST_F(IDELinearConstantAnalysisTest, HandleSubOverflow) {
-  auto Results = doAnalysis("overflow_sub.ll");
+  auto Results = doAnalysis("overflow_sub_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 6, "i", -9223372036854775807);
+  GroundTruth.emplace("main", 6, "j", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 
 TEST_F(IDELinearConstantAnalysisTest, HandleMulOverflow) {
-  auto Results = doAnalysis("overflow_mul.ll");
+  auto Results = doAnalysis("overflow_mul_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 6, "i", 9223372036854775806);
+  GroundTruth.emplace("main", 6, "j", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 
 TEST_F(IDELinearConstantAnalysisTest, HandleDivOverflowForMinIntDivByOne) {
-  auto Results = doAnalysis("overflow_div_min_by_neg_one.ll");
+  auto Results = doAnalysis("overflow_div_min_by_neg_one_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 6, "i", -9223372036854775807);
+  GroundTruth.emplace("main", 6, "j", IDELinearConstantAnalysis::TOP);
+  GroundTruth.emplace("main", 6, "k", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -744,6 +744,44 @@ TEST_F(IDELinearConstantAnalysisTest, HandleGlobalsTest_16) {
   compareResults(Results, GroundTruth);
 }
 
+/* ============== OVERFLOW TESTS ============== */
+
+TEST_F(IDELinearConstantAnalysisTest, HandleAddOverflow) {
+  auto Results = doAnalysis("overflow_add.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleSubOverflow) {
+  auto Results = doAnalysis("overflow_sub.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleMulOverflow) {
+  auto Results = doAnalysis("overflow_mul.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleDivOverflowForMinIntDivByOne) {
+  auto Results = doAnalysis("overflow_div_min_by_neg_one.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
 // main function for the test case
 int main(int Argc, char **Argv) {
   ::testing::InitGoogleTest(&Argc, Argv);


### PR DESCRIPTION
In a the cases that the add/sub/mul operation overflows, we need to set
the edge function lattice (l_t) to TOP.