### PR TITLE
Added support for ExtractValueInstruction to IFDS Taint Analysis

### DIFF
--- a/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlowSolver/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -146,6 +146,13 @@ IFDSTaintAnalysis::FlowFunctionPtrType IFDSTaintAnalysis::getNormalFlowFunction(
   if (const auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(Curr)) {
     return generateFlow(GEP, GEP->getPointerOperand());
   }
+  // Check if a tainted value is extracted and taint the targets of
+  // the extract operation accordingly
+  if (const auto *Extract = llvm::dyn_cast<llvm::ExtractValueInst>(Curr)) {
+
+    return generateFlow(Extract, Extract->getAggregateOperand());
+  }
+
   // Otherwise we do not care and leave everything as it is
   return Identity<IFDSTaintAnalysis::d_t>::getInstance();
 }


### PR DESCRIPTION
extended taint flow analysis. it now generates a flow for ExtractValue instructions, which are very common in Swift-based LLVM IR.

The pattern we are now able to handle is the following:

```
  %3 = call swiftcc { i64, %swift.bridge* } @"Swift.String.init(_builtinStringLiteral: Builtin.RawPointer, utf8CodeUnitCount: Builtin.Word, isASCII: Builtin.Int1) -> Swift.String"(i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0), i64 12, i1 true)
  %4 = extractvalue { i64, %swift.bridge* } %3, 0
  %5 = extractvalue { i64, %swift.bridge* } %3, 1
```

If the result of the method call was tainted we now correctly propagate the taint to %4 and %5