### PR TITLE
Helper analyses optimization

### DIFF
--- a/include/phasar/DB/ProjectIRDB.h
+++ b/include/phasar/DB/ProjectIRDB.h
@@ -168,6 +168,8 @@ public:
     return Modules.size();
   };
 
+  [[nodiscard]] std::size_t getNumInstructions() const;
+
   [[nodiscard]] llvm::Instruction *getInstruction(std::size_t id);
 
   [[nodiscard]] static std::size_t getInstructionID(const llvm::Instruction *I);

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -32,6 +32,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Module.h"
 
@@ -96,6 +97,7 @@ private:
 
   // The worklist for direct callee resolution.
   std::vector<const llvm::Function *> FunctionWL;
+  std::vector<const llvm::CallBase *> IndirectCallsWL;
 
   // Map indirect calls to the number of possible targets found for it. Fixpoint
   // is not reached when more targets are found.

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -38,12 +38,14 @@ namespace psr {
 
 class LLVMPointsToSet : public LLVMPointsToInfo {
 private:
-  using PointsToSetMap = std::unordered_map<
-      const llvm::Value *,
-      std::shared_ptr<std::unordered_set<const llvm::Value *>>>;
+  using PointsToSetTy = std::unordered_set<const llvm::Value *>;
+  using PointsToSetPtrTy = std::shared_ptr<PointsToSetTy>;
+  using PointsToSetMap =
+      std::unordered_map<const llvm::Value *, PointsToSetPtrTy>;
 
   LLVMBasedPointsToAnalysis PTA;
   std::unordered_set<const llvm::Function *> AnalyzedFunctions;
+
   PointsToSetMap PointsToSets;
 
   void computeValuesPointsToSet(const llvm::Value *V);
@@ -53,6 +55,9 @@ private:
   void addSingletonPointsToSet(const llvm::Value *V);
 
   void mergePointsToSets(const llvm::Value *V1, const llvm::Value *V2);
+
+  PointsToSetPtrTy mergePointsToSets(const PointsToSetPtrTy &PTS1,
+                                     const PointsToSetPtrTy &PTS2);
 
   bool interIsReachableAllocationSiteTy(const llvm::Value *V,
                                         const llvm::Value *P);

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -52,7 +52,7 @@ private:
 
   void computeFunctionsPointsToSet(llvm::Function *F);
 
-  void addSingletonPointsToSet(const llvm::Value *V);
+  PointsToSetPtrTy addSingletonPointsToSet(const llvm::Value *V);
 
   void mergePointsToSets(const llvm::Value *V1, const llvm::Value *V2);
 

--- a/lib/DB/ProjectIRDB.cpp
+++ b/lib/DB/ProjectIRDB.cpp
@@ -231,6 +231,10 @@ llvm::Module *ProjectIRDB::getModule(const std::string &ModuleName) {
   return nullptr;
 }
 
+std::size_t ProjectIRDB::getNumInstructions() const {
+  return IDInstructionMapping.size();
+}
+
 llvm::Instruction *ProjectIRDB::getInstruction(std::size_t Id) {
   if (IDInstructionMapping.count(Id)) {
     return IDInstructionMapping[Id];

--- a/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
@@ -50,10 +50,10 @@ int getVFTIndex(const llvm::CallBase *CallSite) {
 }
 
 const llvm::StructType *getReceiverType(const llvm::CallBase *CallSite) {
-  if (CallSite->getNumArgOperands() > 0) {
-    const llvm::Value *Receiver = CallSite->getArgOperand(0);
+  if (!CallSite->arg_empty()) {
+    const auto *Receiver = CallSite->getArgOperand(0);
     if (Receiver->getType()->isPointerTy()) {
-      if (const llvm::StructType *ReceiverTy = llvm::dyn_cast<llvm::StructType>(
+      if (const auto *ReceiverTy = llvm::dyn_cast<llvm::StructType>(
               Receiver->getType()->getPointerElementType())) {
         return ReceiverTy;
       }
@@ -63,7 +63,7 @@ const llvm::StructType *getReceiverType(const llvm::CallBase *CallSite) {
 }
 
 std::string getReceiverTypeName(const llvm::CallBase *CallSite) {
-  const auto *const RT = getReceiverType(CallSite);
+  const auto *RT = getReceiverType(CallSite);
   if (RT) {
     return RT->getName().str();
   }
@@ -107,7 +107,7 @@ Resolver::resolveFunctionPointer(const llvm::CallBase *CallSite) {
   // origin is still unknown)
   if (CallSite->getCalledOperand() != nullptr &&
       CallSite->getCalledOperand()->getType()->isPointerTy()) {
-    if (const llvm::FunctionType *FTy = llvm::dyn_cast<llvm::FunctionType>(
+    if (const auto *FTy = llvm::dyn_cast<llvm::FunctionType>(
             CallSite->getCalledOperand()->getType()->getPointerElementType())) {
       for (const auto *F : IRDB.getAllFunctions()) {
         if (matchesSignature(F, FTy)) {

--- a/tools/phasar-llvm/phasar-llvm.cpp
+++ b/tools/phasar-llvm/phasar-llvm.cpp
@@ -294,9 +294,21 @@ int main(int Argc, const char **Argv) {
                  "Specify a LLVM target module or re-run with '--help'\n";
     return 0;
   }
+
+  bool EmitStats = PhasarConfig::VariablesMap().count("statistical-analysis");
+
   // setup IRDB as source code manager
   ProjectIRDB IRDB(
       PhasarConfig::VariablesMap()["module"].as<std::vector<std::string>>());
+
+  if (EmitStats) {
+    std::cout << "Module " << IRDB.getWPAModule()->getName().str() << ":\n";
+    std::cout << "> LLVM IR instructions:\t" << IRDB.getNumInstructions()
+              << "\n";
+    std::cout << "> functions:\t\t" << IRDB.getWPAModule()->size() << "\n";
+    std::cout << "> global variables:\t" << IRDB.getWPAModule()->global_size()
+              << "\n";
+  }
 
   // store enabled data-flow analyses
   std::vector<DataFlowAnalysisKind> DataFlowAnalyses;
@@ -361,8 +373,8 @@ int main(int Argc, const char **Argv) {
   CallGraphAnalysisType CGTy = toCallGraphAnalysisType(
       PhasarConfig::VariablesMap()["call-graph-analysis"].as<std::string>());
   // setup soudiness level to be used
-  Soundness S = toSoundness(
-      PhasarConfig::VariablesMap()["soundness"].as<std::string>());
+  Soundness S =
+      toSoundness(PhasarConfig::VariablesMap()["soundness"].as<std::string>());
   // setup the emitter options to display the computed analysis results
   AnalysisControllerEmitterOptions EmitterOptions =
       AnalysisControllerEmitterOptions::EmitTextReport;

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
@@ -321,6 +321,7 @@ TEST_F(IFDSConstAnalysisTest, HandleArrayTest_06) {
   initialize({PathToLlFiles + "array/array_06_cpp_m2r_dbg.ll"});
   IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
+  PT->print(std::cerr);
   compareResults({1}, Llvmconstsolver);
 }
 

--- a/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
+++ b/unittests/PhasarLLVM/Pointer/LLVMPointsToSetTest.cpp
@@ -3,6 +3,7 @@
 #include "phasar/Config/Configuration.h"
 #include "phasar/DB/ProjectIRDB.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
+#include "phasar/PhasarLLVM/Passes/ValueAnnotationPass.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToUtils.h"
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
@@ -12,6 +13,7 @@
 using namespace psr;
 
 TEST(LLVMPointsToSet, Intra_01) {
+  ValueAnnotationPass::resetValueID();
   ProjectIRDB IRDB({unittest::PathToLLTestFiles + "pointers/basic_01_cpp.ll"});
 
   LLVMPointsToSet PTS(IRDB, false);
@@ -26,6 +28,7 @@ TEST(LLVMPointsToSet, Intra_01) {
 }
 
 TEST(LLVMPointsToSet, Inter_01) {
+  ValueAnnotationPass::resetValueID();
   ProjectIRDB IRDB({unittest::PathToLLTestFiles + "pointers/call_01_cpp.ll"});
   LLVMPointsToSet PTS(IRDB, false);
   LLVMTypeHierarchy TH(IRDB);
@@ -41,6 +44,7 @@ TEST(LLVMPointsToSet, Inter_01) {
 }
 
 TEST(LLVMPointsToSet, Global_01) {
+  ValueAnnotationPass::resetValueID();
   ProjectIRDB IRDB({unittest::PathToLLTestFiles + "pointers/global_01_cpp.ll"});
   LLVMPointsToSet PTS(IRDB, false);
   LLVMTypeHierarchy TH(IRDB);


### PR DESCRIPTION
The helper analyses of PhASAR - especially the LLVMPointsToSet and LLVMBasedICFG perform unnecessary work leading to runtimes of several hours on large target modules. 

This PR reduces the runtime to just a few minutes for the OpenSSL codebase, even when running PhASAR in debug mode.