### PR TITLE
Fix Logger Macros

### DIFF
--- a/include/phasar/Utils/Logger.h
+++ b/include/phasar/Utils/Logger.h
@@ -105,43 +105,51 @@ private:
     computation;                                                               \
   }
 
-#define IS_LOG_ENABLED Logger::isLoggingEnabled()
+#define IS_LOG_ENABLED ::psr::Logger::isLoggingEnabled()
 
 #define IF_LOG_ENABLED(computation)                                            \
-  IF_LOG_ENABLED_BOOL(Logger::isLoggingEnabled(), computation)
+  IF_LOG_ENABLED_BOOL(::psr::Logger::isLoggingEnabled(), computation)
 
 #define PHASAR_LOG_LEVEL(level, message)                                       \
   IF_LOG_ENABLED_BOOL(                                                         \
-      Logger::isLoggingEnabled() && (level) >= Logger::getLoggerFilterLevel(), \
+      ::psr::Logger::isLoggingEnabled() &&                                     \
+          (::psr::SeverityLevel::level) >=                                     \
+              ::psr::Logger::getLoggerFilterLevel(),                           \
       do {                                                                     \
-        auto &S = Logger::getLogStream(level, std::nullopt);                   \
-        Logger::addLinePrefix(S, level, std::nullopt);                         \
+        auto &Stream = ::psr::Logger::getLogStream(                            \
+            ::psr::SeverityLevel::level, std::nullopt);                        \
+        ::psr::Logger::addLinePrefix(Stream, ::psr::SeverityLevel::level,      \
+                                     std::nullopt);                            \
         /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                       \
-        S << message << '\n';                                                  \
+        Stream << message << '\n';                                             \
       } while (false);)
 
 #define PHASAR_LOG(message) PHASAR_LOG_LEVEL(DEBUG, message)
 
 #define PHASAR_LOG_LEVEL_CAT(level, cat, message)                              \
   IF_LOG_ENABLED_BOOL(                                                         \
-      Logger::isLoggingEnabled() &&                                            \
-          (level) >= Logger::getLoggerFilterLevel() &&                         \
-          Logger::logCategory(cat, level),                                     \
+      ::psr::Logger::isLoggingEnabled() &&                                     \
+          (::psr::SeverityLevel::level) >=                                     \
+              ::psr::Logger::getLoggerFilterLevel() &&                         \
+          ::psr::Logger::logCategory(cat, ::psr::SeverityLevel::level),        \
       do {                                                                     \
-        auto &S = Logger::getLogStream(level, cat);                            \
-        Logger::addLinePrefix(S, level, cat);                                  \
+        auto &Stream =                                                         \
+            ::psr::Logger::getLogStream(::psr::SeverityLevel::level, cat);     \
+        ::psr::Logger::addLinePrefix(Stream, ::psr::SeverityLevel::level,      \
+                                     cat);                                     \
         /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                       \
-        S << message << '\n';                                                  \
+        Stream << message << '\n';                                             \
       } while (false);)
 
 #define PHASAR_LOG_CAT(cat, message)                                           \
   IF_LOG_ENABLED_BOOL(                                                         \
-      Logger::isLoggingEnabled() && Logger::logCategory(cat, std::nullopt),    \
+      ::psr::Logger::isLoggingEnabled() &&                                     \
+          ::psr::Logger::logCategory(cat, std::nullopt),                       \
       do {                                                                     \
-        auto &S = Logger::getLogStream(std::nullopt, cat);                     \
-        Logger::addLinePrefix(S, std::nullopt, cat);                           \
+        auto &Stream = ::psr::Logger::getLogStream(std::nullopt, cat);         \
+        ::psr::Logger::addLinePrefix(Stream, std::nullopt, cat);               \
         /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                       \
-        S << message << '\n';                                                  \
+        Stream << message << '\n';                                             \
       } while (false);)
 
 #else
@@ -149,10 +157,14 @@ private:
   {}
 #define IF_LOG_ENABLED(computation)                                            \
   {}
-#define PHASAR_LOG(computation) ((void)0)
-#define PHASAR_LOG_CAT(cat, message) ((void)0)
-#define PHASAR_LOG_LEVEL_CAT(level, cat, message) ((void)0)
-#define PHASAR_LOG_LEVEL(level, message) ((void)0)
+#define PHASAR_LOG(computation)                                                \
+  {}
+#define PHASAR_LOG_CAT(cat, message)                                           \
+  {}
+#define PHASAR_LOG_LEVEL_CAT(level, cat, message)                              \
+  {}
+#define PHASAR_LOG_LEVEL(level, message)                                       \
+  {}
 #define IS_LOG_ENABLED false
 #endif
 

--- a/unittests/Utils/CMakeLists.txt
+++ b/unittests/Utils/CMakeLists.txt
@@ -8,6 +8,10 @@ set(UtilsSources
   StableVectorTest.cpp
 )
 
+if(PHASAR_ENABLE_DYNAMIC_LOG)
+  list(APPEND UtilsSources LoggerTest.cpp)
+endif()
+
 foreach(TEST_SRC ${UtilsSources})
   add_phasar_unittest(${TEST_SRC})
 endforeach(TEST_SRC)

--- a/unittests/Utils/LoggerTest.cpp
+++ b/unittests/Utils/LoggerTest.cpp
@@ -1,0 +1,28 @@
+#include "phasar/Utils/Logger.h"
+
+#include "gtest/gtest.h"
+
+TEST(LoggerTest, BasicWithinPsr) {
+  using namespace psr;
+  Logger::initializeStderrLogger(SeverityLevel::INFO);
+  Logger::initializeStderrLogger(SeverityLevel::DEBUG, "LLVMAliasSet");
+  PHASAR_LOG("This should not be shown");
+  PHASAR_LOG_LEVEL(INFO, "Basic category-less message");
+  PHASAR_LOG_LEVEL_CAT(DEBUG, "LLVMAliasSet",
+                       "Some message specific to LLVMAliasSet");
+}
+
+TEST(LoggerTest, BasicOutsidePsr) {
+  psr::Logger::initializeStderrLogger(psr::SeverityLevel::INFO);
+  psr::Logger::initializeStderrLogger(psr::SeverityLevel::DEBUG,
+                                      "LLVMAliasSet");
+  PHASAR_LOG("This should not be shown");
+  PHASAR_LOG_LEVEL(INFO, "Basic category-less message");
+  PHASAR_LOG_LEVEL_CAT(DEBUG, "LLVMAliasSet",
+                       "Some message specific to LLVMAliasSet");
+}
+
+int main(int Argc, char **Argv) {
+  ::testing::InitGoogleTest(&Argc, Argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The logger macros `PHASAR_LOG*` currently only work if used within the namesapce `psr` or in an environment that uses `using namespace psr`. 
This PR fixes that issue.