### PR TITLE
insert dummy return instructions in each function in the backward ICFG to get consistency w.r.t. forward ICFG

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -60,7 +60,7 @@ private:
     }
   };
   std::unordered_map<const llvm::Function *, LLVMBackwardRet> BackwardRets;
-  std::unordered_map<const llvm::Instruction *, const llvm::Function *>
+  llvm::DenseMap<const llvm::Instruction *, const llvm::Function *>
       BackwardRetToFunction;
 
 public:

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -18,6 +18,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "llvm/IR/LLVMContext.h"
+
 #include "phasar/PhasarLLVM/ControlFlow/ICFG.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardCFG.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
@@ -42,7 +44,22 @@ class LLVMBasedBackwardsICFG
     : public ICFG<const llvm::Instruction *, const llvm::Function *>,
       public virtual LLVMBasedBackwardCFG {
 private:
-  LLVMBasedICFG ForwardICFG;
+  LLVMBasedICFG &ForwardICFG;
+  static inline const std::unique_ptr<llvm::LLVMContext> LLVMBackwardRetCTX =
+      std::make_unique<llvm::LLVMContext>();
+
+  class LLVMBackwardRet {
+  private:
+    const llvm::ReturnInst *Instance;
+
+  public:
+    LLVMBackwardRet()
+        : Instance(llvm::ReturnInst::Create(*LLVMBackwardRetCTX)){};
+    const llvm::ReturnInst *getInstance() const { return Instance; }
+  };
+  std::unordered_map<const llvm::Function *, LLVMBackwardRet> BackwardRets;
+  std::unordered_map<const llvm::Instruction *, const llvm::Function *>
+      BackwardRetToFunction;
 
 public:
   LLVMBasedBackwardsICFG(LLVMBasedICFG &ICFG);
@@ -77,6 +94,20 @@ public:
 
   std::set<const llvm::Instruction *> allNonCallStartNodes() const override;
 
+  [[nodiscard]] const llvm::Function *
+  getFunctionOf(const llvm::Instruction *Stmt) const override;
+
+  [[nodiscard]] std::vector<const llvm::Instruction *>
+  getPredsOf(const llvm::Instruction *Stmt) const override;
+
+  [[nodiscard]] std::vector<const llvm::Instruction *>
+  getSuccsOf(const llvm::Instruction *Stmt) const override;
+
+  [[nodiscard]] std::set<const llvm::Instruction *>
+  getExitPointsOf(const llvm::Function *Fun) const override;
+
+  [[nodiscard]] bool isExitInst(const llvm::Instruction *Stmt) const override;
+
   void mergeWith(const LLVMBasedBackwardsICFG &other);
 
   using LLVMBasedBackwardCFG::print; // tell the compiler we wish to have both
@@ -94,6 +125,9 @@ public:
   unsigned getNumOfEdges();
 
   std::vector<const llvm::Function *> getDependencyOrderedFunctions();
+
+private:
+  void createBackwardRets();
 
 protected:
   void collectGlobalCtors() override;

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -66,12 +66,6 @@ private:
 public:
   LLVMBasedBackwardsICFG(LLVMBasedICFG &ICFG);
 
-  LLVMBasedBackwardsICFG(ProjectIRDB &IRDB, CallGraphAnalysisType CGType,
-                         const std::set<std::string> &EntryPoints = {},
-                         LLVMTypeHierarchy *TH = nullptr,
-                         LLVMPointsToInfo *PT = nullptr,
-                         Soundness S = Soundness::Soundy);
-
   ~LLVMBasedBackwardsICFG() override = default;
 
   std::set<const llvm::Function *> getAllFunctions() const override;

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -55,7 +55,9 @@ private:
   public:
     LLVMBackwardRet()
         : Instance(llvm::ReturnInst::Create(*LLVMBackwardRetCTX)){};
-    const llvm::ReturnInst *getInstance() const { return Instance; }
+    [[nodiscard]] const llvm::ReturnInst *getInstance() const {
+      return Instance;
+    }
   };
   std::unordered_map<const llvm::Function *, LLVMBackwardRet> BackwardRets;
   std::unordered_map<const llvm::Instruction *, const llvm::Function *>

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
@@ -116,19 +116,18 @@ LLVMBasedBackwardsICFG::getPredsOf(const llvm::Instruction *Stmt) const {
   }
   auto ExitPoints =
       LLVMBasedBackwardCFG::getExitPointsOf(BackwardRetIt->second);
-  std::vector<const llvm::Instruction *> Result(ExitPoints.begin(),
-                                                ExitPoints.end());
-  return Result;
+  return {ExitPoints.begin(), ExitPoints.end()};
 }
 
 std::vector<const llvm::Instruction *>
 LLVMBasedBackwardsICFG::getSuccsOf(const llvm::Instruction *Stmt) const {
-  if (Stmt->getParent() == nullptr && BackwardRetToFunction.count(Stmt) > 0) {
+  if (isExitInst(Stmt)) {
     return {};
   }
   std::vector<const llvm::Instruction *> Succs =
       LLVMBasedBackwardCFG::getSuccsOf(Stmt);
   if (Succs.size() == 0) {
+    assert(Stmt->getParent()->getParent() && "Could not find parent of stmt's parent ");
     Succs.push_back(
         BackwardRets.at(Stmt->getParent()->getParent()).getInstance());
   }

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.cpp
@@ -86,13 +86,8 @@ std::set<const llvm::Instruction *>
 LLVMBasedBackwardsICFG::getReturnSitesOfCallAt(
     const llvm::Instruction *N) const {
   std::set<const llvm::Instruction *> ReturnSites;
-  if (const auto *Call = llvm::dyn_cast<llvm::CallInst>(N)) {
+  if (const auto *Call = llvm::dyn_cast<llvm::CallBase>(N)) {
     for (const auto *Succ : this->getSuccsOf(Call)) {
-      ReturnSites.insert(Succ);
-    }
-  }
-  if (const auto *Invoke = llvm::dyn_cast<llvm::InvokeInst>(N)) {
-    for (const auto *Succ : this->getSuccsOf(Invoke)) {
       ReturnSites.insert(Succ);
     }
   }


### PR DESCRIPTION
requires #419 to be merged first.