### PR TITLE
fix VTables for collapsed types. 

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/Resolver/Resolver.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/Resolver/Resolver.h
@@ -29,11 +29,15 @@ class Function;
 class StructType;
 } // namespace llvm
 
+namespace std {
+template <class T> class optional;
+}
+
 namespace psr {
 class ProjectIRDB;
 class LLVMTypeHierarchy;
 
-int getVFTIndex(const llvm::CallBase *CallSite);
+std::optional<unsigned> getVFTIndex(const llvm::CallBase *CallSite);
 
 const llvm::StructType *getReceiverType(const llvm::CallBase *CallSite);
 

--- a/include/phasar/PhasarLLVM/ControlFlow/Resolver/Resolver.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/Resolver/Resolver.h
@@ -17,6 +17,7 @@
 #ifndef PHASAR_PHASARLLVM_CONTROLFLOW_RESOLVER_RESOLVER_H_
 #define PHASAR_PHASARLLVM_CONTROLFLOW_RESOLVER_RESOLVER_H_
 
+#include <optional>
 #include <set>
 #include <string>
 
@@ -28,10 +29,6 @@ class CallBase;
 class Function;
 class StructType;
 } // namespace llvm
-
-namespace std {
-template <class T> class optional;
-}
 
 namespace psr {
 class ProjectIRDB;

--- a/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
+++ b/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
@@ -88,19 +88,16 @@ public:
   using out_edge_iterator = boost::graph_traits<bidigraph_t>::out_edge_iterator;
   using in_edge_iterator = boost::graph_traits<bidigraph_t>::in_edge_iterator;
 
-  static const std::string StructPrefix;
-
-  static const std::string ClassPrefix;
-
-  static const std::string VTablePrefix;
-
-  static const std::string VTablePrefixDemang;
-
-  static const std::string TypeInfoPrefix;
-
-  static const std::string TypeInfoPrefixDemang;
-
-  static const std::string PureVirtualCallName;
+  static inline constexpr llvm::StringLiteral StructPrefix = "struct.";
+  static inline constexpr llvm::StringLiteral ClassPrefix = "class.";
+  static inline constexpr llvm::StringLiteral VTablePrefix = "_ZTV";
+  static inline constexpr llvm::StringLiteral VTablePrefixDemang =
+      "vtable for ";
+  static inline constexpr llvm::StringLiteral TypeInfoPrefix = "_ZTI";
+  static inline constexpr llvm::StringLiteral TypeInfoPrefixDemang =
+      "typeinfo for ";
+  static inline constexpr llvm::StringLiteral PureVirtualCallName =
+      "__cxa_pure_virtual";
 
 private:
   bidigraph_t TypeGraph;

--- a/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
+++ b/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
@@ -100,6 +100,8 @@ public:
 
   static const std::string TypeInfoPrefixDemang;
 
+  static const std::string PureVirtualCallName;
+
 private:
   bidigraph_t TypeGraph;
   std::unordered_map<const llvm::StructType *, vertex_t> TypeVertexMap;

--- a/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
+++ b/include/phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h
@@ -88,6 +88,18 @@ public:
   using out_edge_iterator = boost::graph_traits<bidigraph_t>::out_edge_iterator;
   using in_edge_iterator = boost::graph_traits<bidigraph_t>::in_edge_iterator;
 
+  static const std::string StructPrefix;
+
+  static const std::string ClassPrefix;
+
+  static const std::string VTablePrefix;
+
+  static const std::string VTablePrefixDemang;
+
+  static const std::string TypeInfoPrefix;
+
+  static const std::string TypeInfoPrefixDemang;
+
 private:
   bidigraph_t TypeGraph;
   std::unordered_map<const llvm::StructType *, vertex_t> TypeVertexMap;
@@ -101,18 +113,6 @@ private:
   std::unordered_map<std::string, const llvm::GlobalVariable *> ClearNameTIMap;
   // map from clearname to vtable variable
   std::unordered_map<std::string, const llvm::GlobalVariable *> ClearNameTVMap;
-
-  static const std::string StructPrefix;
-
-  static const std::string ClassPrefix;
-
-  static const std::string VTablePrefix;
-
-  static const std::string VTablePrefixDemang;
-
-  static const std::string TypeInfoPrefix;
-
-  static const std::string TypeInfoPrefixDemang;
 
   static std::string removeStructOrClassPrefix(const llvm::StructType &T);
 

--- a/include/phasar/PhasarLLVM/TypeHierarchy/LLVMVFTable.h
+++ b/include/phasar/PhasarLLVM/TypeHierarchy/LLVMVFTable.h
@@ -87,7 +87,7 @@ public:
   };
 
   [[nodiscard]] static std::vector<const llvm::Function *>
-  getVFVectorFromIRVTable(const llvm::ConstantStruct *);
+  getVFVectorFromIRVTable(const llvm::ConstantStruct &);
 };
 
 } // namespace psr

--- a/include/phasar/PhasarLLVM/TypeHierarchy/LLVMVFTable.h
+++ b/include/phasar/PhasarLLVM/TypeHierarchy/LLVMVFTable.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
 class Function;
+class ConstantStruct;
 } // namespace llvm
 
 namespace psr {
@@ -84,6 +85,9 @@ public:
   end() const {
     return VFT.end();
   };
+
+  [[nodiscard]] static std::vector<const llvm::Function *>
+  getVFVectorFromIRVTable(const llvm::ConstantStruct *);
 };
 
 } // namespace psr

--- a/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/DTAResolver.cpp
@@ -161,8 +161,8 @@ auto DTAResolver::resolveVirtualCall(const llvm::CallBase *CallSite)
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                 << "Call virtual function: " << llvmIRToString(CallSite));
 
-  auto VtableIndex = getVFTIndex(CallSite);
-  if (VtableIndex < 0) {
+  auto RetrievedVtableIndex = getVFTIndex(CallSite);
+  if (!RetrievedVtableIndex.has_value()) {
     // An error occured
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
@@ -170,6 +170,8 @@ auto DTAResolver::resolveVirtualCall(const llvm::CallBase *CallSite)
                   << llvmIRToString(CallSite) << "\n");
     return {};
   }
+
+  auto VtableIndex = RetrievedVtableIndex.value();
 
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                 << "Virtual function table entry is: " << VtableIndex);

--- a/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/OTFResolver.cpp
@@ -126,7 +126,7 @@ auto OTFResolver::resolveVirtualCall(const llvm::CallBase *CallSite)
               }
               auto *Callee = VFs[VtableIndex];
               if (Callee == nullptr || !Callee->hasName() ||
-                  Callee->getName() == "__cxa_pure_virtual") {
+                  Callee->getName() == LLVMTypeHierarchy::PureVirtualCallName) {
                 continue;
               }
               PossibleCallTargets.insert(Callee);

--- a/lib/PhasarLLVM/ControlFlow/Resolver/RTAResolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/RTAResolver.cpp
@@ -56,8 +56,8 @@ auto RTAResolver::resolveVirtualCall(const llvm::CallBase *CallSite)
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                 << "Call virtual function: " << llvmIRToString(CallSite));
 
-  auto VtableIndex = getVFTIndex(CallSite);
-  if (VtableIndex < 0) {
+  auto RetrievedVtableIndex = getVFTIndex(CallSite);
+  if (!RetrievedVtableIndex.has_value()) {
     // An error occured
     LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                   << "Error with resolveVirtualCall : impossible to retrieve "
@@ -65,6 +65,8 @@ auto RTAResolver::resolveVirtualCall(const llvm::CallBase *CallSite)
                   << llvmIRToString(CallSite) << "\n");
     return {};
   }
+
+  auto VtableIndex = RetrievedVtableIndex.value();
 
   LOG_IF_ENABLE(BOOST_LOG_SEV(lg::get(), DEBUG)
                 << "Virtual function table entry is: " << VtableIndex);

--- a/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <set>
+#include <optional>
 
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -30,23 +31,23 @@ using namespace psr;
 
 namespace psr {
 
-int getVFTIndex(const llvm::CallBase *CallSite) {
+std::optional<unsigned> getVFTIndex(const llvm::CallBase *CallSite) {
   // deal with a virtual member function
   // retrieve the vtable entry that is called
   const auto *Load =
       llvm::dyn_cast<llvm::LoadInst>(CallSite->getCalledOperand());
   if (Load == nullptr) {
-    return -1;
+    return std::nullopt;
   }
   const auto *GEP =
       llvm::dyn_cast<llvm::GetElementPtrInst>(Load->getPointerOperand());
   if (GEP == nullptr) {
-    return -2;
+    return std::nullopt;
   }
   if (auto *CI = llvm::dyn_cast<llvm::ConstantInt>(GEP->getOperand(1))) {
     return CI->getZExtValue();
   }
-  return -3;
+  return std::nullopt;
 }
 
 const llvm::StructType *getReceiverType(const llvm::CallBase *CallSite) {

--- a/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
+++ b/lib/PhasarLLVM/ControlFlow/Resolver/Resolver.cpp
@@ -14,8 +14,8 @@
  *      Author: nicolas bellec
  */
 
-#include <set>
 #include <optional>
+#include <set>
 
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -49,20 +49,6 @@ using namespace std;
 
 namespace psr {
 
-const std::string LLVMTypeHierarchy::StructPrefix = "struct.";
-
-const std::string LLVMTypeHierarchy::ClassPrefix = "class.";
-
-const std::string LLVMTypeHierarchy::VTablePrefix = "_ZTV";
-
-const std::string LLVMTypeHierarchy::VTablePrefixDemang = "vtable for ";
-
-const std::string LLVMTypeHierarchy::TypeInfoPrefix = "_ZTI";
-
-const std::string LLVMTypeHierarchy::TypeInfoPrefixDemang = "typeinfo for ";
-
-const std::string LLVMTypeHierarchy::PureVirtualCallName = "__cxa_pure_virtual";
-
 LLVMTypeHierarchy::VertexProperties::VertexProperties(
     const llvm::StructType *Type)
     : Type(Type), ReachableTypes({Type}) {}

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -203,29 +203,7 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
       }
       if (const auto *I =
               llvm::dyn_cast<llvm::ConstantStruct>(TI->getInitializer())) {
-        for (const auto &Op : I->operands()) {
-          if (auto *CA = llvm::dyn_cast<llvm::ConstantArray>(Op)) {
-            for (auto &COp : CA->operands()) {
-              if (auto *CE = llvm::dyn_cast<llvm::ConstantExpr>(COp)) {
-                std::unique_ptr<llvm::Instruction, decltype(&deleteValue)> AsI(
-                    CE->getAsInstruction(), &deleteValue);
-                if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(AsI.get())) {
-                  // if the entry is a GlobalAlias, get its Aliasee
-                  auto *ENTRY = BC->getOperand(0);
-                  while (auto *GA = llvm::dyn_cast<llvm::GlobalAlias>(ENTRY)) {
-                    ENTRY = GA->getAliasee();
-                  }
-
-                  if (ENTRY->hasName()) {
-                    if (auto *F = M.getFunction(ENTRY->getName())) {
-                      VFS.push_back(F);
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        VFS = LLVMVFTable::getVFVectorFromIRVTable(I);
       }
     }
   }

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -203,7 +203,7 @@ LLVMTypeHierarchy::getVirtualFunctions(const llvm::Module &M,
       }
       if (const auto *I =
               llvm::dyn_cast<llvm::ConstantStruct>(TI->getInitializer())) {
-        VFS = LLVMVFTable::getVFVectorFromIRVTable(I);
+        VFS = LLVMVFTable::getVFVectorFromIRVTable(*I);
       }
     }
   }

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -61,6 +61,8 @@ const std::string LLVMTypeHierarchy::TypeInfoPrefix = "_ZTI";
 
 const std::string LLVMTypeHierarchy::TypeInfoPrefixDemang = "typeinfo for ";
 
+const std::string LLVMTypeHierarchy::PureVirtualCallName = "__cxa_pure_virtual";
+
 LLVMTypeHierarchy::VertexProperties::VertexProperties(
     const llvm::StructType *Type)
     : Type(Type), ReachableTypes({Type}) {}


### PR DESCRIPTION
llvm-link collapsed multiple C++  types with identical members to one single LLVM type. The current  virtual function call resolution then only considers the VTable of the LLVM type that represents all of the collapsed type. Now, we look for all VTables that the function pointer aliases with and extract the possible callees from them.