### PR TITLE
Fixes linking issues of taintconfig + json workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,9 @@ include_directories(${Boost_INCLUDE_DIRS})
 option(JSON_BuildTests OFF)
 add_subdirectory(external/json EXCLUDE_FROM_ALL)
 include_directories(external/json/single_include/)
+if (PHASAR_IN_TREE)
+  set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS nlohmann_json_schema_validator)
+endif()
 
 # Googletest
 if (NOT PHASAR_IN_TREE)

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/CMakeLists.txt
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PHASAR_LINK_LIBS
   phasar_utils
   phasar_phasarllvm_utils
   phasar_db
+  phasar_taintconfig
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/PhasarLLVM/DataFlowSolver/Mono/phasar_mono-config.cmake
+++ b/lib/PhasarLLVM/DataFlowSolver/Mono/phasar_mono-config.cmake
@@ -11,6 +11,7 @@ list(APPEND
   utils
   phasarllvm_utils
   db
+  taintconfig
 )
 
 foreach(dep ${PHASAR_MONO_DEPS})

--- a/lib/PhasarLLVM/TaintConfig/CMakeLists.txt
+++ b/lib/PhasarLLVM/TaintConfig/CMakeLists.txt
@@ -2,6 +2,13 @@ file(GLOB_RECURSE TAINTCONFIG_SRC *.h *.cpp)
 
 set(PHASAR_LINK_LIBS
   phasar_utils
+  phasar_db
+  phasar_phasarllvm_utils
+)
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
 )
 
 if(BUILD_SHARED_LIBS)

--- a/lib/PhasarLLVM/TaintConfig/phasar_taintconfig-config.cmake
+++ b/lib/PhasarLLVM/TaintConfig/phasar_taintconfig-config.cmake
@@ -3,6 +3,8 @@ set(PHASAR_taintconfig_COMPONENT_FOUND 1)
 list(APPEND
   PHASAR_TAINTCONFIG_DEPS
   utils
+  db
+  phasarllvm_utils
 )
 
 foreach(dep ${PHASAR_TAINTCONFIG_DEPS})


### PR DESCRIPTION
Fixes linking issues of taintconfig and adds a workaround to include the
schema validator in LLVM_EXPORT for in tree builds, so llvm correctly
installs the schema lib alongside it's tools/libs.