### PR TITLE
Fixes gcc redeclaration confusion

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/IfdsIde/IFDSFieldSensTaintAnalysis/FlowFunctions/MapTaintedValuesToCaller.h
@@ -28,7 +28,7 @@ public:
 private:
   const llvm::CallInst *CallInst;
   const llvm::ReturnInst *RetInst;
-  TraceStats &TraceStats;
+  ::psr::TraceStats &TraceStats;
   ExtendedValue ZV;
 };
 

--- a/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSSolverConfig.h
+++ b/include/phasar/PhasarLLVM/DataFlowSolver/WPDS/WPDSSolverConfig.h
@@ -29,7 +29,7 @@ struct WPDSSolverConfig {
   WPDSSolverConfig &operator=(WPDSSolverConfig &&) = default;
   bool RecordWitnesses = false;
   WPDSSearchDirection Direction = WPDSSearchDirection::FORWARD;
-  WPDSType WPDSType = WPDSType::FWPDS;
+  ::psr::WPDSType WPDSType = WPDSType::FWPDS;
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const WPDSSolverConfig &SC);
 };


### PR DESCRIPTION
Older gcc versions confuse the type with the member name if both are the
same and see the second as a redeclaration. This is fixed by explicitly
declaring the types namespace.