### PR TITLE
Fix and Simplify Initial Seeds

### DIFF
--- a/include/phasar/DB/ProjectIRDBBase.h
+++ b/include/phasar/DB/ProjectIRDBBase.h
@@ -158,6 +158,15 @@ private:
     return static_cast<const Derived &>(*this);
   }
 };
+
+template <typename DB>
+// NOLINTNEXTLINE(readability-identifier-naming)
+auto IRDBGetFunctionDef(const ProjectIRDBBase<DB> *IRDB) noexcept {
+  return [IRDB](llvm::StringRef Name) {
+    return IRDB->getFunctionDefinition(Name);
+  };
+}
+
 } // namespace psr
 
 #endif // PHASAR_DB_PROJECTIRDBBASE_H

--- a/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
@@ -1,0 +1,102 @@
+/******************************************************************************
+ * Copyright (c) 2023 Fabian Schiebel.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Fabian Schiebel and others
+ *****************************************************************************/
+
+#ifndef PHASAR_DATAFLOW_IFDSIDE_ENTRYPOINTUTILS_H
+#define PHASAR_DATAFLOW_IFDSIDE_ENTRYPOINTUTILS_H
+
+#include "phasar/DB/ProjectIRDBBase.h"
+
+#include <functional>
+
+namespace psr {
+
+template <typename EntryRange, typename C, typename FunctionRetriever,
+          typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints,
+                          FunctionRetriever GetFunction, const C &CFG,
+                          HandlerFn Handler) {
+  for (const auto &EntryPoint : EntryPoints) {
+    const auto &Fn = std::invoke(GetFunction, EntryPoint);
+    if constexpr (std::is_convertible_v<std::decay_t<decltype(Fn)>, bool>) {
+      if (!Fn) {
+        continue;
+      }
+    }
+    for (const auto &SP : CFG.getStartPointsOf(Fn)) {
+      std::invoke(Handler, SP);
+    }
+  }
+}
+
+template <typename EntryRange, typename C, typename FunctionRetriever,
+          typename SeedsT, typename D, typename L>
+void addSeedsForStartingPoints(const EntryRange &EntryPoints,
+                               FunctionRetriever GetFunction, const C &CFG,
+                               SeedsT &Seeds, const D &ZeroValue,
+                               const L &BottomValue) {
+  forallStartingPoints(EntryPoints, std::move(GetFunction), CFG,
+                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
+                         Seeds.addSeed(SP, ZeroValue, BottomValue);
+                       });
+}
+
+template <typename EntryRange, typename C, typename DB, typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints,
+                          const ProjectIRDBBase<DB> *IRDB, const C &CFG,
+                          HandlerFn Handler) {
+  if (EntryPoints.size() == 1 && EntryPoints.front() == "__ALL__") {
+    forallStartingPoints(
+        IRDB->getAllFunctions(), [](auto Fn) { return Fn; }, CFG,
+        std::move(Handler));
+  } else {
+    forallStartingPoints(EntryPoints, IRDBGetFunctionDef(IRDB), CFG,
+                         std::move(Handler));
+  }
+}
+
+template <typename EntryRange, typename C, typename DB, typename SeedsT,
+          typename D, typename L>
+void addSeedsForStartingPoints(const EntryRange &EntryPoints,
+                               const ProjectIRDBBase<DB> *IRDB, const C &CFG,
+                               SeedsT &Seeds, const D &ZeroValue,
+                               const L &BottomValue) {
+  forallStartingPoints(EntryPoints, IRDB, CFG,
+                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
+                         Seeds.addSeed(SP, ZeroValue, BottomValue);
+                       });
+}
+
+template <typename EntryRange, typename I, typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints, const I *ICF,
+                          HandlerFn Handler) {
+  if (EntryPoints.size() == 1 && EntryPoints.front() == "__ALL__") {
+    forallStartingPoints(
+        ICF->getAllFunctions(), [](auto Fn) { return Fn; }, *ICF,
+        std::move(Handler));
+  } else {
+    forallStartingPoints(
+        EntryPoints,
+        [ICF](llvm::StringRef Name) { return ICF->getFunction(Name); }, *ICF,
+        std::move(Handler));
+  }
+}
+
+template <typename EntryRange, typename I, typename SeedsT, typename D,
+          typename L>
+void addSeedsForStartingPoints(const EntryRange &EntryPoints, const I *ICF,
+                               SeedsT &Seeds, const D &ZeroValue,
+                               const L &BottomValue) {
+  forallStartingPoints(EntryPoints, ICF,
+                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
+                         Seeds.addSeed(SP, ZeroValue, BottomValue);
+                       });
+}
+} // namespace psr
+
+#endif // PHASAR_DATAFLOW_IFDSIDE_ENTRYPOINTUTILS_H

--- a/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
@@ -40,7 +40,9 @@ template <typename EntryRange, typename C, typename ICFGorIRDB,
           typename HandlerFn>
 void forallStartingPoints(const EntryRange &EntryPoints, const ICFGorIRDB *ICDB,
                           const CFGBase<C> &CFG, HandlerFn Handler) {
-  if (EntryPoints.size() == 1 && EntryPoints.front() == "__ALL__") {
+
+  if (llvm::hasSingleElement(EntryPoints) &&
+      *llvm::adl_begin(EntryPoints) == "__ALL__") {
     forallStartingPoints(ICDB->getAllFunctions(), CFG, std::move(Handler));
   } else {
     forallStartingPoints(llvm::map_range(EntryPoints,

--- a/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EntryPointUtils.h
@@ -10,81 +10,73 @@
 #ifndef PHASAR_DATAFLOW_IFDSIDE_ENTRYPOINTUTILS_H
 #define PHASAR_DATAFLOW_IFDSIDE_ENTRYPOINTUTILS_H
 
+#include "phasar/ControlFlow/CFGBase.h"
 #include "phasar/DB/ProjectIRDBBase.h"
+
+#include "llvm/ADT/STLExtras.h"
 
 #include <functional>
 
 namespace psr {
 
-template <typename EntryRange, typename C, typename FunctionRetriever,
-          typename HandlerFn>
-void forallStartingPoints(const EntryRange &EntryPoints,
-                          FunctionRetriever GetFunction, const C &CFG,
+namespace detail {
+template <typename EntryRange, typename C, typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints, const CFGBase<C> &CFG,
                           HandlerFn Handler) {
-  for (const auto &EntryPoint : EntryPoints) {
-    const auto &Fn = std::invoke(GetFunction, EntryPoint);
-    if constexpr (std::is_convertible_v<std::decay_t<decltype(Fn)>, bool>) {
-      if (!Fn) {
+  for (const auto &EntryPointFn : EntryPoints) {
+    if constexpr (std::is_convertible_v<std::decay_t<decltype(EntryPointFn)>,
+                                        bool>) {
+      if (!EntryPointFn) {
         continue;
       }
     }
-    for (const auto &SP : CFG.getStartPointsOf(Fn)) {
+    for (const auto &SP : CFG.getStartPointsOf(EntryPointFn)) {
       std::invoke(Handler, SP);
     }
   }
 }
 
-template <typename EntryRange, typename C, typename FunctionRetriever,
-          typename SeedsT, typename D, typename L>
-void addSeedsForStartingPoints(const EntryRange &EntryPoints,
-                               FunctionRetriever GetFunction, const C &CFG,
-                               SeedsT &Seeds, const D &ZeroValue,
-                               const L &BottomValue) {
-  forallStartingPoints(EntryPoints, std::move(GetFunction), CFG,
-                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
-                         Seeds.addSeed(SP, ZeroValue, BottomValue);
-                       });
-}
-
-template <typename EntryRange, typename C, typename DB, typename HandlerFn>
-void forallStartingPoints(const EntryRange &EntryPoints,
-                          const ProjectIRDBBase<DB> *IRDB, const C &CFG,
-                          HandlerFn Handler) {
+template <typename EntryRange, typename C, typename ICFGorIRDB,
+          typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints, const ICFGorIRDB *ICDB,
+                          const CFGBase<C> &CFG, HandlerFn Handler) {
   if (EntryPoints.size() == 1 && EntryPoints.front() == "__ALL__") {
-    forallStartingPoints(
-        IRDB->getAllFunctions(), [](auto Fn) { return Fn; }, CFG,
-        std::move(Handler));
+    forallStartingPoints(ICDB->getAllFunctions(), CFG, std::move(Handler));
   } else {
-    forallStartingPoints(EntryPoints, IRDBGetFunctionDef(IRDB), CFG,
-                         std::move(Handler));
+    forallStartingPoints(llvm::map_range(EntryPoints,
+                                         [ICDB](llvm::StringRef Name) {
+                                           return ICDB->getFunction(Name);
+                                         }),
+                         CFG, std::move(Handler));
   }
 }
 
-template <typename EntryRange, typename C, typename DB, typename SeedsT,
-          typename D, typename L>
-void addSeedsForStartingPoints(const EntryRange &EntryPoints,
-                               const ProjectIRDBBase<DB> *IRDB, const C &CFG,
-                               SeedsT &Seeds, const D &ZeroValue,
-                               const L &BottomValue) {
-  forallStartingPoints(EntryPoints, IRDB, CFG,
-                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
-                         Seeds.addSeed(SP, ZeroValue, BottomValue);
-                       });
+} // namespace detail
+
+template <typename EntryRange, typename C, typename DB, typename HandlerFn>
+void forallStartingPoints(const EntryRange &EntryPoints,
+                          const ProjectIRDBBase<DB> *IRDB,
+                          const CFGBase<C> &CFG, HandlerFn Handler) {
+  return detail::forallStartingPoints(EntryPoints, IRDB, CFG,
+                                      std::move(Handler));
 }
 
 template <typename EntryRange, typename I, typename HandlerFn>
 void forallStartingPoints(const EntryRange &EntryPoints, const I *ICF,
                           HandlerFn Handler) {
-  if (EntryPoints.size() == 1 && EntryPoints.front() == "__ALL__") {
-    forallStartingPoints(
-        ICF->getAllFunctions(), [](auto Fn) { return Fn; }, *ICF,
-        std::move(Handler));
-  } else {
-    forallStartingPoints(
-        EntryPoints,
-        [ICF](llvm::StringRef Name) { return ICF->getFunction(Name); }, *ICF,
-        std::move(Handler));
-  }
+  detail::forallStartingPoints(EntryPoints, ICF, *ICF, std::move(Handler));
+}
+
+template <typename EntryRange, typename C, typename DB, typename SeedsT,
+          typename D, typename L>
+void addSeedsForStartingPoints(const EntryRange &EntryPoints,
+                               const ProjectIRDBBase<DB> *IRDB,
+                               const CFGBase<C> &CFG, SeedsT &Seeds,
+                               const D &ZeroValue, const L &BottomValue) {
+  forallStartingPoints(EntryPoints, IRDB, CFG,
+                       [&Seeds, &ZeroValue, &BottomValue](const auto &SP) {
+                         Seeds.addSeed(SP, ZeroValue, BottomValue);
+                       });
 }
 
 template <typename EntryRange, typename I, typename SeedsT, typename D,

--- a/include/phasar/DataFlow/IfdsIde/IDETabulationProblem.h
+++ b/include/phasar/DataFlow/IfdsIde/IDETabulationProblem.h
@@ -129,6 +129,9 @@ protected:
     return generateFlow(std::move(FactToGenerate), getZeroValue());
   }
 
+  /// Seeds that just start with ZeroValue and bottomElement() at the starting
+  /// points of each EntryPoint function.
+  /// Takes the __ALL__ EntryPoint into account.
   template <
       typename CC = typename AnalysisDomainTy::c_t,
       typename = std::enable_if_t<std::is_nothrow_default_constructible_v<CC>>>

--- a/include/phasar/DataFlow/IfdsIde/IDETabulationProblem.h
+++ b/include/phasar/DataFlow/IfdsIde/IDETabulationProblem.h
@@ -7,12 +7,13 @@
  *     Philipp Schubert, Fabian Schiebel and others
  *****************************************************************************/
 
-#ifndef PHASAR_PHASARLLVM_DATAFLOWSOLVER_IFDSIDE_IDETABULATIONPROBLEM_H_
-#define PHASAR_PHASARLLVM_DATAFLOWSOLVER_IFDSIDE_IDETABULATIONPROBLEM_H_
+#ifndef PHASAR_DATAFLOW_IFDSIDE_IDETABULATIONPROBLEM_H_
+#define PHASAR_DATAFLOW_IFDSIDE_IDETABULATIONPROBLEM_H_
 
 #include "phasar/ControlFlow/ICFGBase.h"
 #include "phasar/DB/ProjectIRDBBase.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctions.h"
+#include "phasar/DataFlow/IfdsIde/EntryPointUtils.h"
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
 #include "phasar/DataFlow/IfdsIde/IFDSIDESolverConfig.h"
 #include "phasar/DataFlow/IfdsIde/InitialSeeds.h"
@@ -21,7 +22,10 @@
 #include "phasar/Utils/Printer.h"
 #include "phasar/Utils/Soundness.h"
 
+#include "llvm/ADT/StringRef.h"
+
 #include <cassert>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <set>
@@ -123,6 +127,19 @@ protected:
   typename FlowFunctions<AnalysisDomainTy, Container>::FlowFunctionPtrType
   generateFromZero(d_t FactToGenerate) {
     return generateFlow(std::move(FactToGenerate), getZeroValue());
+  }
+
+  template <
+      typename CC = typename AnalysisDomainTy::c_t,
+      typename = std::enable_if_t<std::is_nothrow_default_constructible_v<CC>>>
+  [[nodiscard]] InitialSeeds<n_t, d_t, l_t> createDefaultSeeds() {
+    InitialSeeds<n_t, d_t, l_t> Seeds;
+    CC C{};
+
+    addSeedsForStartingPoints(EntryPoints, IRDB, C, Seeds, getZeroValue(),
+                              this->bottomElement());
+
+    return Seeds;
   }
 
   const ProjectIRDBBase<db_t> *IRDB{};

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h
@@ -49,10 +49,11 @@ public:
   }
 
 protected:
-  LLVMBasedCFGImpl(bool IgnoreDbgInstructions = true) noexcept
+  LLVMBasedCFGImpl() noexcept = default;
+  LLVMBasedCFGImpl(bool IgnoreDbgInstructions) noexcept
       : IgnoreDbgInstructions(IgnoreDbgInstructions) {}
 
-  bool IgnoreDbgInstructions = false;
+  bool IgnoreDbgInstructions = true;
 
   [[nodiscard]] f_t getFunctionOfImpl(n_t Inst) const noexcept;
   [[nodiscard]] llvm::SmallVector<n_t, 2> getPredsOfImpl(n_t Inst) const;
@@ -99,7 +100,8 @@ class LLVMBasedCFG : public detail::LLVMBasedCFGImpl<LLVMBasedCFG> {
   friend class LLVMBasedBackwardCFG;
 
 public:
-  LLVMBasedCFG(bool IgnoreDbgInstructions = true) noexcept
+  LLVMBasedCFG() noexcept = default;
+  LLVMBasedCFG(bool IgnoreDbgInstructions) noexcept
       : detail::LLVMBasedCFGImpl<LLVMBasedCFG>(IgnoreDbgInstructions) {}
 
   [[nodiscard]] nlohmann::json exportCFGAsJson(const llvm::Function *F) const;

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -620,21 +620,18 @@ public:
 
   inline InitialSeeds<n_t, d_t, l_t> initialSeeds() override {
     InitialSeeds<n_t, d_t, l_t> Seeds;
-    std::set<const llvm::Function *> EntryPointFuns;
-    for (const auto &EntryPoint : this->EntryPoints) {
-      EntryPointFuns.insert(this->IRDB->getFunctionDefinition(EntryPoint));
-    }
-    // Set initial seeds at the required entry points and generate the global
-    // variables using generalized initial seeds
-    for (const auto *EntryPointFun : EntryPointFuns) {
+
+    forallStartingPoints(this->EntryPoints, ICF, [this, &Seeds](n_t SP) {
+      // Set initial seeds at the required entry points and generate the global
+      // variables using generalized initial seeds
+
       // Generate zero value at the entry points
-      Seeds.addSeed(&EntryPointFun->front().front(), this->getZeroValue(),
-                    bottomElement());
+      Seeds.addSeed(SP, this->getZeroValue(), bottomElement());
       // Generate formal parameters of entry points, e.g. main(). Formal
       // parameters will otherwise cause trouble by overriding alloca
       // instructions without being valid data-flow facts themselves.
-      for (const auto &Arg : EntryPointFun->args()) {
-        Seeds.addSeed(&EntryPointFun->front().front(), &Arg, Bottom{});
+      for (const auto &Arg : SP->getFunction()->args()) {
+        Seeds.addSeed(SP, &Arg, Bottom{});
       }
       // Generate all global variables using generalized initial seeds
 
@@ -648,10 +645,11 @@ public:
             InitialValues =
                 BitVectorSet<e_t>(EdgeFacts.begin(), EdgeFacts.end());
           }
-          Seeds.addSeed(&EntryPointFun->front().front(), GV, InitialValues);
+          Seeds.addSeed(SP, GV, InitialValues);
         }
       }
-    }
+    });
+
     return Seeds;
   }
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEExtendedTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEExtendedTaintAnalysis.cpp
@@ -11,6 +11,7 @@
 
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
+#include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/GenEdgeFunction.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/Helpers.h"
@@ -48,18 +49,8 @@ IDEExtendedTaintAnalysis::initialSeeds() {
     }
   }
 
-  for (const auto &Ep : base_t::EntryPoints) {
-    const auto *EntryFn = ICF->getFunction(Ep);
-
-    if (!EntryFn) {
-      llvm::errs() << "WARNING: Entry-Function \"" << Ep
-                   << "\" not contained in the module; skip it\n";
-      continue;
-    }
-
-    Seeds.addSeed(&EntryFn->front().front(), this->base_t::getZeroValue(),
-                  bottomElement());
-  }
+  addSeedsForStartingPoints(base_t::EntryPoints, ICF, Seeds,
+                            this->base_t::getZeroValue(), bottomElement());
 
   if (Seeds.empty()) {
     llvm::errs() << "WARNING: No initial seeds specified, skip the analysis. "

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEProtoAnalysis.cpp
@@ -10,6 +10,8 @@
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEProtoAnalysis.h"
 
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
+#include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
@@ -68,14 +70,7 @@ InitialSeeds<IDEProtoAnalysis::n_t, IDEProtoAnalysis::d_t,
              IDEProtoAnalysis::l_t>
 IDEProtoAnalysis::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IDEProtoAnalysis::initialSeeds()");
-  InitialSeeds<IDEProtoAnalysis::n_t, IDEProtoAnalysis::d_t,
-               IDEProtoAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue(), bottomElement());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IDEProtoAnalysis::d_t IDEProtoAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDESecureHeapPropagation.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDESecureHeapPropagation.cpp
@@ -101,16 +101,7 @@ IDESecureHeapPropagation::getSummaryFlowFunction(n_t /*CallSite*/,
 InitialSeeds<IDESecureHeapPropagation::n_t, IDESecureHeapPropagation::d_t,
              IDESecureHeapPropagation::l_t>
 IDESecureHeapPropagation::initialSeeds() {
-  InitialSeeds<IDESecureHeapPropagation::n_t, IDESecureHeapPropagation::d_t,
-               IDESecureHeapPropagation::l_t>
-      Seeds;
-  for (const auto &Entry : EntryPoints) {
-    const auto *Fn = IRDB->getFunction(Entry);
-    if (Fn && !Fn->isDeclaration()) {
-      Seeds.addSeed(&Fn->front().front(), getZeroValue(), bottomElement());
-    }
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IDESecureHeapPropagation::d_t

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDESolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDESolverTest.cpp
@@ -12,6 +12,7 @@
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctions.h"
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
@@ -72,13 +73,7 @@ IDESolverTest::getSummaryFlowFunction(IDESolverTest::n_t /*CallSite*/,
 InitialSeeds<IDESolverTest::n_t, IDESolverTest::d_t, IDESolverTest::l_t>
 IDESolverTest::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IDESolverTest::initialSeeds()");
-  InitialSeeds<IDESolverTest::n_t, IDESolverTest::d_t, IDESolverTest::l_t>
-      Seeds;
-  for (auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue(), topElement());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IDESolverTest::d_t IDESolverTest::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -430,14 +430,7 @@ InitialSeeds<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
              IDETypeStateAnalysis::l_t>
 IDETypeStateAnalysis::initialSeeds() {
   // just start in main()
-  InitialSeeds<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-               IDETypeStateAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue(), bottomElement());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IDETypeStateAnalysis::d_t IDETypeStateAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSConstAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSConstAnalysis.cpp
@@ -165,14 +165,7 @@ InitialSeeds<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
              IFDSConstAnalysis::l_t>
 IFDSConstAnalysis::initialSeeds() {
   // just start in main()
-  InitialSeeds<IFDSConstAnalysis::n_t, IFDSConstAnalysis::d_t,
-               IFDSConstAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSConstAnalysis::d_t IFDSConstAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSProtoAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSProtoAnalysis.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSProtoAnalysis.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
@@ -65,14 +66,7 @@ InitialSeeds<IFDSProtoAnalysis::n_t, IFDSProtoAnalysis::d_t,
              IFDSProtoAnalysis::l_t>
 IFDSProtoAnalysis::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IFDSProtoAnalysis::initialSeeds()");
-  InitialSeeds<IFDSProtoAnalysis::n_t, IFDSProtoAnalysis::d_t,
-               IFDSProtoAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSProtoAnalysis::d_t IFDSProtoAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSignAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSignAnalysis.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSignAnalysis.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
@@ -60,14 +61,7 @@ InitialSeeds<IFDSSignAnalysis::n_t, IFDSSignAnalysis::d_t,
              IFDSSignAnalysis::l_t>
 IFDSSignAnalysis::initialSeeds() {
   llvm::outs() << "IFDSSignAnalysis::initialSeeds()\n";
-  InitialSeeds<IFDSSignAnalysis::n_t, IFDSSignAnalysis::d_t,
-               IFDSSignAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSSignAnalysis::d_t IFDSSignAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSolverTest.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSolverTest.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSSolverTest.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
@@ -60,13 +61,7 @@ IFDSSolverTest::getSummaryFlowFunction(IFDSSolverTest::n_t /*CallSite*/,
 InitialSeeds<IFDSSolverTest::n_t, IFDSSolverTest::d_t, IFDSSolverTest::l_t>
 IFDSSolverTest::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IFDSSolverTest::initialSeeds()");
-  InitialSeeds<IFDSSolverTest::n_t, IFDSSolverTest::d_t, IFDSSolverTest::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSSolverTest::d_t IFDSSolverTest::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -9,6 +9,8 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.h"
 
+#include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMFlowFunctions.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
@@ -18,6 +20,8 @@
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Logger.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/AbstractCallSite.h"
 #include "llvm/IR/LLVMContext.h"
@@ -291,19 +295,19 @@ IFDSTaintAnalysis::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IFDSTaintAnalysis::initialSeeds()");
   // If main function is the entry point, commandline arguments have to be
   // tainted. Otherwise we just use the zero value to initialize the analysis.
-  InitialSeeds<IFDSTaintAnalysis::n_t, IFDSTaintAnalysis::d_t,
-               IFDSTaintAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-    if (EntryPoint == "main") {
+  InitialSeeds<n_t, d_t, l_t> Seeds;
+
+  LLVMBasedCFG C;
+  forallStartingPoints(EntryPoints, IRDB, C, [this, &Seeds](n_t SP) {
+    Seeds.addSeed(SP, getZeroValue());
+    if (SP->getFunction()->getName() == "main") {
       std::set<IFDSTaintAnalysis::d_t> CmdArgs;
-      for (const auto &Arg : IRDB->getFunction(EntryPoint)->args()) {
-        Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(), &Arg);
+      for (const auto &Arg : SP->getFunction()->args()) {
+        Seeds.addSeed(SP, &Arg);
       }
     }
-  }
+  });
+
   return Seeds;
 }
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTypeAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTypeAnalysis.cpp
@@ -87,14 +87,7 @@ IFDSTypeAnalysis::getSummaryFlowFunction(IFDSTypeAnalysis::n_t /*Curr*/,
 InitialSeeds<IFDSTypeAnalysis::n_t, IFDSTypeAnalysis::d_t,
              IFDSTypeAnalysis::l_t>
 IFDSTypeAnalysis::initialSeeds() {
-  InitialSeeds<IFDSTypeAnalysis::n_t, IFDSTypeAnalysis::d_t,
-               IFDSTypeAnalysis::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSTypeAnalysis::d_t IFDSTypeAnalysis::createZeroValue() const {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -10,6 +10,7 @@
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSUninitializedVariables.h"
 
 #include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Utils/LLVMIRToSrc.h"
@@ -389,14 +390,7 @@ InitialSeeds<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
              IFDSUninitializedVariables::l_t>
 IFDSUninitializedVariables::initialSeeds() {
   PHASAR_LOG_LEVEL(DEBUG, "IFDSUninitializedVariables::initialSeeds()");
-  InitialSeeds<IFDSUninitializedVariables::n_t, IFDSUninitializedVariables::d_t,
-               IFDSUninitializedVariables::l_t>
-      Seeds;
-  for (const auto &EntryPoint : EntryPoints) {
-    Seeds.addSeed(&IRDB->getFunction(EntryPoint)->front().front(),
-                  getZeroValue());
-  }
-  return Seeds;
+  return createDefaultSeeds();
 }
 
 IFDSUninitializedVariables::d_t


### PR DESCRIPTION
The `initialSeeds()` for most IFDS/IDE problems were set on the first instruction of the `EntryPoints` functions. However, the `LLVMBasedCFG` (correctly) skips debug intrinsics by default which may prevent the IDESolver from computing edge values on entry-functions where the first instruction (that one where the seeds are set) is a debug instruction.

This PR fixes this issue and additionally provides some utilities that make it easier creating correct seeds.