### PR TITLE
Disables warnings in nlohmann_json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ set(CMAKE_CXX_CLANG_TIDY "")
 set(BUILD_TESTS OFF CACHE BOOL "Build json-schema-validator-tests")
 
 # Make nlohmann_json_schema_validator happy by telling it how to find the single include of nlohmann_json
-include_directories(external/json/single_include/)
+include_directories(SYSTEM external/json/single_include/)
 
 if (PHASAR_IN_TREE)
   set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS nlohmann_json_schema_validator)


### PR DESCRIPTION
Warnings, such as, warning: default label in switch which covers all enumeration values, from nlohmann_json spam during compilation, especially for LLVM builds. A default label for a switch is unreachable should all cases covered. LLVM prefers to warn in cases where not all cases are covered. As we cannot change the code in the json lib, we should at least disable the flood of warnings.