### PR TITLE
Fix IIA reverse flow

### DIFF
--- a/include/phasar/Config/Configuration.h
+++ b/include/phasar/Config/Configuration.h
@@ -37,9 +37,7 @@ class PhasarConfig {
 public:
   /// Current Phasar version
   // NOLINTNEXTLINE(readability-identifier-naming)
-  [[nodiscard]] static constexpr llvm::StringRef PhasarVersion() noexcept {
-    return XSTR(PHASAR_VERSION);
-  }
+  [[nodiscard]] static llvm::StringRef PhasarVersion() noexcept;
 
   /// Stores the label/ tag with which we annotate the LLVM IR.
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -49,11 +47,9 @@ public:
 
   /// Specifies the directory in which important configuration files are
   /// located.
-  [[nodiscard]] static constexpr llvm::StringRef
+  [[nodiscard]] static llvm::StringRef
   // NOLINTNEXTLINE(readability-identifier-naming)
-  GlobalConfigurationDirectory() noexcept {
-    return PHASAR_CONFIG_DIR;
-  }
+  GlobalConfigurationDirectory() noexcept;
 
   [[nodiscard]] static std::optional<llvm::StringRef>
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -75,9 +71,7 @@ public:
 
   /// Specifies the directory in which Phasar is located.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  [[nodiscard]] static constexpr llvm::StringRef PhasarDirectory() noexcept {
-    return PHASAR_DIR;
-  }
+  [[nodiscard]] static llvm::StringRef PhasarDirectory() noexcept;
 
   /// Name of the file storing all standard header search paths used for
   /// compilation.
@@ -95,11 +89,9 @@ public:
   }
 
   /// Default Source- and Sink-Functions path
-  [[nodiscard]] static constexpr llvm::StringRef
+  [[nodiscard]] static llvm::StringRef
   // NOLINTNEXTLINE(readability-identifier-naming)
-  DefaultSourceSinkFunctionsPath() noexcept {
-    return PHASAR_DIR "/config/phasar-source-sink-function.json";
-  }
+  DefaultSourceSinkFunctionsPath() noexcept;
 
   // Variables to be used in JSON export format
   /// Identifier for call graph export

--- a/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
@@ -18,6 +18,7 @@
 #define PHASAR_PHASARLLVM_DATAFLOWSOLVER_IFDSIDE_SOLVER_IDESOLVER_H
 
 #include "phasar/Config/Configuration.h"
+#include "phasar/DB/ProjectIRDBBase.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctions.h"
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
 #include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
@@ -275,7 +276,8 @@ public:
     IDEProblem.emitGraphicalReport(getSolverResults(), OS);
   }
 
-  void dumpResults(llvm::raw_ostream &OS = llvm::outs()) {
+  void dumpResults(llvm::raw_ostream &OS = llvm::outs(),
+                   const typename AnalysisDomainTy::db_t *IRDB = nullptr) {
     PAMM_GET_INSTANCE;
     START_TIMER("DFA IDE Result Dumping", PAMM_SEVERITY_LEVEL::Full);
     OS << "\n***************************************************************\n"
@@ -285,16 +287,21 @@ public:
     if (Cells.empty()) {
       OS << "No results computed!" << '\n';
     } else {
-      std::sort(
-          Cells.begin(), Cells.end(), [](const auto &Lhs, const auto &Rhs) {
-            if constexpr (std::is_same_v<n_t, const llvm::Instruction *>) {
-              return StringIDLess{}(getMetaDataID(Lhs.getRowKey()),
-                                    getMetaDataID(Rhs.getRowKey()));
-            } else {
-              // If non-LLVM IR is used
-              return Lhs.getRowKey() < Rhs.getRowKey();
-            }
-          });
+      if (IRDB) {
+        IRDB->dump();
+      }
+
+      // std::sort(
+      //     Cells.begin(), Cells.end(), [IRDB](const auto &Lhs, const auto
+      //     &Rhs) {
+      //       if constexpr (std::is_same_v<n_t, const llvm::Instruction *>) {
+      //         return StringIDLess{}(getMetaDataID(Lhs.getRowKey()),
+      //                               getMetaDataID(Rhs.getRowKey()));
+      //       } else {
+      //         // If non-LLVM IR is used
+      //         return Lhs.getRowKey() < Rhs.getRowKey();
+      //       }
+      //     });
       n_t Prev = n_t{};
       n_t Curr = n_t{};
       f_t PrevFn = f_t{};

--- a/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
@@ -276,8 +276,7 @@ public:
     IDEProblem.emitGraphicalReport(getSolverResults(), OS);
   }
 
-  void dumpResults(llvm::raw_ostream &OS = llvm::outs(),
-                   const typename AnalysisDomainTy::db_t *IRDB = nullptr) {
+  void dumpResults(llvm::raw_ostream &OS = llvm::outs()) {
     PAMM_GET_INSTANCE;
     START_TIMER("DFA IDE Result Dumping", PAMM_SEVERITY_LEVEL::Full);
     OS << "\n***************************************************************\n"
@@ -287,21 +286,16 @@ public:
     if (Cells.empty()) {
       OS << "No results computed!" << '\n';
     } else {
-      if (IRDB) {
-        IRDB->dump();
-      }
-
-      // std::sort(
-      //     Cells.begin(), Cells.end(), [IRDB](const auto &Lhs, const auto
-      //     &Rhs) {
-      //       if constexpr (std::is_same_v<n_t, const llvm::Instruction *>) {
-      //         return StringIDLess{}(getMetaDataID(Lhs.getRowKey()),
-      //                               getMetaDataID(Rhs.getRowKey()));
-      //       } else {
-      //         // If non-LLVM IR is used
-      //         return Lhs.getRowKey() < Rhs.getRowKey();
-      //       }
-      //     });
+      std::sort(
+          Cells.begin(), Cells.end(), [](const auto &Lhs, const auto &Rhs) {
+            if constexpr (std::is_same_v<n_t, const llvm::Instruction *>) {
+              return StringIDLess{}(getMetaDataID(Lhs.getRowKey()),
+                                    getMetaDataID(Rhs.getRowKey()));
+            } else {
+              // If non-LLVM IR is used
+              return Lhs.getRowKey() < Rhs.getRowKey();
+            }
+          });
       n_t Prev = n_t{};
       n_t Curr = n_t{};
       f_t PrevFn = f_t{};

--- a/include/phasar/Domain/LatticeDomain.h
+++ b/include/phasar/Domain/LatticeDomain.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <ostream>
+#include <variant>
 
 namespace psr {
 
@@ -66,11 +67,21 @@ struct LatticeDomain : public std::variant<Top, L, Bottom> {
   [[nodiscard]] inline bool isTop() const noexcept {
     return std::holds_alternative<Top>(*this);
   }
+
   [[nodiscard]] inline L *getValueOrNull() noexcept {
     return std::get_if<L>(this);
   }
   [[nodiscard]] inline const L *getValueOrNull() const noexcept {
     return std::get_if<L>(this);
+  }
+
+  [[nodiscard]] inline L &assertGetValue() noexcept {
+    assert(std::holds_alternative<L>(*this));
+    return std::get<L>(*this);
+  }
+  [[nodiscard]] inline const L &assertGetValue() const noexcept {
+    assert(std::holds_alternative<L>(*this));
+    return std::get<L>(*this);
   }
 };
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -793,10 +793,10 @@ public:
       return EdgeIdentity<l_t>::getInstance();
     }
 
-    // check if the user has registered a fact generator function
-    l_t UserEdgeFacts = bvSetFrom(invoke_or_default(EdgeFactGen, Curr));
-
     if (Curr != CurrNode && Curr == SuccNode) {
+      // check if the user has registered a fact generator function
+      l_t UserEdgeFacts = bvSetFrom(invoke_or_default(EdgeFactGen, Curr));
+
       // We generate Curr in this instruction, so we have to annotate it with
       // edge labels
       return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -12,6 +12,7 @@
 
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionComposer.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionSingletonFactory.h"
+#include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctions.h"
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
 #include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
@@ -55,33 +56,50 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 
 // Have some handy helper functionalities
-namespace {
-
-[[maybe_unused]] inline const llvm::AllocaInst *
-getAllocaInstruction(const llvm::GetElementPtrInst *GEP) {
-  if (!GEP) {
-    return nullptr;
-  }
-  const auto *Alloca = GEP->getPointerOperand();
-  while (const auto *NestedGEP =
-             llvm::dyn_cast<llvm::GetElementPtrInst>(Alloca)) {
-    Alloca = NestedGEP->getPointerOperand();
-  }
-  return llvm::dyn_cast<llvm::AllocaInst>(Alloca);
-}
-
-} // namespace
 
 namespace vara {
 class Taint;
 } // namespace vara
 
 namespace psr {
+
+// [[nodiscard]] static inline const llvm::AllocaInst *
+// getAllocaInstruction(const llvm::GetElementPtrInst *GEP) {
+//   if (!GEP) {
+//     return nullptr;
+//   }
+//   const auto *Alloca = GEP->getPointerOperand();
+//   while (const auto *NestedGEP =
+//              llvm::dyn_cast<llvm::GetElementPtrInst>(Alloca)) {
+//     Alloca = NestedGEP->getPointerOperand();
+//   }
+//   return llvm::dyn_cast<llvm::AllocaInst>(Alloca);
+// }
+
+template <typename T> static BitVectorSet<T> bvSetFrom(const std::set<T> &Set) {
+  BitVectorSet<T> Ret;
+  Ret.reserve(Set.size());
+  Ret.insert(Set.begin(), Set.end());
+  return Ret;
+}
+
+template <typename Callable, typename... ArgTys>
+static std::invoke_result_t<std::decay_t<Callable>, ArgTys...>
+invoke_or_default(Callable &&Fn, ArgTys &&...Args) {
+  if (!Fn) {
+    return {};
+  }
+
+  return std::invoke(Fn, std::forward<ArgTys>(Args)...);
+}
+
 class IDEIIAFlowFact {
+
 public:
   constexpr static unsigned KLimit = 2;
 
@@ -126,6 +144,13 @@ public:
   bool operator==(const llvm::Value *V) const;
 
   inline operator const llvm::Value *() { return BaseVal; }
+
+  [[nodiscard]] std::string str() const {
+    std::string Ret;
+    llvm::raw_string_ostream OS(Ret);
+    print(OS);
+    return Ret;
+  }
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
@@ -385,35 +410,6 @@ public:
     //             0  x  y
     //
     if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
-      // Case x is a load instruction
-      if (const auto *Load =
-              llvm::dyn_cast<llvm::LoadInst>(Store->getValueOperand())) {
-
-        return lambdaFlow<d_t>([Store, Load](d_t Src) -> container_type {
-          // Override old value, i.e., kill value that is written to and
-          // generate from value that is stored.
-          if (Store->getPointerOperand() == Src) {
-            return {};
-          }
-          container_type Facts = {Src};
-          // y now obtains its new value from x
-          if (Load == Src || Load->getPointerOperand() == Src) {
-            Facts.insert(Load->getPointerOperand());
-            Facts.insert(Store->getPointerOperand());
-          }
-          IF_LOG_ENABLED({
-            for (const auto Fact : Facts) {
-              PHASAR_LOG_LEVEL(
-                  DFADEBUG, "Create edge: " << llvmIRToShortString(Src) << " --"
-                                            << llvmIRToShortString(Store)
-                                            << "--> " << Fact);
-            }
-          });
-          return Facts;
-        });
-      }
-
-      // Otherwise
       return lambdaFlow<d_t>([Store](d_t Src) -> container_type {
         // Override old value, i.e., kill value that is written to and
         // generate from value that is stored.
@@ -670,6 +666,94 @@ public:
 
   // In addition provide specifications for the IDE parts.
 
+  inline EdgeFunctionPtrType
+  getStrongUpdateStoreEF(const llvm::StoreInst *Store, d_t CurrNode,
+                         d_t SuccNode, l_t UserEdgeFacts) {
+
+    // Overriding edge: obtain labels from value to be stored (and may add
+    // UserEdgeFacts, if any).
+    //
+    // x --> y
+    //
+    // Edge function:
+    //
+    //            x
+    //             \
+        // store x y    \ \x.x \cup { commit of('store x y') }
+    //               v
+    //               y
+    //
+
+    if (CurrNode == Store->getValueOperand() ||
+        (isZeroValue(CurrNode) &&
+         llvm::isa<llvm::Constant>(Store->getValueOperand()))) {
+      return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
+    }
+
+    if (SyntacticAnalysisOnly) {
+      // Kill all labels that are propagated along the edge of the value that
+      // is overridden.
+      //
+      // y --> y
+      //
+      // Edge function:
+      //
+      //               y
+      //               |
+      // store x y     | \x.{ commit of('store x y') }
+      //               v
+      //               y
+      //
+      if ((CurrNode == SuccNode) && CurrNode == Store->getPointerOperand()) {
+        // y obtains its value(s) from its original allocation and the store
+        // instruction under analysis.
+        IF_LOG_ENABLED({
+          PHASAR_LOG_LEVEL(DFADEBUG,
+                           "Const-Replace at '" << llvmIRToString(Store));
+          PHASAR_LOG_LEVEL(DFADEBUG, "Replacement label(s): ");
+          for (const auto &Item : UserEdgeFacts.assertGetValue()) {
+            PHASAR_LOG_LEVEL(DFADEBUG, Item << ", ");
+          }
+          PHASAR_LOG_LEVEL(DFADEBUG, '\n');
+        });
+        // obtain label from the original allocation
+        return IIAAKillOrReplaceEF::createEdgeFunction(UserEdgeFacts);
+      }
+
+    } else {
+      // Use points-to information to find all possible overriding edges.
+
+      // Kill all labels that are propagated along the edge of the
+      // value/values that is/are overridden.
+      //
+      // y --> y
+      //
+      // Edge function:
+      //
+      //            y
+      //            |
+      // store x y  | \x.{}
+      //            v
+      //            y
+      //
+      if (CurrNode == SuccNode && (Store->getPointerOperand() == CurrNode ||
+                                   this->PT.isInReachableAllocationSites(
+                                       Store->getPointerOperand(), CurrNode,
+                                       OnlyConsiderLocalAliases))) {
+        return IIAAKillOrReplaceEF::createEdgeFunction(BitVectorSet<e_t>());
+      }
+    }
+
+    if (CurrNode == SuccNode) {
+      // Everything unrelated to the store
+      return EdgeIdentity<l_t>::getInstance();
+    }
+
+    llvm::report_fatal_error(
+        llvm::Twine("Unhandled edge: \n> Store: ") + llvmIRToString(Store) +
+        "\n> CurrNode: " + CurrNode.str() + "\n> SuccNode: " + SuccNode.str());
+  }
+
   inline EdgeFunctionPtrType getNormalEdgeFunction(n_t Curr, d_t CurrNode,
                                                    n_t /* Succ */,
                                                    d_t SuccNode) override {
@@ -677,294 +761,38 @@ public:
                      "Process edge: " << llvmIRToShortString(CurrNode) << " --"
                                       << llvmIRToString(Curr) << "--> "
                                       << llvmIRToShortString(SuccNode));
+
+    // Overrides at store instructions
+    if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
+      return getStrongUpdateStoreEF(
+          Store, CurrNode, SuccNode,
+          bvSetFrom(invoke_or_default(EdgeFactGen, Curr)));
+    }
+
     //
-    // Zero --> Zero edges
+    // Identity edges
     //
     // Edge function:
     //
     //                     0
     //                     |
-    // %i = instruction    | \x.BOT
+    // %i = instruction    | \x.x
     //                     v
     //                     0
     //
-    if (isZeroValue(CurrNode) && isZeroValue(SuccNode)) {
+    if (CurrNode == SuccNode) {
       return EdgeIdentity<l_t>::getInstance();
     }
+
     // check if the user has registered a fact generator function
-    l_t UserEdgeFacts = BitVectorSet<e_t>();
-    std::set<e_t> EdgeFacts;
-    if (EdgeFactGen) {
-      EdgeFacts = EdgeFactGen(Curr);
-      // fill BitVectorSet
-      UserEdgeFacts = BitVectorSet<e_t>(EdgeFacts.begin(), EdgeFacts.end());
-    }
-    //
-    // Zero --> Alloca edges
-    //
-    // Edge function:
-    //
-    //                0
-    //                 \
-    // %a = alloca      \ \x.x \cup { commit of('%a = alloca') }
-    //                   v
-    //                   a
-    //
-    if (isZeroValue(CurrNode) && Curr == SuccNode) {
-      if (llvm::isa<llvm::AllocaInst>(Curr)) {
-        return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-      }
-    }
-    //
-    // i --> i edges
-    //
-    // Edge function:
-    //
-    //                    i
-    //                    |
-    // %i = instruction   | \x.x \cup { commit of('%i = instruction') }
-    //                    v
-    //                    i
-    //
-    if (Curr == CurrNode && CurrNode == SuccNode) {
+    l_t UserEdgeFacts = bvSetFrom(invoke_or_default(EdgeFactGen, Curr));
+
+    if (Curr != CurrNode && Curr == SuccNode) {
+      // We generate Curr in this instruction, so we have to annotate it with
+      // edge labels
       return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
     }
-    // Handle loads in non-syntax only analysis
-    if constexpr (!SyntacticAnalysisOnly) {
-      if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
-        //
-        // y --> x
-        //
-        // Edge function:
-        //
-        //             y
-        //              \
-        // x = load y    \ \x.{ commit of('x = load y') } \cup { commits of y }
-        //                v
-        //                x
-        //
-        if ((CurrNode == Load->getPointerOperand() ||
-             this->PT.isInReachableAllocationSites(Load->getPointerOperand(),
-                                                   CurrNode,
-                                                   OnlyConsiderLocalAliases)) &&
-            Load == SuccNode) {
-          IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-        } else {
-          //
-          // y --> y
-          //
-          // Edge function:
-          //
-          //             y
-          //             |
-          // x = load y  | \x.x (loads do not modify the value that is loaded
-          // from)
-          //             v
-          //             y
-          //
-          return EdgeIdentity<l_t>::getInstance();
-        }
-      }
-    }
-    // Overrides at store instructions
-    if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
-      if (SyntacticAnalysisOnly) {
-        // Kill all labels that are propagated along the edge of the value that
-        // is overridden.
-        //
-        // y --> y
-        //
-        // Edge function:
-        //
-        //               y
-        //               |
-        // store x y     | \x.{ commit of('store x y') }
-        //               v
-        //               y
-        //
-        if ((CurrNode == SuccNode) && CurrNode == Store->getPointerOperand()) {
-          // y obtains its value(s) from its original allocation and the store
-          // instruction under analysis.
-          IF_LOG_ENABLED({
-            PHASAR_LOG_LEVEL(DFADEBUG,
-                             "Const-Replace at '" << llvmIRToString(Curr));
-            PHASAR_LOG_LEVEL(DFADEBUG, "Replacement label(s): ");
-            for (const auto &Item : EdgeFacts) {
-              PHASAR_LOG_LEVEL(DFADEBUG, Item << ", ");
-            }
-            PHASAR_LOG_LEVEL(DFADEBUG, '\n');
-          });
-          // obtain label from the original allocation
-          const llvm::AllocaInst *OrigAlloca = nullptr;
-          if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(
-                  Store->getPointerOperand())) {
-            OrigAlloca = Alloca;
-          }
-          if (const auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(
-                  Store->getPointerOperand())) {
-            OrigAlloca = getAllocaInstruction(GEP);
-          }
-          // obtain the label
-          if (OrigAlloca) {
-            if (auto *UEF = std::get_if<BitVectorSet<e_t>>(&UserEdgeFacts)) {
-              UEF->insert(edgeFactGenForInstToBitVectorSet(OrigAlloca));
-            }
-          }
-          return IIAAKillOrReplaceEF::createEdgeFunction(UserEdgeFacts);
-        }
-        //
-        // x --> y
-        //
-        // Edge function:
-        //
-        //             x
-        //              \
-        // store x y     \ \x.{ commit of('store x y') }
-        //                v
-        //                y
-        //
-        if (CurrNode == Store->getValueOperand() &&
-            SuccNode == Store->getPointerOperand()) {
-          IF_LOG_ENABLED({
-            PHASAR_LOG_LEVEL(DFADEBUG, "Var-Override: ");
-            for (const auto &EF : EdgeFacts) {
-              PHASAR_LOG_LEVEL(DFADEBUG, EF << ", ");
-            }
-            PHASAR_LOG_LEVEL(DFADEBUG, "at '" << llvmIRToString(Curr) << "'\n");
-          });
-          return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-        }
-      } else {
-        // Use points-to information to find all possible overriding edges.
 
-        // Overriding edge with literal: kill all labels that are propagated
-        // along the edge of the value that is overridden.
-        //
-        // x --> y
-        //
-        // Edge function:
-        //
-        // Let x be a literal.
-        //
-        //               y
-        //               |
-        // store x y     | \x.{} \cup { commit of('store x y') }
-        //               v
-        //               y
-        //
-        if (llvm::isa<llvm::ConstantData>(Store->getValueOperand()) &&
-            CurrNode == SuccNode &&
-            (this->PT.isInReachableAllocationSites(Store->getPointerOperand(),
-                                                   CurrNode,
-                                                   OnlyConsiderLocalAliases) ||
-             Store->getPointerOperand() == CurrNode)) {
-          // Add the original variable, i.e., memory location.
-          return IIAAKillOrReplaceEF::createEdgeFunction(UserEdgeFacts);
-        }
-        // Kill all labels that are propagated along the edge of the
-        // value/values that is/are overridden.
-        //
-        // y --> y
-        //
-        // Edge function:
-        //
-        //            y
-        //            |
-        // store x y  | \x.{}
-        //            v
-        //            y
-        //
-        if (CurrNode == SuccNode && this->PT.isInReachableAllocationSites(
-                                        Store->getPointerOperand(), CurrNode,
-                                        OnlyConsiderLocalAliases)) {
-          return IIAAKillOrReplaceEF::createEdgeFunction(BitVectorSet<e_t>());
-        }
-        // Overriding edge: obtain labels from value to be stored (and may add
-        // UserEdgeFacts, if any).
-        //
-        // x --> y
-        //
-        // Edge function:
-        //
-        //            x
-        //             \
-        // store x y    \ \x.x \cup { commit of('store x y') }
-        //               v
-        //               y
-        //
-        bool StoreValOpIsPointerTy =
-            Store->getValueOperand()->getType()->isPointerTy();
-        if ((CurrNode == Store->getValueOperand() ||
-             (StoreValOpIsPointerTy &&
-              this->PT.isInReachableAllocationSites(
-                  Store->getValueOperand(), Store->getValueOperand(),
-                  OnlyConsiderLocalAliases))) &&
-            this->PT.isInReachableAllocationSites(Store->getPointerOperand(),
-                                                  Store->getPointerOperand(),
-                                                  OnlyConsiderLocalAliases)) {
-          return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-        }
-      }
-    }
-    // Handle edge functions for general instructions.
-    for (const auto &Op : Curr->operands()) {
-      //
-      // 0 --> o_i
-      //
-      // Edge function:
-      //
-      //                        0
-      //                         \
-      // %i = instruction o_i     \ \x.x \cup { commit of('%i = instruction') }
-      //                           v
-      //                           o_i
-      //
-      if (isZeroValue(CurrNode) && Op == SuccNode) {
-        return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-      }
-      //
-      // o_i --> o_i
-      //
-      // Edge function:
-      //
-      //                        o_i
-      //                        |
-      // %i = instruction o_i   | \x.x \cup { commit of('%i = instruction') }
-      //                        v
-      //                        o_i
-      //
-      if (Op == CurrNode && CurrNode == SuccNode) {
-        IF_LOG_ENABLED({
-          PHASAR_LOG_LEVEL(DFADEBUG, "this is 'i'\n");
-          for (auto &EdgeFact : EdgeFacts) {
-            PHASAR_LOG_LEVEL(DFADEBUG, EdgeFact << ", ");
-          }
-          PHASAR_LOG_LEVEL(DFADEBUG, '\n');
-        });
-        return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-      }
-      //
-      // o_i --> i
-      //
-      // Edge function:
-      //
-      //                        o_i
-      //                         \
-      // %i = instruction o_i     \ \x.x \cup { commit of('%i = instruction') }
-      //                           v
-      //                           i
-      //
-      if (Op == CurrNode && Curr == SuccNode) {
-        IF_LOG_ENABLED({
-          PHASAR_LOG_LEVEL(DFADEBUG, "this is '0'\n");
-          for (auto &EdgeFact : EdgeFacts) {
-            PHASAR_LOG_LEVEL(DFADEBUG, EdgeFact << ", ");
-          }
-          PHASAR_LOG_LEVEL(DFADEBUG, '\n');
-        });
-        return IIAAAddLabelsEF::createEdgeFunction(UserEdgeFacts);
-      }
-    }
     // Otherwise stick to identity.
     return EdgeIdentity<l_t>::getInstance();
   }
@@ -1478,24 +1306,6 @@ private:
   std::function<EdgeFactGeneratorTy> EdgeFactGen;
   static inline const bool OnlyConsiderLocalAliases = true;
 
-  inline BitVectorSet<e_t> edgeFactGenForInstToBitVectorSet(n_t CurrInst) {
-    if (EdgeFactGen) {
-      auto Results = EdgeFactGen(CurrInst);
-      BitVectorSet<e_t> BVS(Results.begin(), Results.end());
-      return BVS;
-    }
-    return {};
-  }
-
-  inline BitVectorSet<e_t>
-  edgeFactGenForGlobalVarToBitVectorSet(const llvm::GlobalVariable *GlobalVar) {
-    if (EdgeFactGen) {
-      auto Results = EdgeFactGen(GlobalVar);
-      BitVectorSet<e_t> BVS(Results.begin(), Results.end());
-      return BVS;
-    }
-    return {};
-  }
 }; // namespace psr
 
 using IDEInstInteractionAnalysis = IDEInstInteractionAnalysisT<>;

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -762,6 +762,11 @@ public:
                                       << llvmIRToString(Curr) << "--> "
                                       << llvmIRToShortString(SuccNode));
 
+    if (isZeroValue(SuccNode)) {
+      // We don't want to propagate any facts on zero
+      return EdgeIdentity<l_t>::getInstance();
+    }
+
     // Overrides at store instructions
     if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
       return getStrongUpdateStoreEF(

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -35,6 +35,19 @@
 using namespace psr;
 
 namespace psr {
+llvm::StringRef PhasarConfig::PhasarVersion() noexcept {
+  return XSTR(PHASAR_VERSION);
+}
+
+llvm::StringRef PhasarConfig::GlobalConfigurationDirectory() noexcept {
+  return PHASAR_CONFIG_DIR;
+}
+
+llvm::StringRef PhasarConfig::PhasarDirectory() noexcept { return PHASAR_DIR; }
+
+llvm::StringRef PhasarConfig::DefaultSourceSinkFunctionsPath() noexcept {
+  return PHASAR_DIR "/config/phasar-source-sink-function.json";
+}
 
 PhasarConfig::PhasarConfig() {
   loadGlibcSpecialFunctionNames();

--- a/lib/Config/Configuration.cpp
+++ b/lib/Config/Configuration.cpp
@@ -49,16 +49,6 @@ llvm::StringRef PhasarConfig::DefaultSourceSinkFunctionsPath() noexcept {
   return PHASAR_DIR "/config/phasar-source-sink-function.json";
 }
 
-llvm::StringRef PhasarConfig::GlobalConfigurationDirectory() noexcept {
-  return PHASAR_CONFIG_DIR;
-}
-
-llvm::StringRef PhasarConfig::PhasarDirectory() noexcept { return PHASAR_DIR; }
-
-llvm::StringRef PhasarConfig::DefaultSourceSinkFunctionsPath() noexcept {
-  return PHASAR_DIR "/config/phasar-source-sink-function.json";
-}
-
 PhasarConfig::PhasarConfig() {
   loadGlibcSpecialFunctionNames();
   loadLLVMSpecialFunctionNames();

--- a/lib/Controller/AnalysisControllerXIDEIIA.cpp
+++ b/lib/Controller/AnalysisControllerXIDEIIA.cpp
@@ -10,10 +10,39 @@
 #include "phasar/Controller/AnalysisController.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h"
 
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/Casting.h"
+
 namespace psr {
 
 void AnalysisController::executeIDEIIA() {
-  executeIDEAnalysis<IDEInstInteractionAnalysis>(EntryPoints);
+  auto EdgeFactGen =
+      [](std::variant<const llvm::Instruction *, const llvm::GlobalVariable *>
+             Src) -> std::set<std::string> {
+    return std::visit(
+        [](const auto *Inst) -> std::set<std::string> {
+          const auto *FVarAnnot = Inst->getMetadata("FVar");
+          if (!FVarAnnot || FVarAnnot->getNumOperands() == 0) {
+            return {};
+          }
+
+          const auto *FVar =
+              llvm::dyn_cast<llvm::MDNode>(FVarAnnot->getOperand(0).get());
+          if (!FVar || FVar->getNumOperands() == 0) {
+            return {};
+          }
+
+          if (const auto *Feat =
+                  llvm::dyn_cast<llvm::MDString>(FVar->getOperand(0).get())) {
+            return {Feat->getString().str()};
+          }
+          return {};
+        },
+        Src);
+  };
+
+  executeIDEAnalysis<IDEInstInteractionAnalysis>(EntryPoints, EdgeFactGen);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/IR/Argument.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalValue.h"
@@ -303,6 +304,10 @@ bool LLVMAliasSet::intraIsReachableAllocationSiteTy(
         return true;
       }
     }
+  } else if (const auto *Arg = llvm::dyn_cast<llvm::Argument>(P)) {
+    /// Arguments are no allocation sites, but in the inTRAprocedural case, they
+    /// act as such
+    return Arg->getParent() == VFun;
   }
 
   return false;

--- a/test/llvm_test_code/inst_interaction/CMakeLists.txt
+++ b/test/llvm_test_code/inst_interaction/CMakeLists.txt
@@ -19,6 +19,7 @@ set(Sources
   call_04.cpp
   call_05.cpp
   call_06.cpp
+  call_07.cpp
   global_01.cpp
   global_02.cpp
   heap_01.cpp

--- a/test/llvm_test_code/inst_interaction/call_07.cpp
+++ b/test/llvm_test_code/inst_interaction/call_07.cpp
@@ -1,0 +1,10 @@
+
+void inputRefParam(int &ir) { // NOLINT
+  ir = 42;
+}
+
+int main() {
+  int VarIR;
+  inputRefParam(VarIR);
+  return VarIR;
+}

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -75,7 +75,7 @@ protected:
     //                                                           EntryPoints);
     assert(HA);
     auto IIAProblem =
-        createAnalysisProblem<IDEInstInteractionAnalysisT<std::string, true>>(
+        createAnalysisProblem<IDEInstInteractionAnalysisT<std::string>>(
             *HA, EntryPoints);
     // use Phasar's instruction ids as testing labels
     auto Generator =
@@ -424,7 +424,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_01) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 9, "i", {"4", "5"}));
+          "main", 9, "i", {"4"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 9, "j", {"4", "5", "6", "7"}));
@@ -441,19 +441,19 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_02) {
           "main", 24, "retval", {"6"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "argc.addr", {"7", "13"}));
+          "main", 24, "argc.addr", {"7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 24, "argv.addr", {"8"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "i", {"16", "18", "20"}));
+          "main", 24, "i", {"16", "18"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 24, "j", {"9", "10", "11", "12"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "k", {"22", "21", "16", "18", "20"}));
+          "main", 24, "k", {"21", "16", "18", "20"}));
   doAnalysisAndCompareResults("basic_02_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -464,10 +464,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_03) {
           "main", 20, "retval", {"3"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 20, "i", {"4", "10", "11", "12", "18"}));
+          "main", 20, "i", {"4", "10", "11", "12"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 20, "x", {"5", "7", "14", "15", "16"}));
+          "main", 20, "x", {"5", "14", "15", "16"}));
   doAnalysisAndCompareResults("basic_03_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -481,19 +481,19 @@ PHASAR_SKIP_TEST(TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_04) {
           "main", 23, "retval", {"13"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 23, "argc.addr", {"14", "21"}));
+          "main", 23, "argc.addr", {"14"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 23, "argv.addr", {"15"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 23, "i", {"16", "17"}));
+          "main", 23, "i", {"16"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 23, "j", {"16", "17", "19", "18", "24"}));
+          "main", 23, "j", {"16", "17", "19", "18"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 23, "k", {"16", "17", "18", "19", "20", "24", "25", "27"}));
+          "main", 23, "k", {"16", "17", "18", "19", "20", "24", "25"}));
   doAnalysisAndCompareResults("basic_04_cpp.ll", {"main"}, GroundTruth, false);
 })
 
@@ -501,7 +501,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_05) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 11, "i", {"5", "7", "9"}));
+          "main", 11, "i", {"5", "7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 11, "retval", {"2"}));
@@ -515,16 +515,16 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_06) {
           "main", 19, "retval", {"5"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "i", {"1", "9"}));
+          "main", 19, "i", {"15", "6", "13"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "j", {"2", "11"}));
+          "main", 19, "j", {"15", "6", "13"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "k", {"6", "13"}));
+          "main", 19, "k", {"6"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "p", {"1", "2", "9", "11", "14", "16"}));
+          "main", 19, "p", {"1", "2", "9", "11"}));
   doAnalysisAndCompareResults("basic_06_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -541,7 +541,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_07) {
           "main", 15, "argv.addr", {"7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 15, "i", {"12", "13"}));
+          "main", 15, "i", {"12"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 15, "j", {"8", "9", "10", "11"}));
@@ -555,7 +555,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_08) {
           "main", 12, "retval", {"2"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "i", {"9", "10"}));
+          "main", 12, "i", {"9"}));
   doAnalysisAndCompareResults("basic_08_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -563,10 +563,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_09) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "i", {"4", "6"}));
+          "main", 10, "i", {"4"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "j", {"4", "6", "7", "8"}));
+          "main", 10, "j", {"4", "6", "7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 10, "retval", {"3"}));
@@ -577,7 +577,7 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_10) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 6, "i", {"3", "4"}));
+          "main", 6, "i", {"3"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 6, "retval", {"2"}));
@@ -588,10 +588,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleBasicTest_11) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 20, "FeatureSelector", {"5", "7", "8", "9"}));
+          "main", 20, "FeatureSelector", {"5", "7", "8"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 20, "retval", {"11", "16", "18"}));
+          "main", 20, "retval", {"11", "16"}));
   doAnalysisAndCompareResults("basic_11_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -602,14 +602,13 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_01) {
           "main", 14, "retval", {"8"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 14, "i", {"9", "10"}));
+          "main", 14, "i", {"9"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 14, "j", {"13", "12", "9", "10", "11"}));
+          "main", 14, "j", {"12", "9", "10", "11"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 14, "k",
-          {"15", "1", "2", "13", "16", "12", "9", "10", "11"}));
+          "main", 14, "k", {"15", "1", "2", "13", "12", "9", "10", "11"}));
   doAnalysisAndCompareResults("call_01_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -620,14 +619,14 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_02) {
           "main", 13, "retval", {"12"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 13, "i", {"13", "15"}));
+          "main", 13, "i", {"13"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 13, "j", {"14", "16"}));
+          "main", 13, "j", {"14"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 13, "k",
-          {"4", "19", "5", "15", "6", "3", "14", "2", "13", "16", "18"}));
+          {"4", "5", "15", "6", "3", "14", "2", "13", "16", "18"}));
   doAnalysisAndCompareResults("call_02_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -638,12 +637,11 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_03) {
           "main", 10, "retval", {"20"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "i", {"21", "22"}));
+          "main", 10, "i", {"21"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 10, "j",
-          {"22", "15", "6", "21", "3", "2", "13", "8", "9", "12", "10", "24",
-           "25"}));
+          {"22", "15", "6", "21", "2", "13", "8", "9", "12", "10", "24"}));
   doAnalysisAndCompareResults("call_03_cpp.ll", {"main"}, GroundTruth, false);
 }
 

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -66,9 +66,9 @@ protected:
                               const std::set<IIACompactResult_t> &GroundTruth,
                               bool PrintDump = false) {
     initializeIR(LlvmFilePath, EntryPoints);
-    if (PrintDump) {
-      IRDB->dump();
-    }
+    // if (PrintDump) {
+    IRDB->emitPreprocessedIR(llvm::outs());
+    // }
 
     // IDEInstInteractionAnalysisT<std::string, true> IIAProblem(IRDB, &ICFG,
     // &PT,
@@ -652,52 +652,53 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_04) {
           "main", 20, "retval", {"33"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 20, "i", {"41", "35", "34"}));
+          "main", 20, "i", {"34"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 20, "j",
-          {"15", "6", "3", "2", "13", "8", "9", "12", "10", "35", "38", "34",
-           "37", "42"}));
+          {"15", "6", "2", "13", "8", "9", "12", "10", "35", "34", "37"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 20, "k",
-          {"41", "19", "15", "6",  "44", "3",  "2",  "13", "8",
-           "45", "18", "9",  "12", "10", "46", "24", "47", "25",
-           "35", "27", "23", "26", "38", "34", "37", "42", "40"}));
+          {"41", "19", "15", "6",  "44", "2",  "13", "8",  "45",
+           "18", "9",  "12", "10", "46", "24", "25", "35", "27",
+           "23", "26", "38", "34", "37", "42", "40"}));
   doAnalysisAndCompareResults("call_04_cpp.ll", {"main"}, GroundTruth, false);
 }
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_05) {
+  // NOTE: Here we are suffering from IntraProceduralAliasesOnly
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 10, "retval", {"8"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "i", {"1", "11", "9"}));
+          "main", 10, "i", {"11", "9"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "j", {"1", "10", "12", "13"}));
+          "main", 10, "j", {"10", "12"}));
   doAnalysisAndCompareResults("call_05_cpp.ll", {"main"}, GroundTruth, false);
 }
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_06) {
+  // NOTE: Here we are suffering from IntraProceduralAliasesOnly
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 24, "retval", {"11"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "i", {"4", "3", "1", "2", "28", "16", "18", "12"}));
+          "main", 24, "i", {"3", "1", "2", "16", "18", "12"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "j", {"4", "19", "21", "3", "1", "2", "13"}));
+          "main", 24, "j", {"19", "21", "3", "1", "2", "13"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "k", {"4", "22", "3", "14", "1", "2", "24"}));
+          "main", 24, "k", {"22", "3", "14", "1", "2", "24"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 24, "l", {"4", "15", "3", "1", "2", "25", "27"}));
+          "main", 24, "l", {"15", "3", "1", "2", "25", "27"}));
   doAnalysisAndCompareResults("call_06_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -708,11 +709,11 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_01) {
           "main", 9, "retval", {"3"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 9, "i", {"7", "8"}));
+          "main", 9, "i", {"7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 9, "j", {"0", "5", "6"}));
-  doAnalysisAndCompareResults("global_01_cpp.ll", {"main"}, GroundTruth, true);
+  doAnalysisAndCompareResults("global_01_cpp.ll", {"main"}, GroundTruth, false);
 }
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_02) {
@@ -725,16 +726,16 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_02) {
           "_Z5initBv", 2, "b", {"2"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "a", {"0", "10"}));
+          "main", 12, "a", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "b", {"2", "11"}));
+          "main", 12, "b", {"2"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 12, "retval", {"6"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "c", {"1", "8", "7", "13"}));
+          "main", 12, "c", {"1", "8", "7"}));
   doAnalysisAndCompareResults("global_02_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -745,10 +746,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_03) {
           "main", 1, "GlobalFeature", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 2, "GlobalFeature", {"0", "1"}));
+          "main", 2, "GlobalFeature", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 17, "GlobalFeature", {"0", "1"}));
+          "main", 17, "GlobalFeature", {"0"}));
   doAnalysisAndCompareResults("global_03_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -759,10 +760,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_04) {
           "main", 1, "GlobalFeature", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 2, "GlobalFeature", {"0", "3"}));
+          "main", 2, "GlobalFeature", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 17, "GlobalFeature", {"0", "3"}));
+          "main", 17, "GlobalFeature", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "_Z7doStuffi", 1, "GlobalFeature", {"0"}));
@@ -780,13 +781,13 @@ TEST_F(IDEInstInteractionAnalysisTest, KillTest_01) {
           "main", 12, "retval", {"4"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "i", {"5", "6", "8"}));
+          "main", 12, "i", {"5"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 12, "j", {"10"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "k", {"9", "8", "5", "6"}));
+          "main", 12, "k", {"9", "8", "5"}));
   doAnalysisAndCompareResults("KillTest_01_cpp.ll", {"main"}, GroundTruth,
                               false);
 }
@@ -798,13 +799,13 @@ TEST_F(IDEInstInteractionAnalysisTest, KillTest_02) {
           "main", 12, "retval", {"6"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "A", {"0", "10"}));
+          "main", 12, "A", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "B", {"2", "11"}));
+          "main", 12, "B", {"2"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 12, "C", {"1", "7", "8", "13"}));
+          "main", 12, "C", {"1", "7", "8"}));
   doAnalysisAndCompareResults("KillTest_02_cpp.ll", {"main"}, GroundTruth,
                               false);
 }
@@ -822,10 +823,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleReturnTest_01) {
           "main", 6, "call", {"0"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 8, "localVar", {"0", "6", "7"}));
+          "main", 8, "localVar", {"0", "6"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 8, "call", {"0", "6"}));
+          "main", 8, "call", {"0"}));
   doAnalysisAndCompareResults("return_01_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -836,10 +837,10 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleHeapTest_01) {
           "main", 19, "retval", {"3"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "i", {"6", "7", "8", "11"}));
+          "main", 19, "i", {"6", "7"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 19, "j", {"6", "7", "8", "17", "10", "9"}));
+          "main", 19, "j", {"6", "7", "8", "10", "9"}));
   doAnalysisAndCompareResults("heap_01_cpp.ll", {"main"}, GroundTruth, false);
 }
 

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -851,13 +851,13 @@ PHASAR_SKIP_TEST(TEST_F(IDEInstInteractionAnalysisTest, HandleRVOTest_01) {
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 16, "retval", {"75", "76", "78"}));
+          "main", 16, "retval", {"75", "76"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 16, "str", {"70", "65", "72", "74", "77"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 16, "ref.tmp", {"66", "9", "6", "29", "72", "73", "71"}));
+          "main", 16, "ref.tmp", {"66", "9", "72", "73", "71"}));
   doAnalysisAndCompareResults("rvo_01_cpp.ll", {"main"}, GroundTruth, false);
 })
 

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -667,17 +667,16 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_04) {
 }
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_05) {
-  // NOTE: Here we are suffering from IntraProceduralAliasesOnly
   std::set<IIACompactResult_t> GroundTruth;
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 10, "retval", {"8"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "i", {"11", "9"}));
+          "main", 10, "i", {"3", "11", "9"}));
   GroundTruth.emplace(
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
-          "main", 10, "j", {"10", "12"}));
+          "main", 10, "j", {"3", "10", "12"}));
   doAnalysisAndCompareResults("call_05_cpp.ll", {"main"}, GroundTruth, false);
 }
 
@@ -700,6 +699,17 @@ TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_06) {
       std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
           "main", 24, "l", {"15", "3", "1", "2", "25", "27"}));
   doAnalysisAndCompareResults("call_06_cpp.ll", {"main"}, GroundTruth, false);
+}
+
+TEST_F(IDEInstInteractionAnalysisTest, HandleCallTest_07) {
+  std::set<IIACompactResult_t> GroundTruth;
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
+          "main", 6, "retval", {"7"}));
+  GroundTruth.emplace(
+      std::tuple<std::string, size_t, std::string, BitVectorSet<std::string>>(
+          "main", 6, "VarIR", {"6", "3", "8"}));
+  doAnalysisAndCompareResults("call_07_cpp.ll", {"main"}, GroundTruth, false);
 }
 
 TEST_F(IDEInstInteractionAnalysisTest, HandleGlobalTest_01) {

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysisTest.cpp
@@ -66,9 +66,9 @@ protected:
                               const std::set<IIACompactResult_t> &GroundTruth,
                               bool PrintDump = false) {
     initializeIR(LlvmFilePath, EntryPoints);
-    // if (PrintDump) {
-    IRDB->emitPreprocessedIR(llvm::outs());
-    // }
+    if (PrintDump) {
+      IRDB->emitPreprocessedIR(llvm::outs());
+    }
 
     // IDEInstInteractionAnalysisT<std::string, true> IIAProblem(IRDB, &ICFG,
     // &PT,


### PR DESCRIPTION
The edge functions in the `IDEInstInteractionAnalysis` sometimes generate dataflows that flow in reverse controlflow direction.
This PR changes that.

Note: This PR also includes changes that are now being out-sourced to #594. So, that PR should probably be merged first