### PR TITLE
Fixes UB handling in LinearConstantAnalysis

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -771,11 +771,17 @@ IDELinearConstantAnalysis::l_t IDELinearConstantAnalysis::executeBinOperation(
                      // not representable in a signed type.
       return TOP;
     }
+    if (Rop == 0) { // Division by zero is UB, so we return TOP
+      return TOP;
+    }
     Res = Lop / Rop;
     break;
 
   case llvm::Instruction::URem:
   case llvm::Instruction::SRem:
+    if (Rop == 0) { // Division by zero is UB, so we return TOP
+      return TOP;
+    }
     Res = Lop % Rop;
     break;
 

--- a/test/llvm_test_code/linear_constant/ub_division_by_zero.cpp
+++ b/test/llvm_test_code/linear_constant/ub_division_by_zero.cpp
@@ -1,0 +1,5 @@
+int main() {
+  int i = 42;
+  int j = i / 0;
+  return 0;
+}

--- a/test/llvm_test_code/linear_constant/ub_modulo_by_zero.cpp
+++ b/test/llvm_test_code/linear_constant/ub_modulo_by_zero.cpp
@@ -1,0 +1,5 @@
+int main() {
+  int i = 42;
+  int j = i % 0;
+  return 0;
+}

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -782,20 +782,18 @@ TEST_F(IDELinearConstantAnalysisTest, HandleDivOverflowForMinIntDivByOne) {
 /* ============== ERROR TESTS ============== */
 
 TEST_F(IDELinearConstantAnalysisTest, HandleDivisionByZero) {
-  auto Results = doAnalysis("ub_division_by_zero.ll");
+  auto Results = doAnalysis("ub_division_by_zero_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 
 TEST_F(IDELinearConstantAnalysisTest, HandleModuloByZero) {
-  auto Results = doAnalysis("ub_modulo_by_zero.ll");
+  auto Results = doAnalysis("ub_modulo_by_zero_cpp_dbg.ll");
   std::set<LCACompactResult_t> GroundTruth;
-
-  // TODO: philipp encode
-
+  GroundTruth.emplace("main", 4, "i", 42);
+  GroundTruth.emplace("main", 4, "j", IDELinearConstantAnalysis::TOP);
   compareResults(Results, GroundTruth);
 }
 

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDELinearConstantAnalysisTest.cpp
@@ -779,6 +779,26 @@ TEST_F(IDELinearConstantAnalysisTest, HandleDivOverflowForMinIntDivByOne) {
   compareResults(Results, GroundTruth);
 }
 
+/* ============== ERROR TESTS ============== */
+
+TEST_F(IDELinearConstantAnalysisTest, HandleDivisionByZero) {
+  auto Results = doAnalysis("ub_division_by_zero.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
+TEST_F(IDELinearConstantAnalysisTest, HandleModuloByZero) {
+  auto Results = doAnalysis("ub_modulo_by_zero.ll");
+  std::set<LCACompactResult_t> GroundTruth;
+
+  // TODO: philipp encode
+
+  compareResults(Results, GroundTruth);
+}
+
 // main function for the test case
 int main(int Argc, char **Argv) {
   ::testing::InitGoogleTest(&Argc, Argv);


### PR DESCRIPTION
Should we encounter a division(module) by zero, which is UB, in the
program under analysis, we set the lattice(l_t) value to TOP.