### PR TITLE
Add curly braces to explicit call the ctor of SmallDenseMap

### DIFF
--- a/include/phasar/Utils/LLVMShorthands.h
+++ b/include/phasar/Utils/LLVMShorthands.h
@@ -241,7 +241,7 @@ class ModulesToSlotTracker {
 private:
   static inline llvm::SmallDenseMap<const llvm::Module *,
                                     std::unique_ptr<llvm::ModuleSlotTracker>, 2>
-      MToST; // NOLINT
+      MToST{};
 
   static void updateMSTForModule(const llvm::Module *Module);
   static void deleteMSTForModule(const llvm::Module *Module);


### PR DESCRIPTION
This is needed, as older gcc versions do not consider the member
declaration as an explicit ctor call.