### PR TITLE
Consume solver results

### DIFF
--- a/include/phasar/DataFlow/IfdsIde/IFDSIDESolverConfig.h
+++ b/include/phasar/DataFlow/IfdsIde/IFDSIDESolverConfig.h
@@ -63,9 +63,8 @@ struct IFDSIDESolverConfig {
                                        const IFDSIDESolverConfig &SC);
 
 private:
-  SolverConfigOptions Options = SolverConfigOptions::AutoAddZero |
-                                SolverConfigOptions::ComputeValues |
-                                SolverConfigOptions::RecordEdges;
+  SolverConfigOptions Options =
+      SolverConfigOptions::AutoAddZero | SolverConfigOptions::ComputeValues;
 };
 
 } // namespace psr

--- a/include/phasar/DataFlow/IfdsIde/SolverResults.h
+++ b/include/phasar/DataFlow/IfdsIde/SolverResults.h
@@ -19,38 +19,45 @@
 
 #include "phasar/Domain/BinaryDomain.h"
 #include "phasar/Utils/ByRef.h"
+#include "phasar/Utils/PAMMMacros.h"
+#include "phasar/Utils/Printer.h"
 #include "phasar/Utils/Table.h"
+#include "phasar/Utils/Utilities.h"
 
 #include <set>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
 
+namespace llvm {
+class Instruction;
+class Value;
+} // namespace llvm
+
 namespace psr {
+// For sorting the results in dumpResults()
+std::string getMetaDataID(const llvm::Value *V);
 
 template <typename N, typename D, typename L> class SolverResults {
-private:
-  Table<N, D, L> &Results;
-  D ZV;
-
 public:
-  SolverResults(Table<N, D, L> &ResTab, D ZV) : Results(ResTab), ZV(ZV) {}
+  using n_t = N;
+  using d_t = D;
+  using l_t = L;
 
-  ByConstRef<L> resultAt(ByConstRef<N> Stmt, ByConstRef<D> Node) const {
+  SolverResults(Table<N, D, L> &ResTab,
+                D ZV) noexcept(std::is_nothrow_move_constructible_v<D>)
+      : Results(ResTab), ZV(std::move(ZV)) {}
+  SolverResults(Table<N, D, L> &&ResTab, D ZV) = delete;
+
+  [[nodiscard]] L resultAt(ByConstRef<N> Stmt, ByConstRef<D> Node) const {
     return Results.get(Stmt, Node);
   }
 
-  std::unordered_map<D, L> resultsAt(ByConstRef<N> Stmt,
-                                     bool StripZero = false) const {
+  [[nodiscard]] std::unordered_map<D, L>
+  resultsAt(ByConstRef<N> Stmt, bool StripZero = false) const {
     std::unordered_map<D, L> Result = Results.row(Stmt);
     if (StripZero) {
-      for (auto It = Result.begin(); It != Result.end();) {
-        if (It->first == ZV) {
-          It = Result.erase(It);
-        } else {
-          ++It;
-        }
-      }
+      Result.erase(ZV);
     }
     return Result;
   }
@@ -60,7 +67,7 @@ public:
   template <typename ValueDomain = L,
             typename = typename std::enable_if_t<
                 std::is_same_v<ValueDomain, BinaryDomain>>>
-  std::set<D> ifdsResultsAt(ByConstRef<N> Stmt) const {
+  [[nodiscard]] std::set<D> ifdsResultsAt(ByConstRef<N> Stmt) const {
     std::set<D> KeySet;
     std::unordered_map<D, BinaryDomain> ResultMap = this->resultsAt(Stmt);
     for (auto FlowFact : ResultMap) {
@@ -73,6 +80,129 @@ public:
   getAllResultEntries() const {
     return Results.cellVec();
   }
+
+  template <typename ICFGTy>
+  void dumpResults(const ICFGTy &ICF, const NodePrinterBase<n_t> &NP,
+                   const DataFlowFactPrinterBase<d_t> &DP,
+                   const EdgeFactPrinterBase<l_t> &LP,
+                   llvm::raw_ostream &OS = llvm::outs()) {
+    using f_t = typename ICFGTy::f_t;
+
+    PAMM_GET_INSTANCE;
+    START_TIMER("DFA IDE Result Dumping", PAMM_SEVERITY_LEVEL::Full);
+    OS << "\n***************************************************************\n"
+       << "*                  Raw IDESolver results                      *\n"
+       << "***************************************************************\n";
+    auto Cells = Results.cellVec();
+    if (Cells.empty()) {
+      OS << "No results computed!" << '\n';
+    } else {
+      std::sort(
+          Cells.begin(), Cells.end(), [](const auto &Lhs, const auto &Rhs) {
+            if constexpr (std::is_same_v<n_t, const llvm::Instruction *>) {
+              return StringIDLess{}(getMetaDataID(Lhs.getRowKey()),
+                                    getMetaDataID(Rhs.getRowKey()));
+            } else {
+              // If non-LLVM IR is used
+              return Lhs.getRowKey() < Rhs.getRowKey();
+            }
+          });
+      n_t Prev = n_t{};
+      n_t Curr = n_t{};
+      f_t PrevFn = f_t{};
+      f_t CurrFn = f_t{};
+      for (unsigned I = 0; I < Cells.size(); ++I) {
+        Curr = Cells[I].getRowKey();
+        CurrFn = ICF.getFunctionOf(Curr);
+        if (PrevFn != CurrFn) {
+          PrevFn = CurrFn;
+          OS << "\n\n============ Results for function '" +
+                    ICF.getFunctionName(CurrFn) + "' ============\n";
+        }
+        if (Prev != Curr) {
+          Prev = Curr;
+          std::string NString = NP.NtoString(Curr);
+          std::string Line(NString.size(), '-');
+          OS << "\n\nN: " << NString << "\n---" << Line << '\n';
+        }
+        OS << "\tD: " << DP.DtoString(Cells[I].getColumnKey())
+           << " | V: " << LP.LtoString(Cells[I].getValue()) << '\n';
+      }
+    }
+    OS << '\n';
+    STOP_TIMER("DFA IDE Result Dumping", PAMM_SEVERITY_LEVEL::Full);
+  }
+
+  template <typename ICFGTy, typename ProblemTy>
+  void dumpResults(const ICFGTy &ICF, const ProblemTy &IDEProblem,
+                   llvm::raw_ostream &OS = llvm::outs()) {
+    dumpResults(ICF, IDEProblem, IDEProblem, IDEProblem, OS);
+  }
+
+private:
+  Table<N, D, L> &Results;
+  D ZV;
+};
+
+template <typename N, typename D, typename L> class OwningSolverResults {
+public:
+  using n_t = N;
+  using d_t = D;
+  using l_t = L;
+
+  OwningSolverResults(Table<N, D, L> ResTab,
+                      D ZV) noexcept(std::is_nothrow_move_constructible_v<D>)
+      : Results(std::move(ResTab)), ZV(ZV) {}
+
+  [[nodiscard]] operator SolverResults<N, D, L>() const &noexcept(
+      std::is_nothrow_copy_constructible_v<D>) {
+    return {Results, ZV};
+  }
+  operator SolverResults<N, D, L>() && = delete;
+
+  [[nodiscard]] ByConstRef<L> resultAt(ByConstRef<N> Stmt,
+                                       ByConstRef<D> Node) const {
+    return Results.get(Stmt, Node);
+  }
+
+  [[nodiscard]] std::unordered_map<D, L>
+  resultsAt(ByConstRef<N> Stmt, bool StripZero = false) const {
+    return static_cast<SolverResults<N, D, L>>(*this).resultsAt(Stmt,
+                                                                StripZero);
+  }
+
+  // this function only exists for IFDS problems which use BinaryDomain as their
+  // value domain L
+  template <typename ValueDomain = L,
+            typename = typename std::enable_if_t<
+                std::is_same_v<ValueDomain, BinaryDomain>>>
+  [[nodiscard]] std::set<D> ifdsResultsAt(ByConstRef<N> Stmt) const {
+    return static_cast<SolverResults<N, D, L>>(*this).ifdsResultsAt(Stmt);
+  }
+
+  [[nodiscard]] std::vector<typename Table<N, D, L>::Cell>
+  getAllResultEntries() const {
+    return Results.cellVec();
+  }
+
+  template <typename ICFGTy>
+  void dumpResults(const ICFGTy &ICF, const NodePrinterBase<n_t> &NP,
+                   const DataFlowFactPrinterBase<d_t> &DP,
+                   const ValuePrinter<l_t> LP,
+                   llvm::raw_ostream &OS = llvm::outs()) {
+    static_cast<SolverResults<N, D, L>>(*this).dumpResults(ICF, NP, DP, LP, OS);
+  }
+
+  template <typename ICFGTy, typename ProblemTy>
+  void dumpResults(const ICFGTy &ICF, const ProblemTy &IDEProblem,
+                   llvm::raw_ostream &OS = llvm::outs()) {
+    static_cast<SolverResults<N, D, L>>(*this).dumpResults(ICF, IDEProblem, OS);
+  }
+
+private:
+  // psr::Table is not const-enabled, so we have to give out mutable references
+  mutable Table<N, D, L> Results;
+  D ZV;
 };
 
 } // namespace psr

--- a/include/phasar/Utils/Printer.h
+++ b/include/phasar/Utils/Printer.h
@@ -72,17 +72,20 @@ template <typename T> struct TypePrinter {
   }
 };
 
-template <typename AnalysisDomainTy> struct EdgeFactPrinter {
-  using l_t = typename AnalysisDomainTy::l_t;
+template <typename L> struct EdgeFactPrinterBase {
+  using l_t = L;
 
-  virtual ~EdgeFactPrinter() = default;
+  virtual ~EdgeFactPrinterBase() = default;
 
-  virtual void printEdgeFact(llvm::raw_ostream &OS, l_t L) const = 0;
+  virtual void printEdgeFact(llvm::raw_ostream &OS, l_t Val) const = 0;
 
-  [[nodiscard]] std::string LtoString(l_t L) const { // NOLINT
-    return toStringBuilder(&EdgeFactPrinter::printEdgeFact, this, L);
+  [[nodiscard]] std::string LtoString(l_t Val) const { // NOLINT
+    return toStringBuilder(&EdgeFactPrinterBase::printEdgeFact, this, Val);
   }
 };
+
+template <typename AnalysisDomainTy>
+using EdgeFactPrinter = EdgeFactPrinterBase<typename AnalysisDomainTy::l_t>;
 
 template <typename AnalysisDomainTy> struct FunctionPrinter {
   using F = typename AnalysisDomainTy::f_t;

--- a/tools/example-tool/myphasartool.cpp
+++ b/tools/example-tool/myphasartool.cpp
@@ -57,9 +57,10 @@ int main(int Argc, const char **Argv) {
     llvm::outs() << "Testing IDE:\n";
     auto M = createAnalysisProblem<IDELinearConstantAnalysis>(HA, EntryPoints);
 
-    IDESolver T(M, &HA.getICFG());
-    T.solve();
-    T.dumpResults();
+    // Alternative way of solving an IFDS/IDEProblem:
+    auto IDEResults = solveIDEProblem(M, HA.getICFG());
+    IDEResults.dumpResults(HA.getICFG(), M);
+
   } else {
     llvm::errs() << "error: file does not contain a 'main' function!\n";
   }


### PR DESCRIPTION
The IDESolver has been found to consume a lot of memory, most of it being intermediate results. 

This PR aims at reducing the total memory overhead with two contributions:
1. The default solver configuration no longer enables recording the ESG edges in an additional map (this feature is anyway likely to be deprecated and replaced in the future). This has to be enabled explicitly. Note: `phasar-cli` already disables recordEdges by default
2. The solver results can be moved out of the IDESolver. This allows destructing the solver while retaining the solver results for subsequent analysis. To simplify the process new functions `solveIDEProblem` and `solveIFDSProblem` have been added