### PR TITLE
added descriptions to TaintConfigSchema.json to explain its semantics

### DIFF
--- a/config/TaintConfigSchema.json
+++ b/config/TaintConfigSchema.json
@@ -14,29 +14,36 @@ R"(
             "description": "Version of this taint configuration"
         },
         "functions": {
+            "description": "Array of functions you want to include in your analysis",
             "type": "array",
             "properties": {
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the function in the llvm IR (look for possible mangling)"
                 },
                 "ret": {
-                    "enum": ["source", "sink", "sanitizer"]
+                    "enum": ["source", "sink", "sanitizer"],
+                    "description": "tag the returned value as source sink or sanitizer"
                 },
                 "params": {
+                    "description": "tags function parameters as source, sink or sanitizer",
                     "properties": {
                         "source": {
+                            "description": "zero based indices of source tags",
                             "type": "array",
                             "properties": {
                                 "type": ["number", "string"]
                             }
                         },
                         "sink": {
+                            "description": "zero based indices of sink tags. A Leak is detected if the function gets called with source taged value in this indices.",
                             "type": "array",
                             "properties": {
                                 "type": ["number", "string"]
                             }
                         },
                         "sanitizer": {
+                            "description": "zero based indices of sanitizer tags",
                             "type": "array",
                             "properties": {
                                 "type": ["number", "string"]


### PR DESCRIPTION
I started playing around with phasar a bit to look if I can use it on llvm code created by rust. At first I have used the analysis-config wrong so I wrote some descriptions into the schema. Maybe this can help future users too and I hope my descriptions are right. 