### PR TITLE
fix caching of llvm::ModuleSlotTracker instances 

### DIFF
--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -22,6 +22,7 @@
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/IR/Value.h"
 
 #include "phasar/Utils/Utilities.h"
@@ -216,6 +217,23 @@ bool isVarAnnotationIntrinsic(const llvm::Function *F);
  *
  */
 llvm::StringRef getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst);
+
+class ModulesToSlotTracker {
+  friend class ProjectIRDB;
+  friend class LLVMBasedICFG;
+  friend class LLVMZeroValue;
+
+private:
+  static inline llvm::SmallDenseMap<const llvm::Module *,
+                                    std::unique_ptr<llvm::ModuleSlotTracker>, 2>
+      MToST;
+
+  static void updateMSTForModule(const llvm::Module *);
+  static void deleteMSTForModule(const llvm::Module *);
+
+public:
+  static llvm::ModuleSlotTracker &getSlotTrackerForModule(const llvm::Module *);
+};
 } // namespace psr
 
 #endif

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -669,10 +669,12 @@ LLVMBasedICFG::getReturnSitesOfCallAt(const llvm::Instruction *N) const {
   if (const auto *Invoke = llvm::dyn_cast<llvm::InvokeInst>(N)) {
     const llvm::Instruction *NormalSucc = &Invoke->getNormalDest()->front();
     auto *UnwindSucc = &Invoke->getUnwindDest()->front();
-    if (!IgnoreDbgInstructions && llvm::isa<llvm::DbgInfoIntrinsic>(NormalSucc)) {
+    if (!IgnoreDbgInstructions &&
+        llvm::isa<llvm::DbgInfoIntrinsic>(NormalSucc)) {
       NormalSucc = NormalSucc->getNextNonDebugInstruction();
     }
-    if (!IgnoreDbgInstructions && llvm::isa<llvm::DbgInfoIntrinsic>(UnwindSucc)) {
+    if (!IgnoreDbgInstructions &&
+        llvm::isa<llvm::DbgInfoIntrinsic>(UnwindSucc)) {
       UnwindSucc = UnwindSucc->getNextNonDebugInstruction();
     }
     if (NormalSucc != nullptr) {
@@ -946,6 +948,8 @@ LLVMBasedICFG::buildCRuntimeGlobalCtorsDtorsModel(llvm::Module &M) {
     IRB.SetInsertPoint(SwitchEnd);
     IRB.CreateRetVoid();
   }
+
+  ModulesToSlotTracker::updateMSTForModule(&M);
 
   return GlobModel;
 }

--- a/lib/Utils/LLVMShorthands.cpp
+++ b/lib/Utils/LLVMShorthands.cpp
@@ -435,6 +435,7 @@ ModulesToSlotTracker::getSlotTrackerForModule(const llvm::Module *M) {
   if (M == nullptr && ret == nullptr) {
     ret = std::make_unique<llvm::ModuleSlotTracker>(M);
   }
+  assert(ret != nullptr && "no ModuleSlotTracker instance for module cached");
   return *ret;
 }
 
@@ -442,7 +443,7 @@ void ModulesToSlotTracker::updateMSTForModule(const llvm::Module *M) {
   MToST[M] = std::make_unique<llvm::ModuleSlotTracker>(M);
 }
 void ModulesToSlotTracker::deleteMSTForModule(const llvm::Module *M) {
-  MToST[M] = nullptr;
+  MToST.erase(M);
 }
 
 } // namespace psr


### PR DESCRIPTION
... for printing llvm::Value - make sure that destruction of an llvm::Module leads to  destruction of its llvm::ModuleSlotTracker in cache
please merge #423 first.