### PR TITLE
Fixes wrong global lookup when global was not in the PTS

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -271,11 +271,11 @@ public:
           container_type computeTargets(d_t src) override {
             container_type Facts;
             Facts.insert(src);
-            if (PTS->count(src)) {
-              Facts.insert(Load);
-            }
+
             // Handle global variables which behave a bit special.
-            if (PTS->empty() && src == Load->getPointerOperand()) {
+            if (src == Load->getPointerOperand()) {
+              Facts.insert(Load);
+            } else if (PTS->count(src)) {
               Facts.insert(Load);
             }
             return Facts;


### PR DESCRIPTION
In cases where a global variable was not in the PTS the
IDEInstInteractionAnalysis did not correctly generate taints for the
specific instruction that loaded from the global.