### PR TITLE
Fix InitialSeeds for IFDS

### DIFF
--- a/include/phasar/DataFlow/IfdsIde/InitialSeeds.h
+++ b/include/phasar/DataFlow/IfdsIde/InitialSeeds.h
@@ -32,7 +32,7 @@ public:
   InitialSeeds(const std::map<N, std::set<D>> &Seeds) {
     for (const auto &[Node, Facts] : Seeds) {
       for (const auto &Fact : Facts) {
-        this->Seeds[Node][Fact] = BinaryDomain::TOP;
+        this->Seeds[Node][Fact] = BinaryDomain::BOTTOM;
       }
     }
   }
@@ -42,7 +42,7 @@ public:
   template <typename LL = L,
             typename = std::enable_if_t<std::is_same_v<LL, BinaryDomain>>>
   void addSeed(N Node, D Fact) {
-    addSeed(Node, Fact, BinaryDomain::TOP);
+    addSeed(Node, Fact, BinaryDomain::BOTTOM);
   }
 
   void addSeed(N Node, D Fact, L Value) {

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMSolverResults.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMSolverResults.h
@@ -21,6 +21,10 @@
 
 namespace psr::detail {
 
+/// FIXME: This is not entirely correct: Does not skip ignored statements and
+/// does not work for backwards analyses.
+/// The right way would be to ask the ICFG, but we don't have a reference to it
+/// here yet (TODO!)
 template <typename Derived, typename N, typename D, typename L>
 template <typename NTy>
 auto SolverResultsBase<Derived, N, D, L>::resultsAtInLLVMSSA(


### PR DESCRIPTION
The default edge value of the `InitialSeeds` for IFDS analyses is `TOP` (the bottom value of the binary lattice) indicating "no information". This is incorrect as holding IFDS dataflow facts semantically have to be annotated with the top value of the binary lattice, which is called `BOTTOM` in phasar.
This issue prevents the `IDESolver` from computing IFDS results at certain call sites.


This PR solves that problem by correctly assigning the `BOTTOM` edge value to the initial seeds of IFDS analyses.

Should fix #629.