### PR TITLE
Disable tests that use GTEST_SKIP for IN_TREE builds.

### DIFF
--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedCFGTest.cpp
@@ -235,11 +235,10 @@ TEST(LLVMBasedCFGTest, HandleFieldStoreField) {
   ASSERT_TRUE(Cfg.isFieldStore(Inst));
 }
 
-TEST(LLVMBasedCFGTest, HandlesCppStandardType) {
-// If we use libcxx this won't work since internal implementation is different
-#ifdef _LIBCPP_VERSION
-  GTEST_SKIP();
-#endif
+PHASAR_SKIP_TEST(TEST(LLVMBasedCFGTest, HandlesCppStandardType) {
+  // If we use libcxx this won't work since internal implementation is different
+  LIBCPP_GTEST_SKIP();
+
   ProjectIRDB IRDB(
       {unittest::PathToLLTestFiles + "name_mangling/special_members_2_cpp.ll"});
 
@@ -256,7 +255,7 @@ TEST(LLVMBasedCFGTest, HandlesCppStandardType) {
       "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev");
   ASSERT_EQ(CFG.getSpecialMemberFunctionType(O),
             SpecialMemberFunctionType::Destructor);
-}
+})
 
 TEST(LLVMBasedCFGTest, HandlesCppUserDefinedType) {
   ProjectIRDB IRDB(

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEExtendedTaintAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEExtendedTaintAnalysisTest.cpp
@@ -310,7 +310,7 @@ TEST_F(IDETaintAnalysisTest, XTaint18) {
   doAnalysis({PathToLLFiles + "xtaint18_cpp.ll"}, gt, std::monostate{});
 }
 
-TEST_F(IDETaintAnalysisTest, XTaint19) {
+PHASAR_SKIP_TEST(TEST_F(IDETaintAnalysisTest, XTaint19) {
   // Is now the same as XTaint17
   GTEST_SKIP();
   map<int, set<string>> gt;
@@ -318,7 +318,7 @@ TEST_F(IDETaintAnalysisTest, XTaint19) {
   gt[22] = {"21"};
 
   doAnalysis({PathToLLFiles + "xtaint19_cpp.ll"}, gt, std::monostate{});
-}
+})
 
 TEST_F(IDETaintAnalysisTest, XTaint20) {
   map<int, set<string>> gt;

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -246,11 +246,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_03) {
   doAnalysisAndCompareResults("basic_03_cpp.ll", GroundTruth, false);
 }
 
-TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_04) {
-// If we use libcxx this won't work since internal implementation is different
-#ifdef _LIBCPP_VERSION
-  GTEST_SKIP();
-#endif
+PHASAR_SKIP_TEST(TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_04) {
+  // If we use libcxx this won't work since internal implementation is different
+  LIBCPP_GTEST_SKIP();
+
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
@@ -271,7 +270,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_04) {
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 24, "k", {"10", "11", "12", "16", "19", "20", "25", "27"}));
   doAnalysisAndCompareResults("basic_04_cpp.ll", GroundTruth, false);
-}
+})
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_05) {
   std::set<IIACompactResult_t> GroundTruth;
@@ -547,11 +546,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleHeapTest_01) {
   doAnalysisAndCompareResults("heap_01_cpp.ll", GroundTruth, false);
 }
 
-TEST_F(IDEInstInteractionAnalysisTest, HandleRVOTest_01) {
+PHASAR_SKIP_TEST(TEST_F(IDEInstInteractionAnalysisTest, HandleRVOTest_01) {
 // If we use libcxx this won't work since internal implementation is different
-#ifdef _LIBCPP_VERSION
-  GTEST_SKIP();
-#endif
+  LIBCPP_GTEST_SKIP();
+
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
@@ -563,7 +561,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleRVOTest_01) {
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 16, "ref.tmp", {"25", "5", "8", "31", "32", "30"}));
   doAnalysisAndCompareResults("rvo_01_cpp.ll", GroundTruth, false);
-}
+})
 
 // // TEST_F(IDEInstInteractionAnalysisTest, HandleStruct_01) {
 // //   std::set<IIACompactResult_t> GroundTruth;

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -547,7 +547,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleHeapTest_01) {
 }
 
 PHASAR_SKIP_TEST(TEST_F(IDEInstInteractionAnalysisTest, HandleRVOTest_01) {
-// If we use libcxx this won't work since internal implementation is different
+  // If we use libcxx this won't work since internal implementation is different
   LIBCPP_GTEST_SKIP();
 
   std::set<IIACompactResult_t> GroundTruth;

--- a/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSConstAnalysisTest.cpp
@@ -366,16 +366,15 @@ TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_02) {
   compareResults({0, 1}, Llvmconstsolver);
 }
 
-TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_03) {
-// If we use libcxx this won't work since internal implementation is different
-#ifdef _LIBCPP_VERSION
-  GTEST_SKIP();
-#endif
+PHASAR_SKIP_TEST(TEST_F(IFDSConstAnalysisTest, HandleSTLArrayTest_03) {
+  // If we use libcxx this won't work since internal implementation is different
+  LIBCPP_GTEST_SKIP();
+
   initialize({PathToLlFiles + "array/stl_array/stl_array_03_cpp_m2r_dbg.ll"});
   IFDSSolver_P<IFDSConstAnalysis> Llvmconstsolver(*Constproblem);
   Llvmconstsolver.solve();
   compareResults({0, 1, 2}, Llvmconstsolver);
-}
+})
 
 TEST_F(IFDSConstAnalysisTest, DISABLED_HandleSTLArrayTest_04) {
   // Guaranteed to fail - enable, once we have more precise points-to

--- a/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
+++ b/unittests/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchyTest.cpp
@@ -730,11 +730,10 @@ TEST(LTHTest, TransitivelyReachableTypes) {
 // // }
 
 // Failing test case
-TEST(LTHTest, HandleSTLString) {
-// If we use libcxx this won't work since internal implementation is different
-#ifdef _LIBCPP_VERSION
-  GTEST_SKIP();
-#endif
+PHASAR_SKIP_TEST(TEST(LTHTest, HandleSTLString) {
+  // If we use libcxx this won't work since internal implementation is different
+  LIBCPP_GTEST_SKIP();
+
   ProjectIRDB IRDB({unittest::PathToLLTestFiles +
                     "type_hierarchies/type_hierarchy_13_cpp.ll"});
   LLVMTypeHierarchy TH(IRDB);
@@ -759,7 +758,7 @@ TEST(LTHTest, HandleSTLString) {
           "std::allocator<char> >::_Alloc_hider")));
   EXPECT_TRUE(TH.isSuperType(TH.getType("class.std::allocator"),
                              TH.getType("class.std::allocator")));
-}
+})
 
 } // namespace psr
 

--- a/unittests/TestUtils/TestConfig.h
+++ b/unittests/TestUtils/TestConfig.h
@@ -16,6 +16,21 @@ inline const std::string PathToTxtTestFiles(PhasarConfig::PhasarDirectory() +
 inline const std::string PathToJSONTestFiles(PhasarConfig::PhasarDirectory() +
                                              "test/json_test_code/");
 
+// Remove wrapped tests in case GTEST_SKIP is not available. This is needed as
+// LLVM currently ships with an older version of gtest (<1.10.0) that does not
+// support GTEST_SKIP. TODO: Remove this macro after LLVM updated their gtest.
+#ifdef GTEST_SKIP
+#define PHASAR_SKIP_TEST(...) __VA_ARGS__
+#else
+#define PHASAR_SKIP_TEST(...)
+#endif
+
+#ifdef _LIBCPP_VERSION
+#define LIBCPP_GTEST_SKIP GTEST_SKIP
+#else
+#define LIBCPP_GTEST_SKIP
+#endif
+
 } // namespace psr::unittest
 
 #endif // UNITTEST_TESTUTILS_TESTCONFIG_H_


### PR DESCRIPTION
This is needed as LLVM currently ships with an older version of gtest
(<1.10.0) that does not support GTEST_SKIP.