### PR TITLE
Fixed Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:latest
-ARG LLVM_INSTALL_DIR="/usr/local/llvm-10"
+FROM ubuntu:20.04
+ARG LLVM_INSTALL_DIR="/usr/local/llvm-12"
 LABEL Name=phasar Version=1.0.0
 
 RUN apt -y update && apt install bash sudo -y
@@ -21,7 +21,7 @@ RUN apt install libboost-all-dev -y
 # installing LLVM
 COPY utils/safeCommandsSet.sh /usr/src/phasar/utils/safeCommandsSet.sh
 COPY utils/install-llvm.sh /usr/src/phasar/utils/install-llvm.sh
-RUN ./utils/install-llvm.sh $(nproc) . ${LLVM_INSTALL_DIR} "llvmorg-10.0.0"
+RUN ./utils/install-llvm.sh $(nproc) . ${LLVM_INSTALL_DIR} "llvmorg-12.0.0"
 
 # installing wllvm
 RUN pip3 install wllvm


### PR DESCRIPTION
Updated LLVM version in the Dockerfile to match the project's requirements.
Also changed the ubuntu image version from latest to a fixed version (20.04), since the newest ubuntu version 21.10 doesn't work with LLVM 12.0.0 and they might update their latest tag at some point.

I'm currently working on a multistage Dockerfile to increase performance. I experimented with GitHub Actions and building the current Dockerfile with an action takes around 4 hours, which is not sufficient. 