### PR TITLE
Bootstrap Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ directory of PhASAR and use the following command:
 $ ./bootstrap.sh --install
 ```
 
-The bootstrap script may ask for superuser permissions (to install the dependencies).
+The bootstrap script may ask for superuser permissions.
 
 Done!
 
@@ -103,8 +103,7 @@ $ export CXX=/usr/local/bin/clang++
 You may need to adjust the paths according to your system. When you cloned PhASAR from Github you need to initialize PhASAR's submodules before building it:
 
 ```
-$ git submodule init
-$ git submodule update
+$ git submodule update --init
 ```
 
 If you downloaded PhASAR as a compressed release (e.g. .zip or .tar.gz) you can use the `init-submodules-release.sh` script that manually clones the required submodules:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ what matters.
 
 How do I get started with PhASAR?
 ---------------------------------
-We have some documentation on PhASAR in our [_**wiki**_](https://github.com/secure-software-engineering/phasar/wiki). You probably would like to read
+We have some documentation on PhASAR in our [_**Wiki**_](https://github.com/secure-software-engineering/phasar/wiki). You probably would like to read
 this README first and then have a look on the material provided on https://phasar.org/
 as well. Please also have a look on PhASAR's project directory and notice the project directory
 examples/ as well as the custom tool tools/myphasartool.cpp.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ prerequisites and compilation. It is recommended to compile PhASAR yourself in
 order to get the full C++ experience and to have full control over the build
 mode.
 
+As a shortcut for the very first PhASAR build on your system, you can use our [bootstrap](./bootstrap.sh) script:
+
+```bash
+$ ./bootstrap.sh
+```
+
+Note: If you want to do changes within PhASAR, it is recommended to build it in Debug mode:
+```bash
+$ ./bootstrap.sh -DCMAKE_BUILD_TYPE=Debug
+```
+
+The bootstrap script may ask for superuser permissions (to install the dependencies); however it is not recommended to start the whole script with `sudo`.
+
+For subsequent builds, see [Compiling PhASAR](#compiling-phasar-if-not-already-done-using-the-installation-scripts).
+
 Please help us to improve PhASAR
 --------------------------------
 You are using PhASAR and would like to help us in the future? Then please
@@ -65,9 +80,11 @@ PhASAR using an Ubuntu or Unix-like system.
 
 Therefore, we provide an installation script. To install PhASAR, just navigate to the top-level
 directory of PhASAR and use the following command:
+```bash
+$ ./bootstrap.sh --install
 ```
-$ sudo ./bootstrap.sh
-```
+
+The bootstrap script may ask for superuser permissions (to install the dependencies).
 
 Done!
 
@@ -101,9 +118,9 @@ Navigate into the PhASAR directory. The following commands will do the job and c
 ```
 $ mkdir build
 $ cd build/
-$ cmake -DCMAKE_BUILD_TYPE=Release ..
-$ make -j $(nproc) # or use a different number of cores to compile it
-$ sudo make install # if you wish to install PhASAR system wide
+$ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
+$ ninja -j $(nproc) # or use a different number of cores to compile it
+$ sudo ninja install # only if you wish to install PhASAR system wide
 ```
 
 When you have used the `bootstrap.sh` script to install PhASAR, the above steps are already done.
@@ -120,8 +137,6 @@ Use the command:
 
 in order to display the manual and help message.
 
-`$ sudo make install`
-
 Please be careful and check if errors occur during the compilation.
 
 When using CMake to compile PhASAR the following optional parameters can be used:
@@ -129,8 +144,8 @@ When using CMake to compile PhASAR the following optional parameters can be used
 | Parameter : Type|  Effect |
 |-----------|--------|
 | <b>BUILD_SHARED_LIBS</b> : BOOL | Build shared libraries (default is ON) |
-| <b>CMAKE_BUILD_TYPE</b> : STRING | Build PhASAR in 'Debug' or 'Release' mode <br> (default is 'Debug') |
-| <b>CMAKE_INSTALL_PREFIX</b> : PATH | Path where PhASAR will be installed if <br> “make install” is invoked or the “install” <br> target is built (default is /usr/local/phasar) |
+| <b>CMAKE_BUILD_TYPE</b> : STRING | Build PhASAR in 'Debug', 'RelWithDebInfo' or 'Release' mode <br> (default is 'Debug') |
+| <b>CMAKE_INSTALL_PREFIX</b> : PATH | Path where PhASAR will be installed if <br> “ninja install” is invoked or the “install” <br> target is built (default is /usr/local/phasar) |
 | <b>PHASAR_BUILD_DOC</b> : BOOL | Build PhASAR documentation (default is OFF) |
 | <b>PHASAR_BUILD_UNITTESTS</b> : BOOL | Build PhASAR unit tests (default is ON) |
 | <b>PHASAR_BUILD_IR</b> : BOOL | Build PhASAR IR (required for running the unit tests) (default is ON) |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -135,15 +135,12 @@ tmp_dir=$(mktemp -d "llvm-build.XXXXXXXX" --tmpdir)
 rm -rf "${tmp_dir}"
 echo "dependencies successfully installed"
 
+echo "Updating the submodules..."
+git submodule update --init
+echo "Submodules successfully updated"
 
 echo "Building PhASAR..."
 ${DO_UNIT_TEST} && echo "with unit tests."
-
-echo "Updating the submodules..."
-git submodule init
-git submodule update
-echo "Submodules successfully updated"
-
 
 export CC=${LLVM_INSTALL_DIR}/bin/clang
 export CXX=${LLVM_INSTALL_DIR}/bin/clang++

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,25 +107,25 @@ else
         fi
 	else
         echo "Already installed boost version ${BOOST_VERSION//_/.}"
-        # if [ -x "$(command -v apt)" ]; then
-        #     DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
-        #     # install missing packages if necessary
-        #     boostlibnames=("libboost-system" "libboost-filesystem"
-        #             "libboost-graph" "libboost-program-options"
-        #             "libboost-thread")
-        #     additional_boost_libs=()
-        #     for boost_lib in ${boostlibnames[@]}; do
-        #         dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 ||
-        #         dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}.0" >/dev/null 2>&1 ||
-        #         additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}") ||
-        #         additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}.0")
-        #         dpkg -s "${boost_lib}-dev" >/dev/null 2>&1 || additional_boost_libs+=("${boost_lib}-dev")
-        #     done
-        #     if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
-        #         echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[*]}"
-        #         sudo apt install "${additional_boost_libs[@]}" -y
-        #     fi
-        # fi
+        if [ -x "$(command -v apt)" ]; then
+            DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
+            # install missing packages if necessary
+            boostlibnames=("libboost-system" "libboost-filesystem"
+                    "libboost-graph" "libboost-program-options"
+                    "libboost-thread")
+            additional_boost_libs=()
+            for boost_lib in ${boostlibnames[@]}; do
+                dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 ||
+                dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}.0" >/dev/null 2>&1 ||
+                additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}") ||
+                additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}.0")
+                dpkg -s "${boost_lib}-dev" >/dev/null 2>&1 || additional_boost_libs+=("${boost_lib}-dev")
+            done
+            if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
+                echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[*]}"
+                sudo apt install "${additional_boost_libs[@]}" -y || true
+            fi
+        fi
 	fi
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,7 +71,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 echo "installing phasar dependencies..."
 if [ -x "$(command -v pacman)" ]; then
-    yes | sudo pacman -Syu --needed which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc z3 libedit graphviz python-sphinx openmp curl python-pip
+    yes | sudo pacman -Syu --needed which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc z3 libedit graphviz python-sphinx openmp curl python-pip ninja
     ./utils/installBuildEAR.sh
 else
     ./utils/InstallAptDependencies.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eo pipefail
 
 source ./utils/safeCommandsSet.sh
 
@@ -10,6 +11,8 @@ readonly LLVM_INSTALL_DIR="/usr/local/llvm-14"
 NUM_THREADS=$(nproc)
 LLVM_RELEASE=llvmorg-14.0.0
 DO_UNIT_TEST=true
+DO_INSTALL=false
+BUILD_TYPE=Release
 
 
 # Parsing command-line-parameters
@@ -48,6 +51,14 @@ case $key in
     DESIRED_BOOST_VERSION="${key#*=}"
     shift # past argument=value
     ;;
+    -DCMAKE_BUILD_TYPE=*)
+    BUILD_TYPE="${key#*=}"
+    shift # past argument=value
+    ;;
+    --install)
+    DO_INSTALL=true
+    shift # past argument
+    ;;
     *)    # unknown option
     POSITIONAL+=("$1") # save it in an array for later
     shift # past argument
@@ -60,12 +71,13 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 echo "installing phasar dependencies..."
 if [ -x "$(command -v pacman)" ]; then
-    yes | sudo pacman -Syu --needed which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc cmake z3 libedit graphviz python-sphinx openmp curl python-pip
+    yes | sudo pacman -Syu --needed which zlib sqlite3 ncurses make python3 doxygen libxml2 swig gcc z3 libedit graphviz python-sphinx openmp curl python-pip
     ./utils/installBuildEAR.sh
 else
     ./utils/InstallAptDependencies.sh
 fi
-sudo pip3 install Pygments pyyaml
+
+pip3 install cmake
 
 if [ ! -z "${DESIRED_BOOST_DIR}" ]; then
     BOOST_PARAMS="-DBOOST_ROOT=${DESIRED_BOOST_DIR}"
@@ -95,65 +107,80 @@ else
         fi
 	else
         echo "Already installed boost version ${BOOST_VERSION//_/.}"
-        if [ -x "$(command -v apt)" ]; then
-            DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
-            # install missing packages if necessary
-            boostlibnames=("libboost-system" "libboost-filesystem"
-                    "libboost-graph" "libboost-program-options"
-                    "libboost-thread")
-            additional_boost_libs=()
-            for boost_lib in ${boostlibnames[@]}; do
-                dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 ||
-                dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}.0" >/dev/null 2>&1 ||
-                additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}") ||
-                additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}.0")
-                dpkg -s "${boost_lib}-dev" >/dev/null 2>&1 || additional_boost_libs+=("${boost_lib}-dev")
-            done
-            if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
-                echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[*]}"
-                sudo apt install "${additional_boost_libs[@]}" -y
-            fi
-        fi
+        # if [ -x "$(command -v apt)" ]; then
+        #     DESIRED_BOOST_VERSION=${BOOST_VERSION//_/.}
+        #     # install missing packages if necessary
+        #     boostlibnames=("libboost-system" "libboost-filesystem"
+        #             "libboost-graph" "libboost-program-options"
+        #             "libboost-thread")
+        #     additional_boost_libs=()
+        #     for boost_lib in ${boostlibnames[@]}; do
+        #         dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}" >/dev/null 2>&1 ||
+        #         dpkg -s "$boost_lib${DESIRED_BOOST_VERSION}.0" >/dev/null 2>&1 ||
+        #         additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}") ||
+        #         additional_boost_libs+=("$boost_lib${DESIRED_BOOST_VERSION}.0")
+        #         dpkg -s "${boost_lib}-dev" >/dev/null 2>&1 || additional_boost_libs+=("${boost_lib}-dev")
+        #     done
+        #     if [ ${#additional_boost_libs[@]} -gt 0 ] ;then
+        #         echo "Installing additional ${#additional_boost_libs[@]} boost packages: ${additional_boost_libs[*]}"
+        #         sudo apt install "${additional_boost_libs[@]}" -y
+        #     fi
+        # fi
 	fi
 fi
 
 # installing LLVM
-tmp_dir=$(mktemp -d "llvm-10_build.XXXXXXXX" --tmpdir)
+tmp_dir=$(mktemp -d "llvm-build.XXXXXXXX" --tmpdir)
 ./utils/install-llvm.sh "${NUM_THREADS}" "${tmp_dir}" ${LLVM_INSTALL_DIR} ${LLVM_RELEASE}
 rm -rf "${tmp_dir}"
-sudo pip3 install wllvm
 echo "dependencies successfully installed"
 
 
 echo "Building PhASAR..."
 ${DO_UNIT_TEST} && echo "with unit tests."
+
+echo "Updating the submodules..."
 git submodule init
 git submodule update
+echo "Submodules successfully updated"
+
 
 export CC=${LLVM_INSTALL_DIR}/bin/clang
 export CXX=${LLVM_INSTALL_DIR}/bin/clang++
 
 mkdir -p "${PHASAR_DIR}"/build
 safe_cd "${PHASAR_DIR}"/build
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release "${BOOST_PARAMS}" -DPHASAR_BUILD_UNITTESTS=${DO_UNIT_TEST} "${PHASAR_DIR}"
-cmake --build .
+cmake -G Ninja -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" "${BOOST_PARAMS}" -DPHASAR_BUILD_UNITTESTS="${DO_UNIT_TEST}" "${PHASAR_DIR}"
+cmake --build . -j "${NUM_THREADS}"
+
+echo "phasar successfully built"
 
 if ${DO_UNIT_TEST}; then
    echo "Running PhASAR unit tests..."
+
+   NUM_FAILED_TESTS=0
+
    pushd unittests
    for x in $(find . -type f -executable -print); do
-       pushd "${x%/*}" && ./"${x##*/}" && popd || { echo "Test ${x} failed, aborting."; exit 1; };
+       pushd "${x%/*}" && ./"${x##*/}" || { echo "Test ${x} failed."; NUM_FAILED_TESTS=$((NUM_FAILED_TESTS+1)); };
+       popd;
        done
    popd
+
+   echo "Finished running PhASAR unittests"
+   echo "${NUM_FAILED_TESTS} tests failed"
 fi
 
-echo "phasar successfully built"
-echo "install phasar..."
-sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
-sudo ldconfig
-safe_cd ..
-echo "phasar successfully installed to ${PHASAR_INSTALL_DIR}"
 
+if ${DO_INSTALL}; then
+    echo "install phasar..."
+    sudo cmake -DCMAKE_INSTALL_PREFIX=${PHASAR_INSTALL_DIR} -P cmake_install.cmake
+    sudo ldconfig
+    safe_cd ..
+    echo "phasar successfully installed to ${PHASAR_INSTALL_DIR}"
 
-echo "Set environment variables"
-./utils/setEnvironmentVariables.sh ${LLVM_INSTALL_DIR} ${PHASAR_INSTALL_DIR}
+    echo "Set environment variables"
+    ./utils/setEnvironmentVariables.sh ${LLVM_INSTALL_DIR} ${PHASAR_INSTALL_DIR}
+fi
+
+echo "done."

--- a/utils/InstallAptDependencies.sh
+++ b/utils/InstallAptDependencies.sh
@@ -2,5 +2,5 @@
 set -e
 
 sudo apt update
-sudo apt install git make cmake -y
-sudo apt install zlib1g-dev sqlite3 libsqlite3-dev bear python3 doxygen graphviz python3-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ cmake libz3-dev libedit-dev python3-sphinx libomp-dev libcurl4-openssl-dev ninja-build -y
+sudo apt install git -y
+sudo apt install zlib1g-dev sqlite3 libsqlite3-dev bear python3 doxygen graphviz python3-pip libxml2 libxml2-dev libncurses5-dev libncursesw5-dev swig build-essential g++ libz3-dev libedit-dev python3-sphinx libomp-dev libcurl4-openssl-dev ninja-build -y

--- a/utils/install-llvm.sh
+++ b/utils/install-llvm.sh
@@ -24,7 +24,7 @@ readonly llvm_major_rev=${llvm_version%%.*}  # i.e. 10, if llvm_release is "llvm
 
 function addLibraryPath {
    #libclang.so.<major rev> has been part of LLVM for a while, and we expect it to stick around -- so this should work for checking to make sure the library is available.
-   if ! ldconfig -p |grep -q libclang.so."${llvm_major_rev}"; then
+   if ! ldconfig -p |grep -q "libclang-${llvm_major_rev}.so"; then
        echo "libLLVM-${llvm_major_rev}.so not found in ldconfig. Trying to add it.";
        echo "${dest_dir}/lib" | sudo tee /etc/ld.so.conf.d/llvm-"${llvm_version}".conf > /dev/null
        sudo ldconfig


### PR DESCRIPTION
By default the bootstrap script installs PhASAR system-wide. However, this is oftentimes not desired (also there are problems uninstalling phasar once it is installed -- check #556).

This PR fixes this issue by making install through bootstrap.sh optional (you have to explicitly state `--install`).
Also, the README has been adopted.