### PR TITLE
Fix Configuration Header

### DIFF
--- a/include/phasar/Config/Configuration.h
+++ b/include/phasar/Config/Configuration.h
@@ -49,11 +49,9 @@ public:
 
   /// Specifies the directory in which important configuration files are
   /// located.
-  [[nodiscard]] static constexpr llvm::StringRef
+  [[nodiscard]] static llvm::StringRef
   // NOLINTNEXTLINE(readability-identifier-naming)
-  GlobalConfigurationDirectory() noexcept {
-    return PHASAR_CONFIG_DIR;
-  }
+  GlobalConfigurationDirectory() noexcept;
 
   [[nodiscard]] static std::optional<llvm::StringRef>
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -75,9 +73,7 @@ public:
 
   /// Specifies the directory in which Phasar is located.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  [[nodiscard]] static constexpr llvm::StringRef PhasarDirectory() noexcept {
-    return PHASAR_DIR;
-  }
+  [[nodiscard]] static llvm::StringRef PhasarDirectory() noexcept;
 
   /// Name of the file storing all standard header search paths used for
   /// compilation.
@@ -95,11 +91,9 @@ public:
   }
 
   /// Default Source- and Sink-Functions path
-  [[nodiscard]] static constexpr llvm::StringRef
+  [[nodiscard]] static llvm::StringRef
   // NOLINTNEXTLINE(readability-identifier-naming)
-  DefaultSourceSinkFunctionsPath() noexcept {
-    return PHASAR_DIR "/config/phasar-source-sink-function.json";
-  }
+  DefaultSourceSinkFunctionsPath() noexcept;
 
   // Variables to be used in JSON export format
   /// Identifier for call graph export

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -36,6 +36,16 @@ using namespace psr;
 
 namespace psr {
 
+llvm::StringRef PhasarConfig::GlobalConfigurationDirectory() noexcept {
+  return PHASAR_CONFIG_DIR;
+}
+
+llvm::StringRef PhasarConfig::PhasarDirectory() noexcept { return PHASAR_DIR; }
+
+llvm::StringRef PhasarConfig::DefaultSourceSinkFunctionsPath() noexcept {
+  return PHASAR_DIR "/config/phasar-source-sink-function.json";
+}
+
 PhasarConfig::PhasarConfig() {
   loadGlibcSpecialFunctionNames();
   loadLLVMSpecialFunctionNames();


### PR DESCRIPTION
The `Configuration.h` header requires the compilation symbols `PHASAR_DIR` and `PHASAR_CONFIG_DIR` to be defined. This is fine for compiling phasar itself; however when using this header from clients that just _use_ phasar as a library, these symbols may not be defined. We should not require them to be defined.

This PR fixes this by moving the parts that depend on these symbols to the `Configuration.cpp` source file.