### PR TITLE
IFDS Taint analysis summary function for Swift's  String.append method

### DIFF
--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.cpp
@@ -281,7 +281,17 @@ IFDSTaintAnalysis::FlowFunctionPtrType
 IFDSTaintAnalysis::getSummaryFlowFunction(
     [[maybe_unused]] IFDSTaintAnalysis::n_t CallSite,
     [[maybe_unused]] IFDSTaintAnalysis::f_t DestFun) {
-  // Don't use a special summary
+  // $sSS1poiyS2S_SStFZ is Swift's String append method
+  // if concat a tainted string with something else the
+  // result should be tainted
+  if (DestFun->getName().equals("$sSS1poiyS2S_SStFZ")) {
+    const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
+
+    return generateFlowIf<d_t>(CallSite, [CS](d_t Source) {
+      return ((Source == CS->getArgOperand(1)) ||
+              (Source == CS->getArgOperand(3)));
+    });
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
I added a special summary function to our IFDS Taint analysis which specifically handles Swift's String append methods. 
With this extension we are able to find the taint flow from this example if we tag getPassword() as source and db.prepare() as sink. 

```import SQLite

@main
public struct SQLExecutableTaintTest {
    public static func main() throws {
        
        let db = try Connection() // in-memory database        

        // nameInput and passwordInput represent possible user input 
        // and are assumed to be received from external inputs
        let nameInput = "'Alice'"
        let passwordInput = getPassword() // source 

        let queryStringName = "SELECT * FROM users WHERE name=" + 
                                        nameInput + 
                                        " AND password="

        let queryString = queryStringName + passwordInput

        let stmt = try db.prepare(queryString) // sink
    }

    // this method represents possible user input
    public static func getPassword() -> String {
        return "'test' OR 1=1;" // this is why user input is dangerous
    }
}```