### PR TITLE
Deserialization for LLVMBasedICFG

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -89,6 +89,9 @@ public:
                          Soundness S = Soundness::Soundy,
                          bool IncludeGlobals = true);
 
+  explicit LLVMBasedICFG(LLVMProjectIRDB *IRDB,
+                         const nlohmann::json &SerializedCG);
+
   ~LLVMBasedICFG();
 
   LLVMBasedICFG(const LLVMBasedICFG &) = delete;

--- a/include/phasar/PhasarLLVM/HelperAnalyses.h
+++ b/include/phasar/PhasarLLVM/HelperAnalyses.h
@@ -33,6 +33,7 @@ public:
                           std::optional<nlohmann::json> PrecomputedPTS,
                           AliasAnalysisType PTATy, bool AllowLazyPTS,
                           std::vector<std::string> EntryPoints,
+                          std::optional<nlohmann::json> PrecomputedCG,
                           CallGraphAnalysisType CGTy, Soundness SoundnessLevel,
                           bool AutoGlobalSupport) noexcept;
 
@@ -69,6 +70,7 @@ private:
   bool AllowLazyPTS{};
 
   // ICF
+  std::optional<nlohmann::json> PrecomputedCG;
   std::vector<std::string> EntryPoints;
   CallGraphAnalysisType CGTy{};
   Soundness SoundnessLevel{};

--- a/include/phasar/PhasarLLVM/HelperAnalysisConfig.h
+++ b/include/phasar/PhasarLLVM/HelperAnalysisConfig.h
@@ -21,6 +21,7 @@
 namespace psr {
 struct HelperAnalysisConfig {
   std::optional<nlohmann::json> PrecomputedPTS = std::nullopt;
+  std::optional<nlohmann::json> PrecomputedCG = std::nullopt;
   AliasAnalysisType PTATy = AliasAnalysisType::CFLAnders;
   CallGraphAnalysisType CGTy = CallGraphAnalysisType::OTF;
   Soundness SoundnessLevel = Soundness::Soundy;

--- a/lib/Controller/AnalysisController.cpp
+++ b/lib/Controller/AnalysisController.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/Controller/AnalysisController.h"
 
+#include "phasar//Utils/NlohmannLogging.h"
 #include "phasar/AnalysisStrategy/Strategies.h"
 #include "phasar/Controller/AnalysisControllerEmitterOptions.h"
 #include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
@@ -183,6 +184,10 @@ void AnalysisController::emitRequestedHelperAnalysisResults() {
   if (EmitterOptions & AnalysisControllerEmitterOptions::EmitCGAsDot) {
     WithResultFileOrStdout("/psr-cg.txt",
                            [this](auto &OS) { HA.getICFG().print(OS); });
+  }
+  if (EmitterOptions & AnalysisControllerEmitterOptions::EmitCGAsJson) {
+    WithResultFileOrStdout(
+        "/psr-cg.json", [this](auto &OS) { OS << HA.getICFG().getAsJson(); });
   }
 
   if (EmitterOptions &

--- a/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/LLVMBasedICFG.cpp
@@ -366,9 +366,8 @@ LLVMBasedICFG::LLVMBasedICFG(LLVMProjectIRDB *IRDB,
                              llvm::ArrayRef<std::string> EntryPoints,
                              LLVMTypeHierarchy *TH, LLVMAliasInfoRef PT,
                              Soundness S, bool IncludeGlobals)
-    : TH(TH) {
+    : IRDB(IRDB), TH(TH) {
   assert(IRDB != nullptr);
-  this->IRDB = IRDB;
 
   Builder B{IRDB, this, PT};
   LLVMAliasInfo PTOwn;
@@ -396,6 +395,51 @@ LLVMBasedICFG::LLVMBasedICFG(LLVMProjectIRDB *IRDB,
       INFO, "LLVMBasedICFG",
       "Finished ICFG construction "
           << std::chrono::steady_clock::now().time_since_epoch().count());
+}
+
+LLVMBasedICFG::LLVMBasedICFG(LLVMProjectIRDB *IRDB,
+                             const nlohmann::json &SerializedCG)
+    : IRDB(IRDB) {
+  assert(IRDB != nullptr);
+
+  // llvm::outs() << "Load precomputed call-graph from JSON\n";
+
+  auto It = SerializedCG.find(PhasarConfig::JsonCallGraphID().str());
+
+  if (It == SerializedCG.end()) {
+    PHASAR_LOG_LEVEL_CAT(ERROR, "LLVMBasedICFG",
+                         "Cannot deserialize call-graph from JSON: No key '"
+                             << PhasarConfig::JsonCallGraphID() << "' present");
+    return;
+  }
+
+  const auto &Edges = It.value();
+
+  CallersOf.reserve(Edges.size());
+  CalleesAt.reserve(Edges.size());
+  VertexFunctions.reserve(Edges.size());
+
+  for (const auto &[FunName, CallerIDs] : Edges.items()) {
+    const auto *Fun = IRDB->getFunction(FunName);
+    if (!Fun) {
+      PHASAR_LOG_LEVEL_CAT(WARNING, "LLVMBasedICFG",
+                           "Invalid function name: " << FunName);
+      continue;
+    }
+    auto *CEdges = addFunctionVertex(Fun);
+    CEdges->reserve(CallerIDs.size());
+
+    for (const auto &JId : CallerIDs) {
+      auto Id = JId.get<size_t>();
+      const auto *CS = IRDB->getInstruction(Id);
+      if (!CS) {
+        PHASAR_LOG_LEVEL_CAT(WARNING, "LLVMBasedICFG",
+                             "Invalid CAll-Instruction Id: " << Id);
+      }
+
+      addCallEdge(CS, Fun);
+    }
+  }
 }
 
 LLVMBasedICFG::~LLVMBasedICFG() = default;
@@ -504,22 +548,12 @@ void LLVMBasedICFG::printImpl(llvm::raw_ostream &OS) const {
 [[nodiscard]] nlohmann::json LLVMBasedICFG::getAsJsonImpl() const {
   nlohmann::json J;
 
-  for (size_t Vtx = 0, VtxEnd = VertexFunctions.size(); Vtx != VtxEnd; ++Vtx) {
-    auto VtxFunName = VertexFunctions[Vtx]->getName().str();
-    J[PhasarConfig::JsonCallGraphID().str()][VtxFunName] =
-        nlohmann::json::array();
+  auto &Edges = J[PhasarConfig::JsonCallGraphID().str()];
+  for (const auto &[Fun, Callers] : CallersOf) {
+    auto &JCallers = Edges[Fun->getName().str()];
 
-    for (const auto &Inst : llvm::instructions(VertexFunctions[Vtx])) {
-      if (!llvm::isa<llvm::CallBase>(Inst)) {
-        continue;
-      }
-
-      if (auto It = CalleesAt.find(&Inst); It != CalleesAt.end()) {
-        for (const auto *Succ : *It->second) {
-          J[PhasarConfig::JsonCallGraphID().str()][VtxFunName].push_back(
-              Succ->getName().str());
-        }
-      }
+    for (const auto *CS : *Callers) {
+      JCallers.push_back(IRDB->getInstructionId(CS));
     }
   }
 

--- a/lib/PhasarLLVM/DB/LLVMProjectIRDB.cpp
+++ b/lib/PhasarLLVM/DB/LLVMProjectIRDB.cpp
@@ -260,5 +260,5 @@ const llvm::Value *psr::fromMetaDataId(const LLVMProjectIRDB &IRDB,
   }
 
   auto IdNr = ParseInt(Id);
-  return IdNr ? IRDB.getInstruction(*IdNr) : nullptr;
+  return IdNr ? IRDB.getValueFromId(*IdNr) : nullptr;
 }

--- a/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
@@ -100,7 +100,7 @@ LLVMAliasSet::LLVMAliasSet(LLVMProjectIRDB *IRDB,
   assert(IRDB != nullptr);
   // Assume, we already have validated the json schema
 
-  llvm::outs() << "Load precomputed points-to info from JSON\n";
+  // llvm::outs() << "Load precomputed points-to info from JSON\n";
 
   const auto &Sets = SerializedPTS.at("AliasSets");
   assert(Sets.is_array());

--- a/unittests/PhasarLLVM/ControlFlow/CMakeLists.txt
+++ b/unittests/PhasarLLVM/ControlFlow/CMakeLists.txt
@@ -9,6 +9,7 @@ set(ControlFlowSources
 	LLVMBasedBackwardICFGTest.cpp
 	LLVMBasedICFGExportTest.cpp
 	LLVMBasedICFGGlobCtorDtorTest.cpp
+	LLVMBasedICFGSerializationTest.cpp
 )
 
 foreach(TEST_SRC ${ControlFlowSources})

--- a/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFGSerializationTest.cpp
+++ b/unittests/PhasarLLVM/ControlFlow/LLVMBasedICFGSerializationTest.cpp
@@ -1,0 +1,155 @@
+
+#include "phasar/ControlFlow/CallGraphAnalysisType.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
+#include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
+#include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
+
+#include "TestConfig.h"
+#include "gtest/gtest.h"
+
+class LLVMBasedICFGGSerializationTest : public ::testing::Test {
+protected:
+  static constexpr auto PathToLLFiles = PHASAR_BUILD_SUBFOLDER("call_graphs/");
+
+  void serAndDeser(const llvm::Twine &IRFile) {
+    using namespace std::string_literals;
+
+    psr::LLVMProjectIRDB IRDB(PathToLLFiles + IRFile);
+
+    psr::LLVMBasedICFG ICF(&IRDB, psr::CallGraphAnalysisType::OTF, {"main"s});
+    auto Ser = ICF.getAsJson();
+
+    psr::LLVMBasedICFG Deser(&IRDB, Ser);
+
+    compareResults(ICF, Deser);
+  }
+
+  void compareResults(const psr::LLVMBasedICFG &Orig,
+                      const psr::LLVMBasedICFG &Deser) {
+    EXPECT_EQ(Orig.getAllVertexFunctions().size(),
+              Deser.getAllVertexFunctions().size());
+
+    {
+      llvm::DenseSet<const llvm::Function *> DeserFuns(
+          Deser.getAllVertexFunctions().begin(),
+          Deser.getAllVertexFunctions().end());
+      for (const auto *Fun : Orig.getAllVertexFunctions()) {
+        EXPECT_TRUE(DeserFuns.contains(Fun))
+            << "Deserialized ICFG does not contain vertex function "
+            << Fun->getName().str();
+      }
+    }
+
+    for (const auto *Fun : Orig.getAllVertexFunctions()) {
+
+      const auto &Calls = Orig.getCallsFromWithin(Fun);
+
+      for (const auto *CS : Calls) {
+        llvm::DenseSet<const llvm::Function *> DeserCallees(
+            Deser.getCalleesOfCallAt(CS).begin(),
+            Deser.getCalleesOfCallAt(CS).end());
+        EXPECT_EQ(Orig.getCalleesOfCallAt(CS).size(), DeserCallees.size());
+
+        for (const auto *OrigCallee : Orig.getCalleesOfCallAt(CS)) {
+          EXPECT_TRUE(DeserCallees.contains(OrigCallee))
+              << "Deserialized ICFG does not contain call to "
+              << OrigCallee->getName().str() << " from "
+              << psr::llvmIRToString(CS);
+        }
+      }
+    }
+  }
+};
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG01) {
+  serAndDeser("static_callsite_1_c.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG02) {
+  serAndDeser("static_callsite_2_c.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG03) {
+  serAndDeser("static_callsite_3_c.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG04) {
+  serAndDeser("static_callsite_4_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG05) {
+  serAndDeser("static_callsite_5_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG06) {
+  serAndDeser("static_callsite_6_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG07) {
+  serAndDeser("static_callsite_7_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG08) {
+  serAndDeser("static_callsite_8_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG09) {
+  serAndDeser("static_callsite_9_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG10) {
+  serAndDeser("static_callsite_10_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG11) {
+  serAndDeser("static_callsite_11_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG12) {
+  serAndDeser("static_callsite_12_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFG13) {
+  serAndDeser("static_callsite_13_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV1) {
+  serAndDeser("virtual_call_1_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV2) {
+  serAndDeser("virtual_call_2_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV3) {
+  serAndDeser("virtual_call_3_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV4) {
+  serAndDeser("virtual_call_4_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV5) {
+  serAndDeser("virtual_call_5_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV6) {
+  serAndDeser("virtual_call_6_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV7) {
+  serAndDeser("virtual_call_7_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV8) {
+  serAndDeser("virtual_call_8_cpp.ll");
+}
+
+TEST_F(LLVMBasedICFGGSerializationTest, SerICFGV9) {
+  serAndDeser("virtual_call_9_cpp.ll");
+}
+
+int main(int Argc, char **Argv) {
+  ::testing::InitGoogleTest(&Argc, Argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add support for deserializing an LLVMBasedICFG from json. For that to work properly the LLVMBasedICFG::getAsJson() function has been refactored -- the result format is different now.

Additionally fixed psr::fromMetaDataId that is required for both LLVMBasedICFG- and LLVMAliasSet deserialization.