### PR TITLE
Minor update to IR Statistics

### DIFF
--- a/include/phasar/PhasarLLVM/Passes/GeneralStatisticsAnalysis.h
+++ b/include/phasar/PhasarLLVM/Passes/GeneralStatisticsAnalysis.h
@@ -49,6 +49,7 @@ private:
   size_t Branches = 0;
   size_t GetElementPtrs = 0;
   size_t PhiNodes = 0;
+  size_t GlobalConsts = 0;
   std::set<const llvm::Type *> AllocatedTypes;
   std::set<const llvm::Instruction *> AllocaInstructions;
   std::set<const llvm::Instruction *> RetResInstructions;
@@ -89,6 +90,11 @@ public:
    * @brief Returns the number of globals.
    */
   [[nodiscard]] size_t getGlobals() const;
+
+  /**
+   * @brief Returns the number of constant globals.
+   */
+  [[nodiscard]] size_t getGlobalConsts() const;
 
   /**
    * @brief Returns the number of memory intrinsics.

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
@@ -130,6 +130,9 @@ GeneralStatistics GeneralStatisticsAnalysis::runOnModule(llvm::Module &M) {
       ++Stats.GlobalPointers;
     }
     ++Stats.Globals;
+    if (Global.isConstant()) {
+      ++Stats.GlobalConsts;
+    }
   }
   // register stuff in PAMM
   // For performance reasons (and out of sheer convenience) we simply initialize
@@ -167,6 +170,7 @@ GeneralStatistics GeneralStatisticsAnalysis::runOnModule(llvm::Module &M) {
       PHASAR_LOG_LEVEL(INFO, "Functions          : " << Stats.Functions);
       PHASAR_LOG_LEVEL(INFO, "Globals            : " << Stats.Globals);
       PHASAR_LOG_LEVEL(INFO, "Global Pointer     : " << Stats.GlobalPointers);
+      PHASAR_LOG_LEVEL(INFO, "Global Consts      : " << Stats.GlobalConsts);
       PHASAR_LOG_LEVEL(INFO, "Memory Intrinsics  : " << Stats.MemIntrinsics);
       PHASAR_LOG_LEVEL(INFO,
                        "Store Instructions : " << Stats.StoreInstructions);
@@ -196,6 +200,8 @@ size_t GeneralStatistics::getBasicBlocks() const { return BasicBlocks; }
 size_t GeneralStatistics::getFunctions() const { return Functions; }
 
 size_t GeneralStatistics::getGlobals() const { return Globals; }
+
+size_t GeneralStatistics::getGlobalConsts() const { return GlobalConsts; }
 
 size_t GeneralStatistics::getMemoryIntrinsics() const { return MemIntrinsics; }
 
@@ -233,6 +239,8 @@ nlohmann::json GeneralStatistics::getAsJson() const {
   J["GetElementPtrs"] = GetElementPtrs;
   J["BasicBlocks"] = BasicBlocks;
   J["PhiNodes"] = PhiNodes;
+  J["GlobalConsts"] = GlobalConsts;
+  J["GlobalPointers"] = GlobalPointers;
   return J;
 }
 
@@ -244,6 +252,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
             << "LLVM IR instructions:\t" << Statistics.Instructions << "\n"
             << "Functions:\t" << Statistics.Functions << "\n"
             << "Global Variables:\t" << Statistics.Globals << "\n"
+            << "Global Variable Consts:\t" << Statistics.GlobalConsts << "\n"
+            << "Global Pointers:\t" << Statistics.GlobalPointers << "\n"
             << "Alloca Instructions:\t" << Statistics.AllocaInstructions.size()
             << "\n"
             << "Call Sites:\t" << Statistics.CallSites << "\n"


### PR DESCRIPTION
Including a counter for global constants (seems like u were right @fabianbs96 , most of the globals generated in Swift-based LLVM IR are consts and can be ignored for most cases :) )