### PR TITLE
PMR Compatibility Workaround

### DIFF
--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToGraph.h
@@ -107,7 +107,9 @@ private:
   /// Keep track of what has already been merged into this points-to graph.
   std::unordered_set<const llvm::Function *> AnalyzedFunctions;
   LLVMBasedPointsToAnalysis PTA;
-  PointsToSetOwner<PointsToSetTy> Owner;
+
+  PointsToSetOwner<PointsToSetTy>::memory_resource_type MRes;
+  PointsToSetOwner<PointsToSetTy> Owner{&MRes};
   std::unordered_map<const llvm::Value *, DynamicPointsToSetPtr<PointsToSetTy>>
       Cache;
 

--- a/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMPointsToSet.h
@@ -10,18 +10,17 @@
 #ifndef PHASAR_PHASARLLVM_POINTER_LLVMPOINTSTOSET_H_
 #define PHASAR_PHASARLLVM_POINTER_LLVMPOINTSTOSET_H_
 
-#include <iostream>
-#include <memory_resource>
-
-#include "nlohmann/json.hpp"
-
-#include "llvm/ADT/DenseSet.h"
-
 #include "phasar/PhasarLLVM/Pointer/DynamicPointsToSetPtr.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMBasedPointsToAnalysis.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
 #include "phasar/PhasarLLVM/Pointer/PointsToSetOwner.h"
 #include "phasar/Utils/StableVector.h"
+
+#include "llvm/ADT/DenseSet.h"
+
+#include "nlohmann/json.hpp"
+
+#include <iostream>
 
 namespace llvm {
 class Value;
@@ -43,7 +42,7 @@ private:
   LLVMBasedPointsToAnalysis PTA;
   llvm::DenseSet<const llvm::Function *> AnalyzedFunctions;
 
-  std::pmr::unsynchronized_pool_resource MRes;
+  PointsToSetOwner<PointsToSetTy>::memory_resource_type MRes;
   PointsToSetOwner<PointsToSetTy> Owner{&MRes};
 
   PointsToSetMap PointsToSets;

--- a/include/phasar/PhasarLLVM/Pointer/PointsToSetOwner.h
+++ b/include/phasar/PhasarLLVM/Pointer/PointsToSetOwner.h
@@ -10,14 +10,26 @@
 #ifndef PHASAR_PHASARLLVM_POINTER_POINTSTOSETOWNER_H
 #define PHASAR_PHASARLLVM_POINTER_POINTSTOSETOWNER_H
 
-#include <memory_resource>
+#include "phasar/PhasarLLVM/ControlFlow/CFG.h"
+#include "phasar/PhasarLLVM/Pointer/DynamicPointsToSetPtr.h"
+#include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
+#include "phasar/Utils/StableVector.h"
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/ErrorHandling.h"
 
-#include "phasar/PhasarLLVM/Pointer/DynamicPointsToSetPtr.h"
-#include "phasar/PhasarLLVM/Pointer/LLVMPointsToInfo.h"
-#include "phasar/Utils/StableVector.h"
+#include <type_traits>
+
+/// On some MAC systems, <memory_resource> is still not fully implemented, so do
+/// a workaround here
+
+#if !defined(__has_include) || __has_include(<memory_resource>)
+#define HAS_MEMORY_RESOURCE 1
+#include <memory_resource>
+#else
+#define HAS_MEMORY_RESOURCE 0
+#include "llvm/Support/RecyclingAllocator.h"
+#endif
 
 namespace llvm {
 class Value;
@@ -26,9 +38,27 @@ class Value;
 namespace psr {
 template <typename PointsToSetTy> class PointsToSetOwner {
 public:
-  PointsToSetOwner(std::pmr::polymorphic_allocator<PointsToSetTy> Alloc =
-                       std::pmr::get_default_resource()) noexcept
-      : Alloc(Alloc) {}
+  using allocator_type =
+#if HAS_MEMORY_RESOURCE
+      std::pmr::polymorphic_allocator<PointsToSetTy>
+#else
+      llvm::RecyclingAllocator<llvm::BumpPtrAllocator, PointsToSetTy> *
+#endif
+      ;
+
+  using memory_resource_type =
+#if HAS_MEMORY_RESOURCE
+      std::pmr::unsynchronized_pool_resource
+#else
+      llvm::RecyclingAllocator<llvm::BumpPtrAllocator, PointsToSetTy>
+#endif
+      ;
+
+  PointsToSetOwner(allocator_type Alloc) noexcept : Alloc(Alloc) {
+    if constexpr (std::is_pointer_v<allocator_type>) {
+      assert(Alloc != nullptr);
+    }
+  }
   PointsToSetOwner(PointsToSetOwner &&) noexcept = default;
 
   PointsToSetOwner(const PointsToSetOwner &) = delete;
@@ -38,16 +68,28 @@ public:
   ~PointsToSetOwner() {
     for (auto PTS : OwnedPTS) {
       std::destroy_at(PTS);
+#if HAS_MEMORY_RESOURCE
       Alloc.deallocate(PTS, 1);
+#else
+      Alloc->Deallocate(PTS);
+#endif
     }
     OwnedPTS.clear();
   }
 
   DynamicPointsToSetPtr<PointsToSetTy> acquire() {
-    auto Ptr = new (Alloc.allocate(1)) PointsToSetTy();
+    auto RawMem =
+#if HAS_MEMORY_RESOURCE
+        Alloc.allocate(1)
+#else
+        Alloc->Allocate()
+#endif
+        ;
+    auto Ptr = new (RawMem) PointsToSetTy();
     OwnedPTS.insert(Ptr);
     return &AllPTS.emplace_back(Ptr);
   }
+
   void release(PointsToSetTy *PTS) noexcept {
     if (LLVM_UNLIKELY(!OwnedPTS.erase(PTS))) {
       llvm::report_fatal_error(
@@ -55,14 +97,18 @@ public:
           "freed, or never allocated with this PointsToSetOwner!");
     }
     std::destroy_at(PTS);
+#if HAS_MEMORY_RESOURCE
     Alloc.deallocate(PTS, 1);
+#else
+    Alloc->Deallocate(PTS);
+#endif
     /// NOTE: Do not delete from AllPTS!
   }
 
   void reserve(size_t Capacity) { OwnedPTS.reserve(Capacity); }
 
 private:
-  std::pmr::polymorphic_allocator<PointsToSetTy> Alloc;
+  allocator_type Alloc{};
   llvm::DenseSet<PointsToSetTy *> OwnedPTS;
   StableVector<PointsToSetTy *> AllPTS;
 };


### PR DESCRIPTION
Replace std::pmr::* with LLVM's allocators in PointsToSetOwner -- Need to discuss about general strategy of dealing with allocators (the default strategy to always use the STL types doesn't seem to work anymore)