### PR TITLE
Dockerfile Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,10 @@ RUN apt-key adv --fetch-keys https://apt.llvm.org/llvm-snapshot.gpg.key && \
               libclang-cpp14-dev \
               clang-tidy-14 && \
             apt download libclang-rt-14-dev && \
-            sudo dpkg --force-all -i libclang-rt-14-dev*
+            dpkg --force-all -i libclang-rt-14-dev*
 
 RUN pip3 install Pygments pyyaml
 
-# installing boost
-RUN apt install libboost-all-dev -y
 
 
 # installing wllvm


### PR DESCRIPTION
sudo is not needed inside Dockerfiles

libboost-all-dev got installed twice for some reason, which caused the build to crash.