### PR TITLE
Default IncludeGlobals to on for soundness

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -192,7 +192,7 @@ public:
   LLVMBasedICFG(ProjectIRDB &IRDB, CallGraphAnalysisType CGType,
                 const std::set<std::string> &EntryPoints = {},
                 LLVMTypeHierarchy *TH = nullptr, LLVMPointsToInfo *PT = nullptr,
-                Soundness S = Soundness::Soundy, bool IncludeGlobals = false);
+                Soundness S = Soundness::Soundy, bool IncludeGlobals = true);
 
   LLVMBasedICFG(const LLVMBasedICFG &);
 


### PR DESCRIPTION
With IncludeGlobals == false the call graph and points-to information may be unsound.