### PR TITLE
Add save/load for LLVMPointsToSet

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -42,7 +42,7 @@ private:
       const llvm::Value *,
       std::shared_ptr<std::unordered_set<const llvm::Value *>>>;
 
-  LLVMBasedPointsToAnalysis PTA;
+  std::shared_ptr<LLVMBasedPointsToAnalysis> PTA;
   std::unordered_set<const llvm::Function *> AnalyzedFunctions;
   PointsToSetMap PointsToSets;
 
@@ -62,6 +62,8 @@ private:
                                         const llvm::Function *VFun,
                                         const llvm::GlobalObject *VG);
 
+  void load(const std::string &PointsToSetFile, ProjectIRDB &IRDB);
+
 public:
   /**
    * Creates points-to set(s) based on the computed alias results.
@@ -75,7 +77,12 @@ public:
   LLVMPointsToSet(ProjectIRDB &IRDB, bool UseLazyEvaluation = true,
                   PointerAnalysisType PATy = PointerAnalysisType::CFLAnders);
 
+  LLVMPointsToSet(ProjectIRDB &IRDB,
+                  const std::string& PointsToSetFile);
+
   ~LLVMPointsToSet() override = default;
+
+  void save(const std::string &PointsToSetFile, ProjectIRDB &IRDB);
 
   [[nodiscard]] inline bool isInterProcedural() const override {
     return false;
@@ -83,7 +90,7 @@ public:
 
   [[nodiscard]] inline PointerAnalysisType
   getPointerAnalysistype() const override {
-    return PTA.getPointerAnalysisType();
+    return PTA->getPointerAnalysisType();
   };
 
   [[nodiscard]] AliasResult

--- a/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
+++ b/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
@@ -58,6 +58,25 @@ TEST(LLVMPointsToSet, Global_01) {
   std::cout << '\n';
 }
 
+TEST(LLVMPointsToSet, SaveAndLoad) {
+  std::vector<std::string> testcases = {"pointers/basic_01_cpp.ll", "pointers/global_01_cpp.ll"};
+
+  for (auto &tc : testcases) {
+    ProjectIRDB IRDB1({unittest::PathToLLTestFiles + tc});
+    LLVMPointsToSet PTS1(IRDB1, false);
+    PTS1.save("./points_to_set", IRDB1);
+
+    ProjectIRDB IRDB2({unittest::PathToLLTestFiles + tc});
+    LLVMPointsToSet PTS2(IRDB2, std::string("./points_to_set"));
+
+    std::cout << "[PTS1]" << std::endl;
+    PTS1.print(std::cout);
+
+    std::cout << "[PTS2]" << std::endl;
+    PTS2.print(std::cout);
+  }
+}
+
 int main(int Argc, char **Argv) {
   ::testing::InitGoogleTest(&Argc, Argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
As mentioned in #411 , save/load methods for LLVMPointsToSet will be very useful, especially when processing large programs. We can load the saved data and no need to generate LLVMPointsToSet again.