### PR TITLE
Fix Crash in GlobalCtorDtor Handling

### DIFF
--- a/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
+++ b/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
@@ -75,20 +75,28 @@ llvm::ModuleSlotTracker &getModuleSlotTrackerFor(const llvm::Value *V);
 /**
  * @brief Returns a string representation of a LLVM Value.
  */
-std::string llvmIRToString(const llvm::Value *V);
+[[nodiscard]] std::string llvmIRToString(const llvm::Value *V);
 
 /**
  * @brief Similar to llvmIRToString, but removes the metadata from the output as
  * they are not always stable. Prefer this function over llvmIRToString, if you
  * are comparing the string representations of LLVM iR instructions.
  */
-std::string llvmIRToStableString(const llvm::Value *V);
+[[nodiscard]] std::string llvmIRToStableString(const llvm::Value *V);
 
 /**
  * @brief Same as @link(llvmIRToString) but tries to shorten the
  *        resulting string
  */
 std::string llvmIRToShortString(const llvm::Value *V);
+
+/**
+ * @brief Returns a string-representation of a LLVM type.
+ *
+ * @param Shorten Tries to shorten the output
+ */
+[[nodiscard]] std::string llvmTypeToString(const llvm::Type *Ty,
+                                           bool Shorten = false);
 
 LLVM_DUMP_METHOD void dumpIRValue(const llvm::Value *V);
 LLVM_DUMP_METHOD void dumpIRValue(const llvm::Instruction *V);

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFGGlobalsImpl.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFGGlobalsImpl.cpp
@@ -136,7 +136,14 @@ static llvm::Function *createDtorCallerForModule(
 
   for (auto It = RegisteredDtors.rbegin(), End = RegisteredDtors.rend();
        It != End; ++It) {
-    IRB.CreateCall(It->first, {It->second});
+    auto FunCallee = It->first;
+    assert(FunCallee.getFunctionType()->getNumParams() == 1);
+    auto *ExpectedArgType = FunCallee.getFunctionType()->getParamType(0);
+    auto *Arg = It->second;
+    if (Arg->getType() != ExpectedArgType) {
+      Arg = IRB.CreateBitOrPointerCast(Arg, ExpectedArgType);
+    }
+    IRB.CreateCall(FunCallee, {Arg});
   }
 
   IRB.CreateRetVoid();
@@ -233,7 +240,7 @@ llvm::Function *LLVMBasedICFG::buildCRuntimeGlobalCtorsDtorsModel(
 
   for (auto [unused, Ctor] : GlobalCtors) {
     assert(Ctor != nullptr);
-    assert(Ctor->arg_size() == 0);
+    assert(Ctor->arg_empty());
 
     IRB.CreateCall(Ctor);
   }
@@ -286,7 +293,7 @@ llvm::Function *LLVMBasedICFG::buildCRuntimeGlobalCtorsDtorsModel(
     auto UEntrySelectorFn = M.getOrInsertFunction(
         "__psrCRuntimeUserEntrySelector", llvm::Type::getInt32Ty(CTX));
 
-    auto *UEntrySelector = IRB.CreateCall(UEntrySelectorFn, {});
+    auto *UEntrySelector = IRB.CreateCall(UEntrySelectorFn);
 
     auto *DefaultBB = llvm::BasicBlock::Create(CTX, "invalid", GlobModel);
     auto *SwitchEnd = llvm::BasicBlock::Create(CTX, "switchEnd", GlobModel);

--- a/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
+++ b/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
@@ -222,6 +222,23 @@ std::string llvmIRToShortString(const llvm::Value *V) {
   return llvm::StringRef(IRBuffer).ltrim().str();
 }
 
+std::string llvmTypeToString(const llvm::Type *Ty, bool Shorten) {
+  if (!Ty) {
+    return "<null>";
+  }
+  if (Shorten) {
+    if (const auto *StructTy = llvm::dyn_cast<llvm::StructType>(Ty);
+        StructTy && StructTy->hasName()) {
+      return StructTy->getName().str();
+    }
+  }
+
+  std::string IRBuffer;
+  llvm::raw_string_ostream RSO(IRBuffer);
+  Ty->print(RSO, false, Shorten);
+  return IRBuffer;
+}
+
 void dumpIRValue(const llvm::Value *V) {
   llvm::outs() << llvmIRToString(V) << '\n';
 }


### PR DESCRIPTION
To handle global constructors and destructors we are generating wrapper functions that call these. In some (rare) cases the generated call-sites was incompatible with the expected callee-signature (some missing pointe-bitcasts).
As this is only checked with debug-assertions on LLVM-side, this error only shows up when using a debug-build of LLVM (for example in the in-tree build).

This PR fixes the issue on phasar side.