### PR TITLE
Fix TaintConfig Initial Seeds

### DIFF
--- a/lib/PhasarLLVM/TaintConfig/CMakeLists.txt
+++ b/lib/PhasarLLVM/TaintConfig/CMakeLists.txt
@@ -5,6 +5,8 @@ set(PHASAR_LINK_LIBS
   phasar_db
   phasar_llvm_db
   phasar_llvm_utils
+  phasar_controlflow
+  phasar_llvm_controlflow
 )
 
 set(LLVM_LINK_COMPONENTS

--- a/lib/PhasarLLVM/TaintConfig/LLVMTaintConfig.cpp
+++ b/lib/PhasarLLVM/TaintConfig/LLVMTaintConfig.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/TaintConfig/LLVMTaintConfig.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/TaintConfig/TaintConfigBase.h"
 #include "phasar/PhasarLLVM/Utils/Annotation.h"
@@ -481,8 +482,10 @@ LLVMTaintConfig::makeInitialSeedsImpl() const {
       InitialSeeds[Inst].insert(Inst);
     } else if (const auto *Arg = llvm::dyn_cast<llvm::Argument>(SourceValue);
                Arg && !Arg->getParent()->isDeclaration()) {
-      const auto *FunFirstInst = &Arg->getParent()->getEntryBlock().front();
-      InitialSeeds[FunFirstInst].insert(Arg);
+      LLVMBasedCFG C;
+      for (const auto *SP : C.getStartPointsOf(Arg->getParent())) {
+        InitialSeeds[SP].insert(Arg);
+      }
     }
   }
   return InitialSeeds;


### PR DESCRIPTION
The `makeInitialSeeds` function from `LLVMTaintConfig` may generate seeds at skipped (e.g., debug-) instructions leading the IDESolver to produce no IDE edge values generated from those seeds