### PR TITLE
Template Typestate Analysis

### DIFF
--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.h
@@ -10,137 +10,51 @@
 #ifndef PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_PROBLEMS_IDETYPESTATEANALYSIS_H
 #define PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_PROBLEMS_IDETYPESTATEANALYSIS_H
 
+#include "phasar/DataFlow/IfdsIde/EdgeFunction.h"
+#include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
+#include "phasar/DataFlow/IfdsIde/FlowFunctions.h"
 #include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h"
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMFlowFunctions.h"
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/Domain/LLVMAnalysisDomain.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMAliasInfo.h"
+#include "phasar/Utils/ByRef.h"
+#include "phasar/Utils/JoinLattice.h"
+#include "phasar/Utils/Logger.h"
 #include "phasar/Utils/Printer.h"
+#include "phasar/Utils/TypeTraits.h"
 
-#include "llvm/IR/InstrTypes.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Demangle/Demangle.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Value.h"
 
 #include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <utility>
-
-namespace llvm {
-class CallBase;
-class Instruction;
-class Function;
-class Value;
-} // namespace llvm
 
 namespace psr {
 
 class LLVMBasedICFG;
 class LLVMTypeHierarchy;
-struct TypeStateDescription;
 
-struct TypeState {
-  int State{};
-  std::string (*Print)(int) = nullptr;
+namespace detail {
+class IDETypeStateAnalysisBase {
+protected:
+  template <typename IsTypeNameOfInterestFn>
+  IDETypeStateAnalysisBase(
+      LLVMAliasInfoRef PT,
+      IsTypeNameOfInterestFn &&IsTypeNameOfInterest) noexcept
+      : PT(PT), IsTypeNameOfInterest(std::forward<IsTypeNameOfInterestFn>(
+                    IsTypeNameOfInterest)) {}
 
-  TypeState() noexcept = default;
-  TypeState(int State, std::string (*Print)(int)) noexcept
-      : State(State), Print{Print} {}
-
-  operator int() const noexcept { return State; }
-};
-
-struct IDETypeStateAnalysisDomain : public LLVMAnalysisDomainDefault {
-  using l_t = TypeState;
-};
-
-class IDETypeStateAnalysis
-    : public IDETabulationProblem<IDETypeStateAnalysisDomain> {
-public:
-  using IDETabProblemType = IDETabulationProblem<IDETypeStateAnalysisDomain>;
-  using typename IDETabProblemType::d_t;
-  using typename IDETabProblemType::f_t;
-  using typename IDETabProblemType::i_t;
-  using typename IDETabProblemType::l_t;
-  using typename IDETabProblemType::n_t;
-  using typename IDETabProblemType::t_t;
-  using typename IDETabProblemType::v_t;
-
-  using ConfigurationTy = TypeStateDescription;
-
-  IDETypeStateAnalysis(const LLVMProjectIRDB *IRDB, LLVMAliasInfoRef PT,
-                       const TypeStateDescription *TSD,
-                       std::vector<std::string> EntryPoints = {"main"});
-
-  ~IDETypeStateAnalysis() override = default;
-
-  // start formulating our analysis by specifying the parts required for IFDS
-
-  FlowFunctionPtrType getNormalFlowFunction(n_t Curr, n_t Succ) override;
-
-  FlowFunctionPtrType getCallFlowFunction(n_t CallSite, f_t DestFun) override;
-
-  FlowFunctionPtrType getRetFlowFunction(n_t CallSite, f_t CalleeFun,
-                                         n_t ExitStmt, n_t RetSite) override;
-
-  FlowFunctionPtrType
-  getCallToRetFlowFunction(n_t CallSite, n_t RetSite,
-                           llvm::ArrayRef<f_t> Callees) override;
-
-  FlowFunctionPtrType getSummaryFlowFunction(n_t CallSite,
-                                             f_t DestFun) override;
-
-  InitialSeeds<n_t, d_t, l_t> initialSeeds() override;
-
-  [[nodiscard]] d_t createZeroValue() const;
-
-  [[nodiscard]] bool isZeroValue(d_t Fact) const override;
-
-  // in addition provide specifications for the IDE parts
-
-  EdgeFunction<l_t> getNormalEdgeFunction(n_t Curr, d_t CurrNode, n_t Succ,
-                                          d_t SuccNode) override;
-
-  EdgeFunction<l_t> getCallEdgeFunction(n_t CallSite, d_t SrcNode,
-                                        f_t DestinationFunction,
-                                        d_t DestNode) override;
-
-  EdgeFunction<l_t> getReturnEdgeFunction(n_t CallSite, f_t CalleeFunction,
-                                          n_t ExitInst, d_t ExitNode,
-                                          n_t RetSite, d_t RetNode) override;
-
-  EdgeFunction<l_t>
-  getCallToRetEdgeFunction(n_t CallSite, d_t CallNode, n_t RetSite,
-                           d_t RetSiteNode,
-                           llvm::ArrayRef<f_t> Callees) override;
-
-  EdgeFunction<l_t> getSummaryEdgeFunction(n_t CallSite, d_t CallNode,
-                                           n_t RetSite,
-                                           d_t RetSiteNode) override;
-
-  l_t topElement() override;
-
-  l_t bottomElement() override;
-
-  /**
-   * We have a lattice with BOTTOM representing all information
-   * and TOP representing no information. The other lattice elements
-   * are defined by the type state description, i.e. represented by the
-   * states of the finite state machine.
-   *
-   * @note Only one-level lattice's are handled currently
-   */
-  l_t join(l_t Lhs, l_t Rhs) override;
-
-  EdgeFunction<l_t> allTopFunction() override;
-
-  void emitTextReport(const SolverResults<n_t, d_t, l_t> &SR,
-                      llvm::raw_ostream &OS = llvm::outs()) override;
-
-private:
-  const TypeStateDescription *TSD{};
-  std::string (*Print)(int) = nullptr;
-  std::map<const llvm::Value *, LLVMAliasInfo::AliasSetTy> AliasCache;
-  LLVMAliasInfoRef PT{};
-  std::map<const llvm::Value *, std::set<const llvm::Value *>>
-      RelevantAllocaCache;
-
+  using d_t = const llvm::Value *;
+  using container_type = std::set<d_t>;
   /**
    * @brief Returns all alloca's that are (indirect) aliases of V.
    *
@@ -150,7 +64,7 @@ private:
    * for each alias of V we collect related alloca instructions by checking
    * load and store instructions for used alloca's.
    */
-  std::set<d_t> getRelevantAllocas(d_t V);
+  container_type getRelevantAllocas(d_t V);
 
   /**
    * @brief Returns whole-module aliases of V.
@@ -161,25 +75,631 @@ private:
    * might become unnecessary once PhASAR's AliasGraph starts using a cache
    * itself.
    */
-  std::set<d_t> getWMAliasSet(d_t V);
+  container_type getWMAliasSet(d_t V);
 
   /**
    * @brief Provides whole module aliases and relevant alloca's of V.
    */
-  std::set<d_t> getWMAliasesAndAllocas(d_t V);
+  container_type getWMAliasesAndAllocas(d_t V);
 
   /**
    * @brief Provides local aliases and relevant alloca's of V.
    */
-  std::set<d_t> getLocalAliasesAndAllocas(d_t V, const std::string &Fname);
+  container_type getLocalAliasesAndAllocas(d_t V, llvm::StringRef Fname);
 
   /**
    * @brief Checks if the type machtes the type of interest.
    */
   bool hasMatchingType(d_t V);
+
+private:
+  std::map<const llvm::Value *, LLVMAliasInfo::AliasSetTy> AliasCache;
+  LLVMAliasInfoRef PT{};
+  std::map<const llvm::Value *, std::set<const llvm::Value *>>
+      RelevantAllocaCache;
+  std::function<bool(llvm::StringRef)> IsTypeNameOfInterest;
+};
+} // namespace detail
+
+template <typename TypeStateDescriptionTy>
+struct IDETypeStateAnalysisDomain : public LLVMAnalysisDomainDefault {
+  using l_t = typename TypeStateDescriptionTy::State;
 };
 
-std::string LToString(TypeState S);
+template <typename TypeStateDescriptionTy>
+class IDETypeStateAnalysis
+    : public IDETabulationProblem<
+          IDETypeStateAnalysisDomain<TypeStateDescriptionTy>>,
+      private detail::IDETypeStateAnalysisBase {
+public:
+  using IDETabProblemType =
+      IDETabulationProblem<IDETypeStateAnalysisDomain<TypeStateDescriptionTy>>;
+  using typename IDETabProblemType::container_type;
+  using typename IDETabProblemType::d_t;
+  using typename IDETabProblemType::f_t;
+  using typename IDETabProblemType::i_t;
+  using typename IDETabProblemType::l_t;
+  using typename IDETabProblemType::n_t;
+  using typename IDETabProblemType::t_t;
+  using typename IDETabProblemType::v_t;
+
+  using typename IDETabProblemType::FlowFunctionPtrType;
+  using ConfigurationTy = TypeStateDescriptionTy;
+
+private:
+  static AllBottom<l_t>
+  makeAllBottom(const TypeStateDescriptionTy *TSD) noexcept {
+    if constexpr (HasJoinLatticeTraits<l_t>) {
+      return AllBottom<l_t>{};
+    } else {
+      return AllBottom<l_t>{TSD->bottom()};
+    }
+  }
+  template <typename LL = l_t,
+            typename = std::enable_if_t<HasJoinLatticeTraits<LL>>>
+  static AllBottom<l_t> makeAllBottom(EmptyType) noexcept {
+    return AllBottom<l_t>{};
+  }
+  static bool isBottom(l_t State, const TypeStateDescriptionTy *TSD) noexcept {
+    if constexpr (HasJoinLatticeTraits<l_t>) {
+      return State == JoinLatticeTraits<l_t>::bottom();
+    } else {
+      return State == TSD->bottom();
+    }
+  }
+  template <typename LL = l_t,
+            typename = std::enable_if_t<HasJoinLatticeTraits<LL>>>
+  static bool isBottom(l_t State, EmptyType) noexcept {
+    return State == JoinLatticeTraits<l_t>::bottom();
+  }
+
+  struct TSEdgeFunctionComposer : EdgeFunctionComposer<l_t> {
+    TSEdgeFunctionComposer(EdgeFunction<l_t> First, EdgeFunction<l_t> Second,
+                           const TypeStateDescriptionTy *TSD) noexcept
+        : EdgeFunctionComposer<l_t>{std::move(First), std::move(Second)} {
+      if constexpr (!HasJoinLatticeTraits<l_t>) {
+        BotElement = TSD->bottom();
+      }
+    }
+
+    [[no_unique_address]] std::conditional_t<HasJoinLatticeTraits<l_t>,
+                                             EmptyType, l_t>
+        BotElement{};
+
+    static EdgeFunction<l_t> join(EdgeFunctionRef<TSEdgeFunctionComposer> This,
+                                  const EdgeFunction<l_t> &OtherFunction) {
+      if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
+        return Default;
+      }
+      if constexpr (HasJoinLatticeTraits<l_t>) {
+        return AllBottom<l_t>{};
+      } else {
+        return AllBottom<l_t>{This->BotElement};
+      }
+    }
+  };
+
+  struct TSEdgeFunction {
+    using l_t = l_t;
+    const TypeStateDescriptionTy *TSD{};
+    // XXX: Do we really need a string here? Can't we just use an integer or sth
+    // else that is cheap?
+    std::string Token;
+    const llvm::CallBase *CallSite{};
+
+    [[nodiscard]] l_t computeTarget(l_t Source) const {
+
+      // assert((Source != TSD->top()) && "Error: call computeTarget with
+      // TOP\n");
+
+      auto CurrentState = TSD->getNextState(
+          Token, Source == TSD->top() ? TSD->uninit() : Source, CallSite);
+      PHASAR_LOG_LEVEL(DEBUG, "State machine transition: ("
+                                  << Token << " , " << LToString(Source)
+                                  << ") -> " << LToString(CurrentState));
+      return CurrentState;
+    }
+
+    static EdgeFunction<l_t> compose(EdgeFunctionRef<TSEdgeFunction> This,
+                                     const EdgeFunction<l_t> &SecondFunction) {
+      if (auto Default = defaultComposeOrNull(This, SecondFunction)) {
+        return Default;
+      }
+
+      return TSEdgeFunctionComposer{This, SecondFunction, This->TSD};
+    }
+
+    static EdgeFunction<l_t> join(EdgeFunctionRef<TSEdgeFunction> This,
+                                  const EdgeFunction<l_t> &OtherFunction) {
+      if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
+        return Default;
+      }
+
+      return makeAllBottom(This->TSD);
+    }
+
+    bool operator==(const TSEdgeFunction &Other) const {
+      return CallSite == Other.CallSite && Token == Other.Token;
+    }
+
+    friend llvm::raw_ostream &print(llvm::raw_ostream &OS,
+                                    const TSEdgeFunction &TSE) {
+      return OS << "TSEF(" << TSE.Token << " at "
+                << llvmIRToShortString(TSE.CallSite) << ")";
+    }
+  };
+
+  struct TSConstant : ConstantEdgeFunction<l_t> {
+    std::conditional_t<HasJoinLatticeTraits<l_t>, EmptyType,
+                       const TypeStateDescriptionTy *>
+        TSD{};
+
+    TSConstant(l_t Value, const TypeStateDescriptionTy *TSD) noexcept
+        : ConstantEdgeFunction<l_t>{Value} {
+      if constexpr (!HasJoinLatticeTraits<l_t>) {
+        this->TSD = TSD;
+      }
+    }
+
+    template <typename LL = l_t,
+              typename = std::enable_if_t<HasJoinLatticeTraits<LL>>>
+    TSConstant(l_t Value, EmptyType = {}) noexcept
+        : ConstantEdgeFunction<l_t>{Value} {
+      if constexpr (!HasJoinLatticeTraits<l_t>) {
+        this->TSD = TSD;
+      }
+    }
+
+    /// XXX: Cannot default compose() and join(), because l_t does not implement
+    /// JoinLatticeTraits (because bottom value is not constant)
+    template <typename ConcreteEF>
+    static EdgeFunction<l_t> compose(EdgeFunctionRef<ConcreteEF> This,
+                                     const EdgeFunction<l_t> &SecondFunction) {
+
+      if (auto Default = defaultComposeOrNull(This, SecondFunction)) {
+        return Default;
+      }
+
+      l_t Ret = SecondFunction.computeTarget(This->Value);
+      if (Ret == This->Value) {
+        return This;
+      }
+      if (isBottom(Ret, This->TSD)) {
+        return makeAllBottom(This->TSD);
+      }
+
+      return TSConstant{Ret, This->TSD};
+    }
+
+    template <typename ConcreteEF>
+    static EdgeFunction<l_t> join(EdgeFunctionRef<ConcreteEF> This,
+                                  const EdgeFunction<l_t> &OtherFunction) {
+      if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
+        return Default;
+      }
+
+      auto Top = [TSD = This->TSD] {
+        if constexpr (HasJoinLatticeTraits<l_t>) {
+          return JoinLatticeTraits<l_t>::top();
+        } else {
+          return TSD->top();
+        }
+      }();
+      if (const auto *C = llvm::dyn_cast<TSConstant>(OtherFunction)) {
+        if (C->Value == This->Value || C->Value == Top) {
+          return This;
+        }
+        if (This->Value == Top) {
+          return OtherFunction;
+        }
+      }
+      return makeAllBottom(This->TSD);
+    }
+
+    bool operator==(const TSConstant &Other) const noexcept {
+      return this->Value == Other.Value;
+    }
+
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                         const TSConstant &EF) {
+      return OS << "TSConstant[" << LToString(EF.Value) << "]";
+    }
+  };
+
+public:
+  IDETypeStateAnalysis(const LLVMProjectIRDB *IRDB, LLVMAliasInfoRef PT,
+                       const TypeStateDescriptionTy *TSD,
+                       std::vector<std::string> EntryPoints = {"main"})
+      : IDETabProblemType(IRDB, std::move(EntryPoints), createZeroValue()),
+        IDETypeStateAnalysisBase(PT,
+                                 [TSD](llvm::StringRef Name) {
+                                   return Name.contains(
+                                       TSD->getTypeNameOfInterest());
+                                 }),
+        TSD(TSD) {
+    assert(TSD != nullptr);
+    assert(PT);
+  }
+
+  ~IDETypeStateAnalysis() override = default;
+
+  // start formulating our analysis by specifying the parts required for IFDS
+
+  FlowFunctionPtrType getNormalFlowFunction(n_t Curr, n_t Succ) override {
+    // Check if Alloca's type matches the target type. If so, generate from zero
+    // value.
+    if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
+      if (hasMatchingType(Alloca)) {
+        return this->generateFromZero(Alloca);
+      }
+    }
+    // Check load instructions for target type. Generate from the loaded value
+    // and kill the load instruction if it was generated previously (strong
+    // update!).
+    if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
+      if (hasMatchingType(Load)) {
+        return transferFlow(Load, Load->getPointerOperand());
+      }
+    }
+    if (const auto *Gep = llvm::dyn_cast<llvm::GetElementPtrInst>(Curr)) {
+      if (hasMatchingType(Gep->getPointerOperand())) {
+        return identityFlow<d_t>();
+        // return lambdaFlow<d_t>([=](d_t Source) -> std::set<d_t> {
+        //   // if (Source == Gep->getPointerOperand()) {
+        //   //  return {Source, Gep};
+        //   //}
+        //   return {Source};
+        // });
+      }
+    }
+    // Check store instructions for target type. Perform a strong update, i.e.
+    // kill the alloca pointed to by the pointer-operand and all alloca's
+    // related to the value-operand and then generate them from the
+    // value-operand.
+    if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
+      if (hasMatchingType(Store)) {
+        auto RelevantAliasesAndAllocas = getLocalAliasesAndAllocas(
+            Store->getPointerOperand(), // pointer- or value operand???
+            // Store->getValueOperand(),
+            Curr->getFunction()->getName().str());
+
+        RelevantAliasesAndAllocas.insert(Store->getValueOperand());
+        return lambdaFlow<d_t>(
+            [Store, AliasesAndAllocas = std::move(RelevantAliasesAndAllocas)](
+                d_t Source) -> container_type {
+              // We kill all relevant loacal aliases and alloca's
+              if (Source == Store->getPointerOperand()) {
+                // XXX: later kill must-aliases too
+                return {};
+              }
+              // Generate all local aliases and relevant alloca's from the
+              // stored value
+              if (Source == Store->getValueOperand()) {
+                return AliasesAndAllocas;
+              }
+              return {Source};
+            });
+      }
+    }
+    return identityFlow<d_t>();
+  }
+
+  FlowFunctionPtrType getCallFlowFunction(n_t CallSite, f_t DestFun) override {
+    // Kill all data-flow facts if we hit a function of the target API.
+    // Those functions are modled within Call-To-Return.
+    if (TSD->isAPIFunction(llvm::demangle(DestFun->getName().str()))) {
+      return killAllFlows<d_t>();
+    }
+    // Otherwise, if we have an ordinary function call, we can just use the
+    // standard mapping.
+    if (const auto *Call = llvm::dyn_cast<llvm::CallBase>(CallSite)) {
+      return mapFactsToCallee(Call, DestFun);
+    }
+    llvm::report_fatal_error("callSite not a CallInst nor a InvokeInst");
+  }
+
+  FlowFunctionPtrType getRetFlowFunction(n_t CallSite, f_t CalleeFun,
+                                         n_t ExitStmt, n_t RetSite) override {
+
+    /// TODO: Implement return-POI in LLVMFlowFunctions.h
+    return lambdaFlow<d_t>([this, CalleeFun,
+                            CS = llvm::cast<llvm::CallBase>(CallSite),
+                            Ret = llvm::dyn_cast<llvm::ReturnInst>(ExitStmt)](
+                               d_t Source) -> container_type {
+      if (LLVMZeroValue::isLLVMZeroValue(Source)) {
+        return {Source};
+      }
+      container_type Res;
+      // Handle C-style varargs functions
+      if (CalleeFun->isVarArg() && !CalleeFun->isDeclaration()) {
+        const llvm::Instruction *AllocVarArg;
+        // Find the allocation of %struct.__va_list_tag
+        for (const auto &BB : *CalleeFun) {
+          for (const auto &I : BB) {
+            if (const auto *Alloc = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
+              if (Alloc->getAllocatedType()->isArrayTy() &&
+                  Alloc->getAllocatedType()->getArrayNumElements() > 0 &&
+                  Alloc->getAllocatedType()
+                      ->getArrayElementType()
+                      ->isStructTy() &&
+                  Alloc->getAllocatedType()
+                          ->getArrayElementType()
+                          ->getStructName() == "struct.__va_list_tag") {
+                AllocVarArg = Alloc;
+                // TODO break out this nested loop earlier (without goto ;-)
+              }
+            }
+          }
+        }
+        // Generate the varargs things by using an over-approximation
+        if (Source == AllocVarArg) {
+          for (unsigned Idx = CalleeFun->arg_size(); Idx < CS->arg_size();
+               ++Idx) {
+            Res.insert(CS->getArgOperand(Idx));
+          }
+        }
+      }
+      // Handle ordinary case
+      // Map formal parameter into corresponding actual parameter.
+      for (auto [Formal, Actual] : llvm::zip(CalleeFun->args(), CS->args())) {
+        if (Source == &Formal) {
+          Res.insert(Actual); // corresponding actual
+        }
+      }
+
+      // Collect the return value
+      if (Ret && Source == Ret->getReturnValue()) {
+        Res.insert(CS);
+      }
+
+      // Collect all relevant alloca's to map into caller context
+      {
+        container_type RelAllocas;
+        for (const auto *Fact : Res) {
+          const auto &Allocas = getRelevantAllocas(Fact);
+          RelAllocas.insert(Allocas.begin(), Allocas.end());
+        }
+        Res.insert(RelAllocas.begin(), RelAllocas.end());
+      }
+
+      return Res;
+    });
+  }
+
+  FlowFunctionPtrType
+  getCallToRetFlowFunction(n_t CallSite, n_t RetSite,
+                           llvm::ArrayRef<f_t> Callees) override {
+    const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
+    for (const auto *Callee : Callees) {
+      std::string DemangledFname = llvm::demangle(Callee->getName().str());
+      // Generate the return value of factory functions from zero value
+      if (TSD->isFactoryFunction(DemangledFname)) {
+        return this->generateFromZero(CS);
+      }
+
+      /// XXX: Revisit this:
+
+      // Handle all functions that are not modeld with special semantics.
+      // Kill actual parameters of target type and all its aliases
+      // and the corresponding alloca(s) as these data-flow facts are
+      // (inter-procedurally) propagated via Call- and the corresponding
+      // Return-Flow. Otherwise we might propagate facts with not updated
+      // states.
+      // Alloca's related to the return value of non-api functions will
+      // not be killed during call-to-return, since it is not safe to assume
+      // that the return value will be used afterwards, i.e. is stored to memory
+      // pointed to by related alloca's.
+      if (!TSD->isAPIFunction(DemangledFname) && !Callee->isDeclaration()) {
+        for (const auto &Arg : CS->args()) {
+          if (hasMatchingType(Arg)) {
+            return killManyFlows<d_t>(getWMAliasesAndAllocas(Arg.get()));
+          }
+        }
+      }
+    }
+    return identityFlow<d_t>();
+  }
+
+  FlowFunctionPtrType getSummaryFlowFunction(n_t CallSite,
+                                             f_t DestFun) override {
+    return nullptr;
+  }
+
+  InitialSeeds<n_t, d_t, l_t> initialSeeds() override {
+    return this->createDefaultSeeds();
+  }
+
+  [[nodiscard]] d_t createZeroValue() const {
+    return LLVMZeroValue::getInstance();
+  }
+
+  [[nodiscard]] bool isZeroValue(d_t Fact) const override {
+    return LLVMZeroValue::isLLVMZeroValue(Fact);
+  }
+
+  // in addition provide specifications for the IDE parts
+
+  EdgeFunction<l_t> getNormalEdgeFunction(n_t Curr, d_t CurrNode, n_t Succ,
+                                          d_t SuccNode) override {
+    // Set alloca instructions of target type to uninitialized.
+    if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
+      if (hasMatchingType(Alloca)) {
+        if (LLVMZeroValue::isLLVMZeroValue(CurrNode) && SuccNode == Alloca) {
+          return TSConstant(TSD->uninit(), TSD);
+        }
+      }
+    }
+    return EdgeIdentity<l_t>{};
+  }
+
+  EdgeFunction<l_t> getCallEdgeFunction(n_t CallSite, d_t SrcNode,
+                                        f_t DestinationFunction,
+                                        d_t DestNode) override {
+    return EdgeIdentity<l_t>{};
+  }
+
+  EdgeFunction<l_t> getReturnEdgeFunction(n_t CallSite, f_t CalleeFunction,
+                                          n_t ExitInst, d_t ExitNode,
+                                          n_t RetSite, d_t RetNode) override {
+    return EdgeIdentity<l_t>{};
+  }
+
+  EdgeFunction<l_t>
+  getCallToRetEdgeFunction(n_t CallSite, d_t CallNode, n_t RetSite,
+                           d_t RetSiteNode,
+                           llvm::ArrayRef<f_t> Callees) override {
+    const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
+    for (const auto *Callee : Callees) {
+      std::string DemangledFname = llvm::demangle(Callee->getName().str());
+
+      // For now we assume that we can only generate from the return value.
+      // We apply the same edge function for the return value, i.e. callsite.
+      if (TSD->isFactoryFunction(DemangledFname)) {
+        PHASAR_LOG_LEVEL(DEBUG, "Processing factory function");
+        if (isZeroValue(CallNode) && RetSiteNode == CS) {
+          return TSConstant{
+              TSD->getNextState(DemangledFname, TSD->uninit(), CS), TSD};
+        }
+      }
+
+      // For every consuming parameter and all its aliases and relevant alloca's
+      // we apply the same edge function.
+      if (TSD->isConsumingFunction(DemangledFname)) {
+        PHASAR_LOG_LEVEL(DEBUG, "Processing consuming function");
+        for (auto Idx : TSD->getConsumerParamIdx(DemangledFname)) {
+          const auto &AliasAndAllocas =
+              getWMAliasesAndAllocas(CS->getArgOperand(Idx));
+
+          if (CallNode == RetSiteNode && AliasAndAllocas.count(CallNode)) {
+            return TSEdgeFunction{TSD, DemangledFname, CS};
+          }
+        }
+      }
+    }
+    return EdgeIdentity<l_t>{};
+  }
+
+  EdgeFunction<l_t> getSummaryEdgeFunction(n_t CallSite, d_t CallNode,
+                                           n_t RetSite,
+                                           d_t RetSiteNode) override {
+    return nullptr;
+  }
+
+  l_t topElement() override { return TSD->top(); }
+
+  l_t bottomElement() override { return TSD->bottom(); }
+
+  /**
+   * We have a lattice with BOTTOM representing all information
+   * and TOP representing no information. The other lattice elements
+   * are defined by the type state description, i.e. represented by the
+   * states of the finite state machine.
+   *
+   * @note Only one-level lattice's are handled currently
+   */
+  l_t join(l_t Lhs, l_t Rhs) override {
+    if (Lhs == Rhs) {
+      return Lhs;
+    }
+    if (Lhs == TSD->top()) {
+      return Rhs;
+    }
+    if (Rhs == TSD->top()) {
+      return Lhs;
+    }
+    return TSD->bottom();
+  }
+
+  EdgeFunction<l_t> allTopFunction() override {
+    if constexpr (HasJoinLatticeTraits<l_t>) {
+      return AllTop<l_t>{};
+    } else {
+      return AllTop<l_t>{topElement()};
+    }
+  }
+
+  void emitTextReport(const SolverResults<n_t, d_t, l_t> &SR,
+                      llvm::raw_ostream &OS = llvm::outs()) override {
+    LLVMBasedCFG CFG;
+    OS << "\n======= TYPE STATE RESULTS =======\n";
+    for (const auto &F : this->IRDB->getAllFunctions()) {
+      OS << '\n' << F->getName() << '\n';
+      for (const auto &BB : *F) {
+        for (const auto &I : BB) {
+          auto Results = SR.resultsAt(&I, true);
+          if (CFG.isExitInst(&I)) {
+            OS << "\nAt exit stmt: " << NToString(&I) << '\n';
+            for (auto Res : Results) {
+              if (const auto *Alloca =
+                      llvm::dyn_cast<llvm::AllocaInst>(Res.first)) {
+                if (Res.second == TSD->error()) {
+                  OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
+                     << DToString(Res.first) << '\n';
+                  for (const auto *Pred : CFG.getPredsOf(&I)) {
+                    OS << "\nPredecessor: " << NToString(Pred) << '\n';
+                    auto PredResults = SR.resultsAt(Pred, true);
+                    for (auto Res : PredResults) {
+                      if (Res.first == Alloca) {
+                        OS << "Pred State: " << LToString(Res.second) << '\n';
+                      }
+                    }
+                  }
+                  OS << "============================\n";
+                } else {
+                  OS << "\nAlloca : " << DToString(Res.first)
+                     << "\nState  : " << LToString(Res.second) << '\n';
+                }
+              } else {
+                OS << "\nInst: " << NToString(&I) << '\n'
+                   << "Fact: " << DToString(Res.first) << '\n'
+                   << "State: " << LToString(Res.second) << '\n';
+              }
+            }
+          } else {
+            for (auto Res : Results) {
+              if (const auto *Alloca =
+                      llvm::dyn_cast<llvm::AllocaInst>(Res.first)) {
+                if (Res.second == TSD->error()) {
+                  OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
+                     << DToString(Res.first) << '\n'
+                     << "\nAt IR Inst: " << NToString(&I) << '\n';
+                  for (const auto *Pred : CFG.getPredsOf(&I)) {
+                    OS << "\nPredecessor: " << NToString(Pred) << '\n';
+                    auto PredResults = SR.resultsAt(Pred, true);
+                    for (auto Res : PredResults) {
+                      if (Res.first == Alloca) {
+                        OS << "Pred State: " << LToString(Res.second) << '\n';
+                      }
+                    }
+                  }
+                  OS << "============================\n";
+                }
+              } else {
+                OS << "\nInst: " << NToString(&I) << '\n'
+                   << "Fact: " << DToString(Res.first) << '\n'
+                   << "State: " << LToString(Res.second) << '\n';
+              }
+            }
+          }
+        }
+      }
+      OS << "\n--------------------------------------------\n";
+    }
+  }
+
+private:
+  const TypeStateDescriptionTy *TSD{};
+};
+
+template <typename TypeStateDescriptionTy>
+IDETypeStateAnalysis(const LLVMProjectIRDB *, LLVMAliasInfoRef,
+                     const TypeStateDescriptionTy *,
+                     std::vector<std::string> EntryPoints)
+    -> IDETypeStateAnalysis<TypeStateDescriptionTy>;
+
+// class CSTDFILEIOTypeStateDescription;
+
+// extern template class IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>;
 
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
@@ -19,8 +19,33 @@
 
 namespace psr {
 
-enum class CSTDFILEIOState;
+enum class CSTDFILEIOState {
+  TOP = 42,
+  UNINIT = 0,
+  OPENED = 1,
+  CLOSED = 2,
+  ERROR = 3,
+  BOT = 4
+};
 llvm::StringRef to_string(CSTDFILEIOState State) noexcept;
+template <> struct JoinLatticeTraits<CSTDFILEIOState> {
+  static constexpr CSTDFILEIOState top() noexcept {
+    return CSTDFILEIOState::TOP;
+  }
+  static constexpr CSTDFILEIOState bottom() noexcept {
+    return CSTDFILEIOState::BOT;
+  }
+  static constexpr CSTDFILEIOState join(CSTDFILEIOState L,
+                                        CSTDFILEIOState R) noexcept {
+    if (L == top() || R == bottom()) {
+      return R;
+    }
+    if (L == bottom() || R == top()) {
+      return L;
+    }
+    return bottom();
+  }
+};
 
 /**
  * A type state description for C's file I/O API. The finite state machine

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h
@@ -10,6 +10,7 @@
 #ifndef PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_PROBLEMS_TYPESTATEDESCRIPTIONS_CSTDFILEIOTYPESTATEDESCRIPTION_H
 #define PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_PROBLEMS_TYPESTATEDESCRIPTIONS_CSTDFILEIOTYPESTATEDESCRIPTION_H
 
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
 
 #include <map>
@@ -18,30 +19,37 @@
 
 namespace psr {
 
+enum class CSTDFILEIOState;
+llvm::StringRef to_string(CSTDFILEIOState State) noexcept;
+
 /**
  * A type state description for C's file I/O API. The finite state machine
  * is encoded by a two-dimensional array with rows as function tokens and
  * columns as states.
  */
-class CSTDFILEIOTypeStateDescription : public TypeStateDescription {
+class CSTDFILEIOTypeStateDescription
+    : public TypeStateDescription<CSTDFILEIOState> {
 public:
-  [[nodiscard]] bool isFactoryFunction(const std::string &F) const override;
-  [[nodiscard]] bool isConsumingFunction(const std::string &F) const override;
-  [[nodiscard]] bool isAPIFunction(const std::string &F) const override;
+  using TypeStateDescription::getNextState;
+  [[nodiscard]] bool isFactoryFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isConsumingFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isAPIFunction(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State
-  getNextState(std::string Tok, TypeStateDescription::State S) const override;
+  getNextState(llvm::StringRef Tok,
+               TypeStateDescription::State S) const override;
   [[nodiscard]] std::string getTypeNameOfInterest() const override;
   [[nodiscard]] std::set<int>
-  getConsumerParamIdx(const std::string &F) const override;
+  getConsumerParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] std::set<int>
-  getFactoryParamIdx(const std::string &F) const override;
-  [[nodiscard]] auto getStateToString() const -> std::string (*)(int) override;
+  getFactoryParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State bottom() const override;
   [[nodiscard]] TypeStateDescription::State top() const override;
   [[nodiscard]] TypeStateDescription::State uninit() const override;
   [[nodiscard]] TypeStateDescription::State start() const override;
   [[nodiscard]] TypeStateDescription::State error() const override;
 };
+
+extern template class IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>;
 
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h
@@ -13,7 +13,7 @@
 #include "phasar/DataFlow/IfdsIde/Solver/IDESolver.h"
 #include "phasar/Domain/AnalysisDomain.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.h"
-#include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h"
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFDescription.h"
 
 #include <map>
 #include <set>
@@ -27,31 +27,34 @@ class Value;
 namespace psr {
 
 /**
+ * We use the following lattice
+ *                BOT = all information
+ *
+ * UNINIT     CTX_ATTACHED   PARAM_INIT   DERIVED   ERROR
+ *
+ *                TOP = no information
+ */
+enum class OpenSSLEVPKDFCTXState {
+  TOP = 42,
+  UNINIT = 5,
+  CTX_ATTACHED = 1,
+  PARAM_INIT = 2,
+  DERIVED = 3,
+  ERROR = 4,
+  BOT = 0 // It is VERY IMPORTANT, athat BOT has value 0, since this is the
+          // default value
+};
+
+llvm::StringRef to_string(OpenSSLEVPKDFCTXState State) noexcept;
+
+/**
  * A type state description for OpenSSL's EVP Key Derivation functions. The
  * finite state machine is encoded by a two-dimensional array with rows as
  * function tokens and columns as states.
  */
-class OpenSSLEVPKDFCTXDescription : public TypeStateDescription {
+class OpenSSLEVPKDFCTXDescription
+    : public TypeStateDescription<OpenSSLEVPKDFCTXState> {
 private:
-  /**
-   * We use the following lattice
-   *                BOT = all information
-   *
-   * UNINIT     CTX_ATTACHED   PARAM_INIT   DERIVED   ERROR
-   *
-   *                TOP = no information
-   */
-  enum OpenSSLEVPKDFState {
-    TOP = 42,
-    UNINIT = 5,
-    CTX_ATTACHED = 1,
-    PARAM_INIT = 2,
-    DERIVED = 3,
-    ERROR = 4,
-    BOT = 0 // It is VERY IMPORTANT, athat BOT has value 0, since this is the
-            // default value
-  };
-
   /**
    * The STAR token represents all functions besides EVP_KDF_fetch(),
    * EVP_KDF_CTX_new(), EVP_KDF_CTX_set_params() ,derive() and
@@ -65,41 +68,40 @@ private:
     STAR = 4
   };
 
-  static const std::map<std::string, std::set<int>> OpenSSLEVPKDFFuncs;
   // Delta matrix to implement the state machine's Delta function
-  static const OpenSSLEVPKDFState Delta[5][6];
+  static const OpenSSLEVPKDFCTXState Delta[5][6];
 
   // std::map<std::pair<const llvm::Instruction *, const llvm::Value *>, int>
   //     requiredKDFState;
-  IDESolver<IDETypeStateAnalysisDomain> &KDFAnalysisResults;
-  static OpenSSLEVTKDFToken funcNameToToken(const std::string &F);
+  IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFDescription>>
+      &KDFAnalysisResults;
+  static OpenSSLEVTKDFToken funcNameToToken(llvm::StringRef F);
 
 public:
+  using TypeStateDescription::getNextState;
   OpenSSLEVPKDFCTXDescription(
-      IDESolver<IDETypeStateAnalysisDomain> &KDFAnalysisResults)
+      IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFDescription>>
+          &KDFAnalysisResults)
       : KDFAnalysisResults(KDFAnalysisResults) {}
 
+  [[nodiscard]] bool isFactoryFunction(llvm::StringRef FuncName) const override;
   [[nodiscard]] bool
-  isFactoryFunction(const std::string &FuncName) const override;
-  [[nodiscard]] bool
-  isConsumingFunction(const std::string &FuncName) const override;
-  [[nodiscard]] bool isAPIFunction(const std::string &FuncName) const override;
-  [[nodiscard]] TypeStateDescription::State
-  getNextState(std::string Tok, TypeStateDescription::State S) const override;
-  [[nodiscard]] TypeStateDescription::State
-  getNextState(const std::string &Tok, TypeStateDescription::State S,
+  isConsumingFunction(llvm::StringRef FuncName) const override;
+  [[nodiscard]] bool isAPIFunction(llvm::StringRef FuncName) const override;
+  [[nodiscard]] State getNextState(llvm::StringRef Tok, State S) const override;
+  [[nodiscard]] State
+  getNextState(llvm::StringRef Tok, State S,
                const llvm::CallBase *CallSite) const override;
   [[nodiscard]] std::string getTypeNameOfInterest() const override;
   [[nodiscard]] std::set<int>
-  getConsumerParamIdx(const std::string &F) const override;
+  getConsumerParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] std::set<int>
-  getFactoryParamIdx(const std::string &F) const override;
-  [[nodiscard]] auto getStateToString() const -> std::string (*)(int) override;
-  [[nodiscard]] TypeStateDescription::State bottom() const override;
-  [[nodiscard]] TypeStateDescription::State top() const override;
-  [[nodiscard]] TypeStateDescription::State uninit() const override;
-  [[nodiscard]] TypeStateDescription::State start() const override;
-  [[nodiscard]] TypeStateDescription::State error() const override;
+  getFactoryParamIdx(llvm::StringRef F) const override;
+  [[nodiscard]] State bottom() const override;
+  [[nodiscard]] State top() const override;
+  [[nodiscard]] State uninit() const override;
+  [[nodiscard]] State start() const override;
+  [[nodiscard]] State error() const override;
   /*
     /// Checks all callSites, where a EVP_KDF object needs to be in a
     /// certain state, such that the state transition for EVP_KDF_CTX is valid.

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFDescription.h
@@ -17,24 +17,28 @@
 #include <string>
 
 namespace psr {
-class OpenSSLEVPKDFDescription : public TypeStateDescription {
-public:
-  /**
-   * We use the following lattice
-   *                BOT = all information
-   *
-   *         UNINIT     KDF_FETCHED     ERROR
-   *
-   *                TOP = no information
-   */
-  enum OpenSSLEVPKDFState {
-    TOP = 42,
-    UNINIT = 0,
-    KDF_FETCHED = 1,
-    ERROR = 2,
-    BOT = 3
-  };
 
+/**
+ * We use the following lattice
+ *                BOT = all information
+ *
+ *         UNINIT     KDF_FETCHED     ERROR
+ *
+ *                TOP = no information
+ */
+enum class OpenSSLEVPKDFState {
+  TOP = 42,
+  UNINIT = 0,
+  KDF_FETCHED = 1,
+  ERROR = 2,
+  BOT = 3
+};
+
+llvm::StringRef to_string(OpenSSLEVPKDFState State) noexcept;
+
+class OpenSSLEVPKDFDescription
+    : public TypeStateDescription<OpenSSLEVPKDFState> {
+public:
   /**
    * The STAR token represents all functions besides EVP_KDF_fetch(),
    * EVP_KDF_fetch()  and EVP_KDF_CTX_free().
@@ -45,31 +49,32 @@ public:
     STAR = 2
   };
 
+  using State = OpenSSLEVPKDFState;
+
 private:
-  static const std::map<std::string, std::set<int>> OpenSSLEVPKDFFuncs;
   // delta matrix to implement the state machine's delta function
   static const OpenSSLEVPKDFState Delta[3][4];
-  static OpenSSLEVTKDFToken funcNameToToken(const std::string &F);
+  static OpenSSLEVTKDFToken funcNameToToken(llvm::StringRef F);
 
 public:
-  [[nodiscard]] bool isFactoryFunction(const std::string &F) const override;
+  using TypeStateDescription::getNextState;
+  [[nodiscard]] bool isFactoryFunction(llvm::StringRef F) const override;
 
-  [[nodiscard]] bool isConsumingFunction(const std::string &F) const override;
+  [[nodiscard]] bool isConsumingFunction(llvm::StringRef F) const override;
 
-  [[nodiscard]] bool isAPIFunction(const std::string &F) const override;
+  [[nodiscard]] bool isAPIFunction(llvm::StringRef F) const override;
 
   [[nodiscard]] TypeStateDescription::State
-  getNextState(std::string Tok, TypeStateDescription::State S) const override;
+  getNextState(llvm::StringRef Tok,
+               TypeStateDescription::State S) const override;
 
   [[nodiscard]] std::string getTypeNameOfInterest() const override;
 
   [[nodiscard]] std::set<int>
-  getConsumerParamIdx(const std::string &F) const override;
+  getConsumerParamIdx(llvm::StringRef F) const override;
 
   [[nodiscard]] std::set<int>
-  getFactoryParamIdx(const std::string &F) const override;
-
-  [[nodiscard]] auto getStateToString() const -> std::string (*)(int) override;
+  getFactoryParamIdx(llvm::StringRef F) const override;
 
   [[nodiscard]] TypeStateDescription::State bottom() const override;
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h
@@ -18,19 +18,20 @@
 #include <string>
 
 namespace psr {
+enum class OpenSSLSecureHeapState {
+  TOP = 42,
+  BOT = 0,
+  UNINIT = 1,
+  ALLOCATED = 2,
+  ZEROED = 3,
+  FREED = 4,
+  ERROR = 5
+};
+llvm::StringRef to_string(OpenSSLSecureHeapState State) noexcept;
 
-class OpenSSLSecureHeapDescription : public TypeStateDescription {
+class OpenSSLSecureHeapDescription
+    : public TypeStateDescription<OpenSSLSecureHeapState> {
 private:
-  enum OpenSSLSecureHeapState {
-    TOP = 42,
-    BOT = 0,
-    UNINIT = 1,
-    ALLOCATED = 2,
-    ZEROED = 3,
-    FREED = 4,
-    ERROR = 5
-  };
-
   enum class OpenSSLSecureHeapToken {
     SECURE_MALLOC = 0,
     SECURE_ZALLOC = 1,
@@ -39,33 +40,33 @@ private:
     STAR = 4
   };
 
-  static const std::map<std::string, std::set<int>> OpenSSLSecureHeapFuncs;
   // Delta matrix to implement the state machine's Delta function
   static const OpenSSLSecureHeapState Delta[5][6];
 
   IDESolver<IDESecureHeapPropagationAnalysisDomain>
       &SecureHeapPropagationResults;
 
-  static OpenSSLSecureHeapToken funcNameToToken(const std::string &F);
+  static OpenSSLSecureHeapToken funcNameToToken(llvm::StringRef F);
 
 public:
+  using TypeStateDescription::getNextState;
   OpenSSLSecureHeapDescription(IDESolver<IDESecureHeapPropagationAnalysisDomain>
                                    &SecureHeapPropagationResults);
 
-  [[nodiscard]] bool isFactoryFunction(const std::string &F) const override;
-  [[nodiscard]] bool isConsumingFunction(const std::string &F) const override;
-  [[nodiscard]] bool isAPIFunction(const std::string &F) const override;
+  [[nodiscard]] bool isFactoryFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isConsumingFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isAPIFunction(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State
-  getNextState(std::string Tok, TypeStateDescription::State S) const override;
+  getNextState(llvm::StringRef Tok,
+               TypeStateDescription::State S) const override;
   [[nodiscard]] TypeStateDescription::State
-  getNextState(const std::string &Tok, TypeStateDescription::State S,
+  getNextState(llvm::StringRef Tok, TypeStateDescription::State S,
                const llvm::CallBase *CallSite) const override;
   [[nodiscard]] std::string getTypeNameOfInterest() const override;
   [[nodiscard]] std::set<int>
-  getConsumerParamIdx(const std::string &F) const override;
+  getConsumerParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] std::set<int>
-  getFactoryParamIdx(const std::string &F) const override;
-  [[nodiscard]] auto getStateToString() const -> std::string (*)(int) override;
+  getFactoryParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State bottom() const override;
   [[nodiscard]] TypeStateDescription::State top() const override;
   [[nodiscard]] TypeStateDescription::State uninit() const override;

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureMemoryDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureMemoryDescription.h
@@ -18,19 +18,24 @@
 
 namespace psr {
 
-class OpenSSLSecureMemoryDescription : public TypeStateDescription {
+enum class OpenSSLSecureMemoryState;
+llvm::StringRef to_string(OpenSSLSecureMemoryState State) noexcept;
+
+class OpenSSLSecureMemoryDescription
+    : public TypeStateDescription<OpenSSLSecureMemoryState> {
 public:
-  [[nodiscard]] bool isFactoryFunction(const std::string &F) const override;
-  [[nodiscard]] bool isConsumingFunction(const std::string &F) const override;
-  [[nodiscard]] bool isAPIFunction(const std::string &F) const override;
+  using TypeStateDescription::getNextState;
+  [[nodiscard]] bool isFactoryFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isConsumingFunction(llvm::StringRef F) const override;
+  [[nodiscard]] bool isAPIFunction(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State
-  getNextState(std::string Tok, TypeStateDescription::State S) const override;
+  getNextState(llvm::StringRef Tok,
+               TypeStateDescription::State S) const override;
   [[nodiscard]] std::string getTypeNameOfInterest() const override;
   [[nodiscard]] std::set<int>
-  getConsumerParamIdx(const std::string &F) const override;
+  getConsumerParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] std::set<int>
-  getFactoryParamIdx(const std::string &F) const override;
-  [[nodiscard]] auto getStateToString() const -> std::string (*)(int) override;
+  getFactoryParamIdx(llvm::StringRef F) const override;
   [[nodiscard]] TypeStateDescription::State bottom() const override;
   [[nodiscard]] TypeStateDescription::State top() const override;
   [[nodiscard]] TypeStateDescription::State uninit() const override;

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h
@@ -17,6 +17,19 @@
 
 namespace psr {
 
+struct TypeStateDescriptionBase {
+  virtual ~TypeStateDescriptionBase() = default;
+
+  [[nodiscard]] virtual bool isFactoryFunction(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual bool isConsumingFunction(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual bool isAPIFunction(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual std::string getTypeNameOfInterest() const = 0;
+  [[nodiscard]] virtual std::set<int>
+  getConsumerParamIdx(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual std::set<int>
+  getFactoryParamIdx(llvm::StringRef F) const = 0;
+};
+
 /**
  * Interface for a type state problem to be used with the IDETypeStateAnalysis.
  * It needs to provide a finite state machine to handle state changes and a list
@@ -31,13 +44,11 @@ namespace psr {
  *
  * @see CSTDFILEIOTypeStateDescription as an example of type state description.
  */
-template <typename StateTy> struct TypeStateDescription {
+template <typename StateTy>
+struct TypeStateDescription : public TypeStateDescriptionBase {
   /// Type for states of the finite state machine
   using State = StateTy;
-  virtual ~TypeStateDescription() = default;
-  [[nodiscard]] virtual bool isFactoryFunction(llvm::StringRef F) const = 0;
-  [[nodiscard]] virtual bool isConsumingFunction(llvm::StringRef F) const = 0;
-  [[nodiscard]] virtual bool isAPIFunction(llvm::StringRef F) const = 0;
+  ~TypeStateDescription() override = default;
 
   /**
    * @brief For a given function name (as a string token) and a state, this
@@ -50,11 +61,7 @@ template <typename StateTy> struct TypeStateDescription {
                const llvm::CallBase * /*CallSite*/) const {
     return getNextState(Tok, S);
   }
-  [[nodiscard]] virtual std::string getTypeNameOfInterest() const = 0;
-  [[nodiscard]] virtual std::set<int>
-  getConsumerParamIdx(llvm::StringRef F) const = 0;
-  [[nodiscard]] virtual std::set<int>
-  getFactoryParamIdx(llvm::StringRef F) const = 0;
+
   [[nodiscard]] virtual State bottom() const = 0;
   [[nodiscard]] virtual State top() const = 0;
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/TypeStateDescription.h
@@ -31,32 +31,30 @@ namespace psr {
  *
  * @see CSTDFILEIOTypeStateDescription as an example of type state description.
  */
-struct TypeStateDescription {
+template <typename StateTy> struct TypeStateDescription {
   /// Type for states of the finite state machine
-  using State = int;
+  using State = StateTy;
   virtual ~TypeStateDescription() = default;
-  [[nodiscard]] virtual bool isFactoryFunction(const std::string &F) const = 0;
-  [[nodiscard]] virtual bool
-  isConsumingFunction(const std::string &F) const = 0;
-  [[nodiscard]] virtual bool isAPIFunction(const std::string &F) const = 0;
+  [[nodiscard]] virtual bool isFactoryFunction(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual bool isConsumingFunction(llvm::StringRef F) const = 0;
+  [[nodiscard]] virtual bool isAPIFunction(llvm::StringRef F) const = 0;
 
   /**
    * @brief For a given function name (as a string token) and a state, this
    * function returns the next state.
    */
-  [[nodiscard]] virtual State getNextState(std::string Tok, State S) const = 0;
+  [[nodiscard]] virtual State getNextState(llvm::StringRef Tok,
+                                           State S) const = 0;
   [[nodiscard]] virtual State
-  getNextState(const std::string &Tok, State S,
+  getNextState(llvm::StringRef Tok, State S,
                const llvm::CallBase * /*CallSite*/) const {
     return getNextState(Tok, S);
   }
   [[nodiscard]] virtual std::string getTypeNameOfInterest() const = 0;
   [[nodiscard]] virtual std::set<int>
-  getConsumerParamIdx(const std::string &F) const = 0;
+  getConsumerParamIdx(llvm::StringRef F) const = 0;
   [[nodiscard]] virtual std::set<int>
-  getFactoryParamIdx(const std::string &F) const = 0;
-  [[nodiscard]] virtual auto getStateToString() const
-      -> std::string (*)(int) = 0;
+  getFactoryParamIdx(llvm::StringRef F) const = 0;
   [[nodiscard]] virtual State bottom() const = 0;
   [[nodiscard]] virtual State top() const = 0;
 

--- a/lib/Controller/AnalysisControllerXIDECSTDIOTS.cpp
+++ b/lib/Controller/AnalysisControllerXIDECSTDIOTS.cpp
@@ -15,7 +15,8 @@ namespace psr {
 
 void AnalysisController::executeIDECSTDIOTS() {
   CSTDFILEIOTypeStateDescription TSDesc;
-  executeIDEAnalysis<IDETypeStateAnalysis>(&TSDesc, EntryPoints);
+  executeIDEAnalysis<IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>>(
+      &TSDesc, EntryPoints);
 }
 
 } // namespace psr

--- a/lib/Controller/AnalysisControllerXIDEOpenSSLTS.cpp
+++ b/lib/Controller/AnalysisControllerXIDEOpenSSLTS.cpp
@@ -15,7 +15,8 @@ namespace psr {
 
 void AnalysisController::executeIDEOpenSSLTS() {
   OpenSSLEVPKDFDescription TSDesc;
-  executeIDEAnalysis<IDETypeStateAnalysis>(&TSDesc, EntryPoints);
+  executeIDEAnalysis<IDETypeStateAnalysis<OpenSSLEVPKDFDescription>>(
+      &TSDesc, EntryPoints);
 }
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -36,6 +36,190 @@
 
 namespace psr::detail {
 
+auto IDETypeStateAnalysisBase::getNormalFlowFunction(n_t Curr, n_t /*Succ*/)
+    -> FlowFunctionPtrType {
+  // Check if Alloca's type matches the target type. If so, generate from zero
+  // value.
+  if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
+    if (hasMatchingType(Alloca)) {
+      return this->generateFromZero(Alloca);
+    }
+  }
+  // Check load instructions for target type. Generate from the loaded value
+  // and kill the load instruction if it was generated previously (strong
+  // update!).
+  if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
+    if (hasMatchingType(Load)) {
+      return transferFlow(Load, Load->getPointerOperand());
+    }
+  }
+  if (const auto *Gep = llvm::dyn_cast<llvm::GetElementPtrInst>(Curr)) {
+    if (hasMatchingType(Gep->getPointerOperand())) {
+      return identityFlow<d_t>();
+      // return lambdaFlow<d_t>([=](d_t Source) -> std::set<d_t> {
+      //   // if (Source == Gep->getPointerOperand()) {
+      //   //  return {Source, Gep};
+      //   //}
+      //   return {Source};
+      // });
+    }
+  }
+  // Check store instructions for target type. Perform a strong update, i.e.
+  // kill the alloca pointed to by the pointer-operand and all alloca's
+  // related to the value-operand and then generate them from the
+  // value-operand.
+  if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
+    if (hasMatchingType(Store)) {
+      auto RelevantAliasesAndAllocas = getLocalAliasesAndAllocas(
+          Store->getPointerOperand(), // pointer- or value operand???
+          // Store->getValueOperand(),
+          Curr->getFunction()->getName().str());
+
+      RelevantAliasesAndAllocas.insert(Store->getValueOperand());
+      return lambdaFlow<d_t>(
+          [Store, AliasesAndAllocas = std::move(RelevantAliasesAndAllocas)](
+              d_t Source) -> container_type {
+            // We kill all relevant loacal aliases and alloca's
+            if (Source == Store->getPointerOperand()) {
+              // XXX: later kill must-aliases too
+              return {};
+            }
+            // Generate all local aliases and relevant alloca's from the
+            // stored value
+            if (Source == Store->getValueOperand()) {
+              return AliasesAndAllocas;
+            }
+            return {Source};
+          });
+    }
+  }
+  return identityFlow<d_t>();
+}
+
+auto IDETypeStateAnalysisBase::getCallFlowFunction(n_t CallSite, f_t DestFun)
+    -> FlowFunctionPtrType {
+  // Kill all data-flow facts if we hit a function of the target API.
+  // Those functions are modled within Call-To-Return.
+  if (isAPIFunction(llvm::demangle(DestFun->getName().str()))) {
+    return killAllFlows<d_t>();
+  }
+  // Otherwise, if we have an ordinary function call, we can just use the
+  // standard mapping.
+  if (const auto *Call = llvm::dyn_cast<llvm::CallBase>(CallSite)) {
+    return mapFactsToCallee(Call, DestFun);
+  }
+  llvm::report_fatal_error("callSite not a CallInst nor a InvokeInst");
+}
+
+auto IDETypeStateAnalysisBase::getRetFlowFunction(n_t CallSite, f_t CalleeFun,
+                                                  n_t ExitStmt, n_t /*RetSite*/)
+    -> FlowFunctionPtrType {
+
+  /// TODO: Implement return-POI in LLVMFlowFunctions.h
+  return lambdaFlow<d_t>([this, CalleeFun,
+                          CS = llvm::cast<llvm::CallBase>(CallSite),
+                          Ret = llvm::dyn_cast<llvm::ReturnInst>(ExitStmt)](
+                             d_t Source) -> container_type {
+    if (LLVMZeroValue::isLLVMZeroValue(Source)) {
+      return {Source};
+    }
+    container_type Res;
+    // Handle C-style varargs functions
+    if (CalleeFun->isVarArg() && !CalleeFun->isDeclaration()) {
+      const llvm::Instruction *AllocVarArg;
+      // Find the allocation of %struct.__va_list_tag
+      for (const auto &BB : *CalleeFun) {
+        for (const auto &I : BB) {
+          if (const auto *Alloc = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
+            if (Alloc->getAllocatedType()->isArrayTy() &&
+                Alloc->getAllocatedType()->getArrayNumElements() > 0 &&
+                Alloc->getAllocatedType()
+                    ->getArrayElementType()
+                    ->isStructTy() &&
+                Alloc->getAllocatedType()
+                        ->getArrayElementType()
+                        ->getStructName() == "struct.__va_list_tag") {
+              AllocVarArg = Alloc;
+              // TODO break out this nested loop earlier (without goto ;-)
+            }
+          }
+        }
+      }
+      // Generate the varargs things by using an over-approximation
+      if (Source == AllocVarArg) {
+        for (unsigned Idx = CalleeFun->arg_size(); Idx < CS->arg_size();
+             ++Idx) {
+          Res.insert(CS->getArgOperand(Idx));
+        }
+      }
+    }
+    // Handle ordinary case
+    // Map formal parameter into corresponding actual parameter.
+    for (auto [Formal, Actual] : llvm::zip(CalleeFun->args(), CS->args())) {
+      if (Source == &Formal) {
+        Res.insert(Actual); // corresponding actual
+      }
+    }
+
+    // Collect the return value
+    if (Ret && Source == Ret->getReturnValue()) {
+      Res.insert(CS);
+    }
+
+    // Collect all relevant alloca's to map into caller context
+    {
+      container_type RelAllocas;
+      for (const auto *Fact : Res) {
+        const auto &Allocas = getRelevantAllocas(Fact);
+        RelAllocas.insert(Allocas.begin(), Allocas.end());
+      }
+      Res.insert(RelAllocas.begin(), RelAllocas.end());
+    }
+
+    return Res;
+  });
+}
+
+auto IDETypeStateAnalysisBase::getCallToRetFlowFunction(
+    n_t CallSite, n_t /*RetSite*/, llvm::ArrayRef<f_t> Callees)
+    -> FlowFunctionPtrType {
+  const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
+  for (const auto *Callee : Callees) {
+    std::string DemangledFname = llvm::demangle(Callee->getName().str());
+    // Generate the return value of factory functions from zero value
+    if (isFactoryFunction(DemangledFname)) {
+      return this->generateFromZero(CS);
+    }
+
+    /// XXX: Revisit this:
+
+    // Handle all functions that are not modeld with special semantics.
+    // Kill actual parameters of target type and all its aliases
+    // and the corresponding alloca(s) as these data-flow facts are
+    // (inter-procedurally) propagated via Call- and the corresponding
+    // Return-Flow. Otherwise we might propagate facts with not updated
+    // states.
+    // Alloca's related to the return value of non-api functions will
+    // not be killed during call-to-return, since it is not safe to assume
+    // that the return value will be used afterwards, i.e. is stored to memory
+    // pointed to by related alloca's.
+    if (!isAPIFunction(DemangledFname) && !Callee->isDeclaration()) {
+      for (const auto &Arg : CS->args()) {
+        if (hasMatchingType(Arg)) {
+          return killManyFlows<d_t>(getWMAliasesAndAllocas(Arg.get()));
+        }
+      }
+    }
+  }
+  return identityFlow<d_t>();
+}
+
+auto IDETypeStateAnalysisBase::getSummaryFlowFunction(n_t /*CallSite*/,
+                                                      f_t /*DestFun*/)
+    -> FlowFunctionPtrType {
+  return nullptr;
+}
+
 auto IDETypeStateAnalysisBase::getRelevantAllocas(d_t V) -> container_type {
   if (RelevantAllocaCache.find(V) != RelevantAllocaCache.end()) {
     return RelevantAllocaCache[V];
@@ -113,48 +297,37 @@ auto IDETypeStateAnalysisBase::getLocalAliasesAndAllocas(
   return AliasAndAllocas;
 }
 
-static bool hasMatchingTypeName(
-    const llvm::Type *Ty,
-    const std::function<bool(llvm::StringRef)> &IsTypeNameOfInterest) {
+bool IDETypeStateAnalysisBase::hasMatchingTypeName(const llvm::Type *Ty) {
   if (const auto *StructTy = llvm::dyn_cast<llvm::StructType>(Ty)) {
-    return IsTypeNameOfInterest(StructTy->getName());
+    return isTypeNameOfInterest(StructTy->getName());
   }
   // primitive type
   std::string Str;
   llvm::raw_string_ostream S(Str);
   S << *Ty;
   S.flush();
-  return IsTypeNameOfInterest(Str);
+  return isTypeNameOfInterest(Str);
 }
 
 bool IDETypeStateAnalysisBase::hasMatchingType(d_t V) {
   // General case
   if (V->getType()->isPointerTy()) {
-    if (hasMatchingTypeName(V->getType()->getPointerElementType(),
-                            IsTypeNameOfInterest)) {
+    if (hasMatchingTypeName(V->getType()->getPointerElementType())) {
       return true;
     }
   }
   if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(V)) {
     if (Alloca->getAllocatedType()->isPointerTy()) {
       if (hasMatchingTypeName(
-              Alloca->getAllocatedType()->getPointerElementType(),
-              IsTypeNameOfInterest)) {
+              Alloca->getAllocatedType()->getPointerElementType())) {
         return true;
       }
     }
     return false;
   }
   if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(V)) {
-    if (Load->getPointerOperand()
-            ->getType()
-            ->getPointerElementType()
-            ->isPointerTy()) {
-      if (hasMatchingTypeName(Load->getPointerOperand()
-                                  ->getType()
-                                  ->getPointerElementType()
-                                  ->getPointerElementType(),
-                              IsTypeNameOfInterest)) {
+    if (Load->getType()->isPointerTy()) {
+      if (hasMatchingTypeName(Load->getType()->getPointerElementType())) {
         return true;
       }
     }
@@ -163,8 +336,7 @@ bool IDETypeStateAnalysisBase::hasMatchingType(d_t V) {
   if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(V)) {
     if (Store->getValueOperand()->getType()->isPointerTy()) {
       if (hasMatchingTypeName(
-              Store->getValueOperand()->getType()->getPointerElementType(),
-              IsTypeNameOfInterest)) {
+              Store->getValueOperand()->getType()->getPointerElementType())) {
         return true;
       }
     }

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETypeStateAnalysis.cpp
@@ -34,548 +34,14 @@
 #include <algorithm>
 #include <utility>
 
-namespace psr {
+namespace psr::detail {
 
-///
-///
-/// TODO: Make Bottom common across all implementations of TypeStateDescription!
-/// then we can factor it out of all edge functions making some of them
-/// applicable for small-object optimization!
-///
-///
-
-// customize the edge function composer
-struct TSEdgeFunctionComposer
-    : EdgeFunctionComposer<IDETypeStateAnalysisDomain::l_t> {
-  IDETypeStateAnalysisDomain::l_t BotElement;
-
-  static EdgeFunction<IDETypeStateAnalysisDomain::l_t>
-  join(EdgeFunctionRef<TSEdgeFunctionComposer> This,
-       const EdgeFunction<IDETypeStateAnalysisDomain::l_t> &OtherFunction) {
-    if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
-      return Default;
-    }
-
-    return AllBottom<IDETypeStateAnalysis::l_t>{This->BotElement};
-  }
-};
-
-struct TSEdgeFunction {
-  const TypeStateDescription *TSD;
-  // XXX: Do we really need a string here? Can't we just use an integer or sth
-  // else that is cheap?
-  std::string Token;
-  const llvm::CallBase *CallSite;
-
-  using l_t = IDETypeStateAnalysisDomain ::l_t;
-
-  [[nodiscard]] l_t computeTarget(l_t Source) const {
-
-    // assert((Source != TSD->top()) && "Error: call computeTarget with TOP\n");
-
-    auto CurrentState = TSD->getNextState(
-        Token, Source == TSD->top() ? TSD->uninit() : Source, CallSite);
-    PHASAR_LOG_LEVEL(DEBUG, "State machine transition: ("
-                                << Token << " , " << LToString(Source)
-                                << ") -> " << LToString(CurrentState));
-    return {CurrentState, Source.Print};
-  }
-
-  static EdgeFunction<l_t> compose(EdgeFunctionRef<TSEdgeFunction> This,
-                                   const EdgeFunction<l_t> &SecondFunction) {
-    if (auto Default = defaultComposeOrNull(This, SecondFunction)) {
-      return Default;
-    }
-
-    return TSEdgeFunctionComposer{
-        {This, SecondFunction},
-        {This->TSD->bottom(), This->TSD->getStateToString()}};
-  }
-
-  static EdgeFunction<l_t> join(EdgeFunctionRef<TSEdgeFunction> This,
-                                const EdgeFunction<l_t> &OtherFunction) {
-    if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
-      return Default;
-    }
-
-    return AllBottom<IDETypeStateAnalysis::l_t>{
-        {This->TSD->bottom(), This->TSD->getStateToString()}};
-  }
-
-  bool operator==(const TSEdgeFunction &Other) const {
-    return CallSite == Other.CallSite && Token == Other.Token;
-  }
-
-  friend llvm::raw_ostream &print(llvm::raw_ostream &OS,
-                                  const TSEdgeFunction &TSE) {
-    return OS << "TSEF(" << TSE.Token << " at "
-              << llvmIRToShortString(TSE.CallSite) << ")";
-  }
-};
-
-struct TSConstant : ConstantEdgeFunction<IDETypeStateAnalysisDomain::l_t> {
-  const TypeStateDescription *TSD{};
-
-  /// XXX: Cannot default compose() and join(), because l_t does not implement
-  /// JoinLatticeTraits (because bottom value is not constant)
-  template <typename ConcreteEF>
-  static EdgeFunction<l_t> compose(EdgeFunctionRef<ConcreteEF> This,
-                                   const EdgeFunction<l_t> &SecondFunction) {
-
-    if (auto Default = defaultComposeOrNull(This, SecondFunction)) {
-      return Default;
-    }
-
-    l_t Ret = SecondFunction.computeTarget(This->Value);
-    if (Ret == This->Value) {
-      return This;
-    }
-    if (Ret == This->TSD->bottom()) {
-      return AllBottom<l_t>{Ret};
-    }
-
-    return TSConstant{{Ret}, This->TSD};
-  }
-
-  template <typename ConcreteEF>
-  static EdgeFunction<l_t> join(EdgeFunctionRef<ConcreteEF> This,
-                                const EdgeFunction<l_t> &OtherFunction) {
-    if (auto Default = defaultJoinOrNull(This, OtherFunction)) {
-      return Default;
-    }
-
-    const auto *TSD = This->TSD;
-    if (const auto *C = llvm::dyn_cast<TSConstant>(OtherFunction)) {
-      if (C->Value == This->Value || C->Value == TSD->top()) {
-        return This;
-      }
-      if (This->Value == TSD->top()) {
-        return OtherFunction;
-      }
-    }
-    return AllBottom<IDETypeStateAnalysis::l_t>{
-        {TSD->bottom(), TSD->getStateToString()}};
-  }
-};
-
-bool operator==(ByConstRef<TSConstant> LHS,
-                ByConstRef<TSConstant> RHS) noexcept {
-  return LHS.Value == RHS.Value;
-}
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                              ByConstRef<TSConstant> EF) {
-  return OS << "TSConstant[" << LToString(EF.Value) << "]";
-}
-
-IDETypeStateAnalysis::IDETypeStateAnalysis(const LLVMProjectIRDB *IRDB,
-                                           LLVMAliasInfoRef PT,
-                                           const TypeStateDescription *TSD,
-                                           std::vector<std::string> EntryPoints)
-    : IDETabulationProblem(IRDB, std::move(EntryPoints), createZeroValue()),
-      TSD(TSD), PT(PT) {
-  assert(TSD != nullptr);
-  assert(PT);
-
-  Print = TSD->getStateToString();
-}
-
-// Start formulating our analysis by specifying the parts required for IFDS
-
-IDETypeStateAnalysis::FlowFunctionPtrType
-IDETypeStateAnalysis::getNormalFlowFunction(
-    IDETypeStateAnalysis::n_t Curr, IDETypeStateAnalysis::n_t /*Succ*/) {
-  // Check if Alloca's type matches the target type. If so, generate from zero
-  // value.
-  if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
-    if (hasMatchingType(Alloca)) {
-      return generateFromZero(Alloca);
-    }
-  }
-  // Check load instructions for target type. Generate from the loaded value and
-  // kill the load instruction if it was generated previously (strong update!).
-  if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
-    if (hasMatchingType(Load)) {
-      struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
-        const llvm::LoadInst *Load;
-
-        TSFlowFunction(const llvm::LoadInst *L) : Load(L) {}
-        ~TSFlowFunction() override = default;
-        std::set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t Source) override {
-          if (Source == Load) {
-            return {};
-          }
-          if (Source == Load->getPointerOperand()) {
-            return {Source, Load};
-          }
-          return {Source};
-        }
-      };
-      return std::make_shared<TSFlowFunction>(Load);
-    }
-  }
-  if (const auto *Gep = llvm::dyn_cast<llvm::GetElementPtrInst>(Curr)) {
-    if (hasMatchingType(Gep->getPointerOperand())) {
-      return lambdaFlow<d_t>([=](d_t Source) -> std::set<d_t> {
-        // if (Source == Gep->getPointerOperand()) {
-        //  return {Source, Gep};
-        //}
-        return {Source};
-      });
-    }
-  }
-  // Check store instructions for target type. Perform a strong update, i.e.
-  // kill the alloca pointed to by the pointer-operand and all alloca's related
-  // to the value-operand and then generate them from the value-operand.
-  if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
-    if (hasMatchingType(Store)) {
-      auto RelevantAliasesAndAllocas = getLocalAliasesAndAllocas(
-          Store->getPointerOperand(), // pointer- or value operand???
-          // Store->getValueOperand(),
-          Curr->getParent()->getParent()->getName().str());
-
-      struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
-        const llvm::StoreInst *Store;
-        std::set<IDETypeStateAnalysis::d_t> AliasesAndAllocas;
-        TSFlowFunction(const llvm::StoreInst *S,
-                       std::set<IDETypeStateAnalysis::d_t> AA)
-            : Store(S), AliasesAndAllocas(std::move(AA)) {}
-        ~TSFlowFunction() override = default;
-        std::set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t Source) override {
-          // We kill all relevant loacal aliases and alloca's
-          if (Source != Store->getValueOperand() &&
-              // AliasesAndAllocas.find(Source) != AliasesAndAllocas.end()
-              // Is simple comparison sufficient?
-              Source == Store->getPointerOperand()) {
-            return {};
-          }
-          // Generate all local aliases and relevant alloca's from the stored
-          // value
-          if (Source == Store->getValueOperand()) {
-            AliasesAndAllocas.insert(Source);
-            return AliasesAndAllocas;
-          }
-          return {Source};
-        }
-      };
-      return std::make_shared<TSFlowFunction>(Store, RelevantAliasesAndAllocas);
-    }
-  }
-  return Identity<IDETypeStateAnalysis::d_t>::getInstance();
-}
-
-IDETypeStateAnalysis::FlowFunctionPtrType
-IDETypeStateAnalysis::getCallFlowFunction(IDETypeStateAnalysis::n_t CallSite,
-                                          IDETypeStateAnalysis::f_t DestFun) {
-  // Kill all data-flow facts if we hit a function of the target API.
-  // Those functions are modled within Call-To-Return.
-  if (TSD->isAPIFunction(llvm::demangle(DestFun->getName().str()))) {
-    return killAllFlows<d_t>();
-  }
-  // Otherwise, if we have an ordinary function call, we can just use the
-  // standard mapping.
-  if (const auto *Call = llvm::dyn_cast<llvm::CallBase>(CallSite)) {
-    return mapFactsToCallee(Call, DestFun);
-  }
-  llvm::report_fatal_error("callSite not a CallInst nor a InvokeInst");
-}
-
-IDETypeStateAnalysis::FlowFunctionPtrType
-IDETypeStateAnalysis::getRetFlowFunction(
-    IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::f_t CalleeFun,
-    IDETypeStateAnalysis::n_t ExitStmt, IDETypeStateAnalysis::n_t /*RetSite*/) {
-  // Besides mapping the formal parameter back into the actual parameter and
-  // propagating the return value into the caller context, we also propagate
-  // all related alloca's of the formal parameter and the return value.
-  struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
-    const llvm::CallBase *CallSite;
-    const llvm::Function *CalleeFun;
-    const llvm::ReturnInst *ExitSite;
-    IDETypeStateAnalysis *Analysis;
-    std::vector<const llvm::Value *> Actuals;
-    std::vector<const llvm::Value *> Formals;
-    TSFlowFunction(const llvm::CallBase *CallSite,
-                   const llvm::Function *CalleeFun,
-                   const llvm::Instruction *ExitSite,
-                   IDETypeStateAnalysis *Analysis)
-        : CallSite(CallSite), CalleeFun(CalleeFun),
-          ExitSite(llvm::dyn_cast<llvm::ReturnInst>(ExitSite)),
-          Analysis(Analysis) {
-      // Set up the actual parameters
-      for (unsigned Idx = 0; Idx < CallSite->arg_size(); ++Idx) {
-        Actuals.push_back(CallSite->getArgOperand(Idx));
-      }
-      // Set up the formal parameters
-      for (unsigned Idx = 0; Idx < CalleeFun->arg_size(); ++Idx) {
-        Formals.push_back(getNthFunctionArgument(CalleeFun, Idx));
-      }
-    }
-
-    ~TSFlowFunction() override = default;
-
-    std::set<IDETypeStateAnalysis::d_t>
-    computeTargets(IDETypeStateAnalysis::d_t Source) override {
-      if (!LLVMZeroValue::isLLVMZeroValue(Source)) {
-        std::set<const llvm::Value *> Res;
-        // Handle C-style varargs functions
-        if (CalleeFun->isVarArg() && !CalleeFun->isDeclaration()) {
-          const llvm::Instruction *AllocVarArg;
-          // Find the allocation of %struct.__va_list_tag
-          for (const auto &BB : *CalleeFun) {
-            for (const auto &I : BB) {
-              if (const auto *Alloc = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
-                if (Alloc->getAllocatedType()->isArrayTy() &&
-                    Alloc->getAllocatedType()->getArrayNumElements() > 0 &&
-                    Alloc->getAllocatedType()
-                        ->getArrayElementType()
-                        ->isStructTy() &&
-                    Alloc->getAllocatedType()
-                            ->getArrayElementType()
-                            ->getStructName() == "struct.__va_list_tag") {
-                  AllocVarArg = Alloc;
-                  // TODO break out this nested loop earlier (without goto ;-)
-                }
-              }
-            }
-          }
-          // Generate the varargs things by using an over-approximation
-          if (Source == AllocVarArg) {
-            for (unsigned Idx = Formals.size(); Idx < Actuals.size(); ++Idx) {
-              Res.insert(Actuals[Idx]);
-            }
-          }
-        }
-        // Handle ordinary case
-        // Map formal parameter into corresponding actual parameter.
-        for (unsigned Idx = 0; Idx < Formals.size(); ++Idx) {
-          if (Source == Formals[Idx]) {
-            Res.insert(Actuals[Idx]); // corresponding actual
-          }
-        }
-        // Collect the return value
-        if (Source == ExitSite->getReturnValue()) {
-          Res.insert(CallSite);
-        }
-        // Collect all relevant alloca's to map into caller context
-        std::set<IDETypeStateAnalysis::d_t> RelAllocas;
-        for (const auto *Fact : Res) {
-          auto Allocas = Analysis->getRelevantAllocas(Fact);
-          RelAllocas.insert(Allocas.begin(), Allocas.end());
-        }
-        Res.insert(RelAllocas.begin(), RelAllocas.end());
-        return Res;
-      }
-      return {Source};
-    }
-  };
-  return std::make_shared<TSFlowFunction>(llvm::cast<llvm::CallBase>(CallSite),
-                                          CalleeFun, ExitStmt, this);
-}
-
-IDETypeStateAnalysis::FlowFunctionPtrType
-IDETypeStateAnalysis::getCallToRetFlowFunction(
-    IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::n_t /*RetSite*/,
-    llvm::ArrayRef<f_t> Callees) {
-  const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
-  for (const auto *Callee : Callees) {
-    std::string DemangledFname = llvm::demangle(Callee->getName().str());
-    // Generate the return value of factory functions from zero value
-    if (TSD->isFactoryFunction(DemangledFname)) {
-      struct TSFlowFunction : FlowFunction<IDETypeStateAnalysis::d_t> {
-        IDETypeStateAnalysis::d_t CS, ZeroValue;
-
-        TSFlowFunction(IDETypeStateAnalysis::d_t CS,
-                       IDETypeStateAnalysis::d_t Z)
-            : CS(CS), ZeroValue(Z) {}
-        ~TSFlowFunction() override = default;
-        std::set<IDETypeStateAnalysis::d_t>
-        computeTargets(IDETypeStateAnalysis::d_t Source) override {
-          if (Source == CS) {
-            return {};
-          }
-          if (Source == ZeroValue) {
-            return {Source, CS};
-          }
-          return {Source};
-        }
-      };
-      return std::make_shared<TSFlowFunction>(CS, getZeroValue());
-    }
-
-    // Handle all functions that are not modeld with special semantics.
-    // Kill actual parameters of target type and all its aliases
-    // and the corresponding alloca(s) as these data-flow facts are
-    // (inter-procedurally) propagated via Call- and the corresponding
-    // Return-Flow. Otherwise we might propagate facts with not updated
-    // states.
-    // Alloca's related to the return value of non-api functions will
-    // not be killed during call-to-return, since it is not safe to assume
-    // that the return value will be used afterwards, i.e. is stored to memory
-    // pointed to by related alloca's.
-    if (!TSD->isAPIFunction(DemangledFname) && !Callee->isDeclaration()) {
-      for (const auto &Arg : CS->args()) {
-        if (hasMatchingType(Arg)) {
-          return killManyFlows<d_t>(getWMAliasesAndAllocas(Arg.get()));
-        }
-      }
-    }
-  }
-  return Identity<IDETypeStateAnalysis::d_t>::getInstance();
-}
-
-IDETypeStateAnalysis::FlowFunctionPtrType
-IDETypeStateAnalysis::getSummaryFlowFunction(
-    IDETypeStateAnalysis::n_t /*CallSite*/,
-    IDETypeStateAnalysis::f_t /*DestFun*/) {
-  return nullptr;
-}
-
-InitialSeeds<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-             IDETypeStateAnalysis::l_t>
-IDETypeStateAnalysis::initialSeeds() {
-  // just start in main()
-  return createDefaultSeeds();
-}
-
-IDETypeStateAnalysis::d_t IDETypeStateAnalysis::createZeroValue() const {
-  // create a special value to represent the zero value!
-  return LLVMZeroValue::getInstance();
-}
-
-bool IDETypeStateAnalysis::isZeroValue(IDETypeStateAnalysis::d_t Fact) const {
-  return LLVMZeroValue::isLLVMZeroValue(Fact);
-}
-
-// in addition provide specifications for the IDE parts
-
-struct TSAllocaEF : TSConstant {
-  const llvm::AllocaInst *Alloca;
-  TSAllocaEF(const TypeStateDescription *Tsd,
-             const llvm::AllocaInst *Alloca) noexcept
-      : TSConstant{{{Tsd->uninit(), Tsd->getStateToString()}}, Tsd},
-        Alloca(Alloca) {}
-
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                       const TSAllocaEF &TSA) {
-    return OS << "Alloca(" << llvmIRToShortString(TSA.Alloca) << ")";
-  }
-};
-
-auto IDETypeStateAnalysis::getNormalEdgeFunction(
-    IDETypeStateAnalysis::n_t Curr, IDETypeStateAnalysis::d_t CurrNode,
-    IDETypeStateAnalysis::n_t /*Succ*/, IDETypeStateAnalysis::d_t SuccNode)
-    -> EdgeFunction<l_t> {
-  // Set alloca instructions of target type to uninitialized.
-  if (const auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(Curr)) {
-    if (hasMatchingType(Alloca)) {
-      if (CurrNode == getZeroValue() && SuccNode == Alloca) {
-        return TSAllocaEF(TSD, Alloca);
-      }
-    }
-  }
-  return EdgeIdentity<l_t>{};
-}
-
-auto IDETypeStateAnalysis::getCallEdgeFunction(
-    IDETypeStateAnalysis::n_t /*CallSite*/,
-    IDETypeStateAnalysis::d_t /*SrcNode*/,
-    IDETypeStateAnalysis::f_t /*DestinationFunction*/,
-    IDETypeStateAnalysis::d_t /*DestNode*/) -> EdgeFunction<l_t> {
-  return EdgeIdentity<l_t>{};
-}
-
-auto IDETypeStateAnalysis::getReturnEdgeFunction(
-    IDETypeStateAnalysis::n_t /*CallSite*/,
-    IDETypeStateAnalysis::f_t /*CalleeFunction*/,
-    IDETypeStateAnalysis::n_t /*ExitSite*/,
-    IDETypeStateAnalysis::d_t /*ExitNode*/,
-    IDETypeStateAnalysis::n_t /*ReSite*/, IDETypeStateAnalysis::d_t /*RetNode*/)
-    -> EdgeFunction<l_t> {
-  return EdgeIdentity<l_t>{};
-}
-
-auto IDETypeStateAnalysis::getCallToRetEdgeFunction(
-    IDETypeStateAnalysis::n_t CallSite, IDETypeStateAnalysis::d_t CallNode,
-    IDETypeStateAnalysis::n_t /*RetSite*/,
-    IDETypeStateAnalysis::d_t RetSiteNode, llvm::ArrayRef<f_t> Callees)
-    -> EdgeFunction<l_t> {
-  const auto *CS = llvm::cast<llvm::CallBase>(CallSite);
-  for (const auto *Callee : Callees) {
-    std::string DemangledFname = llvm::demangle(Callee->getName().str());
-
-    // For now we assume that we can only generate from the return value.
-    // We apply the same edge function for the return value, i.e. callsite.
-    if (TSD->isFactoryFunction(DemangledFname)) {
-      PHASAR_LOG_LEVEL(DEBUG, "Processing factory function");
-      if (isZeroValue(CallNode) && RetSiteNode == CS) {
-        return TSConstant{
-            {{TSD->getNextState(DemangledFname, TSD->uninit(), CS), Print}},
-            TSD};
-      }
-    }
-
-    // For every consuming parameter and all its aliases and relevant alloca's
-    // we apply the same edge function.
-    if (TSD->isConsumingFunction(DemangledFname)) {
-      PHASAR_LOG_LEVEL(DEBUG, "Processing consuming function");
-      for (auto Idx : TSD->getConsumerParamIdx(DemangledFname)) {
-        std::set<IDETypeStateAnalysis::d_t> AliasAndAllocas =
-            getWMAliasesAndAllocas(CS->getArgOperand(Idx));
-
-        if (CallNode == RetSiteNode &&
-            AliasAndAllocas.find(CallNode) != AliasAndAllocas.end()) {
-          return TSEdgeFunction{TSD, DemangledFname, CS};
-        }
-      }
-    }
-  }
-  return EdgeIdentity<l_t>{};
-}
-
-auto IDETypeStateAnalysis::getSummaryEdgeFunction(
-    IDETypeStateAnalysis::n_t /*CallSite*/,
-    IDETypeStateAnalysis::d_t /*CallNode*/,
-    IDETypeStateAnalysis::n_t /*RetSite*/,
-    IDETypeStateAnalysis::d_t /*RetSiteNode*/) -> EdgeFunction<l_t> {
-  return nullptr;
-}
-
-IDETypeStateAnalysis::l_t IDETypeStateAnalysis::topElement() {
-  return {TSD->top(), Print};
-}
-
-IDETypeStateAnalysis::l_t IDETypeStateAnalysis::bottomElement() {
-  return {TSD->bottom(), Print};
-}
-
-IDETypeStateAnalysis::l_t
-IDETypeStateAnalysis::join(IDETypeStateAnalysis::l_t Lhs,
-                           IDETypeStateAnalysis::l_t Rhs) {
-  if (Lhs == Rhs) {
-    return Lhs;
-  }
-  if (Lhs == TSD->top()) {
-    return Rhs;
-  }
-  if (Rhs == TSD->top()) {
-    return Lhs;
-  }
-  return {TSD->bottom(), Print};
-}
-
-auto IDETypeStateAnalysis::allTopFunction() -> EdgeFunction<l_t> {
-  return AllTop<IDETypeStateAnalysis::l_t>{{TSD->top(), Print}};
-}
-
-std::set<IDETypeStateAnalysis::d_t>
-IDETypeStateAnalysis::getRelevantAllocas(IDETypeStateAnalysis::d_t V) {
+auto IDETypeStateAnalysisBase::getRelevantAllocas(d_t V) -> container_type {
   if (RelevantAllocaCache.find(V) != RelevantAllocaCache.end()) {
     return RelevantAllocaCache[V];
   }
   auto AliasSet = getWMAliasSet(V);
-  std::set<IDETypeStateAnalysis::d_t> RelevantAllocas;
+  container_type RelevantAllocas;
   PHASAR_LOG_LEVEL(DEBUG, "Compute relevant alloca's of " << DToString(V));
   for (const auto *Alias : AliasSet) {
     PHASAR_LOG_LEVEL(DEBUG, "Alias: " << DToString(Alias));
@@ -607,11 +73,9 @@ IDETypeStateAnalysis::getRelevantAllocas(IDETypeStateAnalysis::d_t V) {
   return RelevantAllocas;
 }
 
-std::set<IDETypeStateAnalysis::d_t>
-IDETypeStateAnalysis::getWMAliasSet(IDETypeStateAnalysis::d_t V) {
+auto IDETypeStateAnalysisBase::getWMAliasSet(d_t V) -> container_type {
   if (AliasCache.find(V) != AliasCache.end()) {
-    std::set<IDETypeStateAnalysis::d_t> AliasSet(AliasCache[V].begin(),
-                                                 AliasCache[V].end());
+    container_type AliasSet(AliasCache[V].begin(), AliasCache[V].end());
     return AliasSet;
   }
   auto PTS = PT.getAliasSet(V);
@@ -620,28 +84,25 @@ IDETypeStateAnalysis::getWMAliasSet(IDETypeStateAnalysis::d_t V) {
       AliasCache[Alias] = *PTS;
     }
   }
-  std::set<IDETypeStateAnalysis::d_t> AliasSet(PTS->begin(), PTS->end());
+  container_type AliasSet(PTS->begin(), PTS->end());
   return AliasSet;
 }
 
-std::set<IDETypeStateAnalysis::d_t>
-IDETypeStateAnalysis::getWMAliasesAndAllocas(IDETypeStateAnalysis::d_t V) {
-  std::set<IDETypeStateAnalysis::d_t> AliasAndAllocas;
-  std::set<IDETypeStateAnalysis::d_t> RelevantAllocas = getRelevantAllocas(V);
-  std::set<IDETypeStateAnalysis::d_t> Aliases = getWMAliasSet(V);
+auto IDETypeStateAnalysisBase::getWMAliasesAndAllocas(d_t V) -> container_type {
+  container_type AliasAndAllocas;
+  container_type RelevantAllocas = getRelevantAllocas(V);
+  container_type Aliases = getWMAliasSet(V);
   AliasAndAllocas.insert(Aliases.begin(), Aliases.end());
   AliasAndAllocas.insert(RelevantAllocas.begin(), RelevantAllocas.end());
   return AliasAndAllocas;
 }
 
-std::set<IDETypeStateAnalysis::d_t>
-IDETypeStateAnalysis::getLocalAliasesAndAllocas(IDETypeStateAnalysis::d_t V,
-                                                const std::string & /*Fname*/) {
-  std::set<IDETypeStateAnalysis::d_t> AliasAndAllocas;
-  std::set<IDETypeStateAnalysis::d_t> RelevantAllocas = getRelevantAllocas(V);
-  std::set<IDETypeStateAnalysis::d_t>
-      Aliases; // =
-               // IRDB->getAliasGraph(Fname)->getAliasSet(V);
+auto IDETypeStateAnalysisBase::getLocalAliasesAndAllocas(
+    d_t V, llvm::StringRef /*Fname*/) -> container_type {
+  container_type AliasAndAllocas;
+  container_type RelevantAllocas = getRelevantAllocas(V);
+  container_type Aliases; // =
+                          // IRDB->getAliasGraph(Fname)->getAliasSet(V);
   for (const auto *Alias : Aliases) {
     if (hasMatchingType(Alias)) {
       AliasAndAllocas.insert(Alias);
@@ -651,22 +112,26 @@ IDETypeStateAnalysis::getLocalAliasesAndAllocas(IDETypeStateAnalysis::d_t V,
   AliasAndAllocas.insert(RelevantAllocas.begin(), RelevantAllocas.end());
   return AliasAndAllocas;
 }
-bool hasMatchingTypeName(const llvm::Type *Ty, const std::string &Pattern) {
+
+static bool hasMatchingTypeName(
+    const llvm::Type *Ty,
+    const std::function<bool(llvm::StringRef)> &IsTypeNameOfInterest) {
   if (const auto *StructTy = llvm::dyn_cast<llvm::StructType>(Ty)) {
-    return StructTy->getName().contains(Pattern);
+    return IsTypeNameOfInterest(StructTy->getName());
   }
   // primitive type
   std::string Str;
   llvm::raw_string_ostream S(Str);
   S << *Ty;
   S.flush();
-  return Str.find(Pattern) != std::string::npos;
+  return IsTypeNameOfInterest(Str);
 }
-bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
+
+bool IDETypeStateAnalysisBase::hasMatchingType(d_t V) {
   // General case
   if (V->getType()->isPointerTy()) {
     if (hasMatchingTypeName(V->getType()->getPointerElementType(),
-                            TSD->getTypeNameOfInterest())) {
+                            IsTypeNameOfInterest)) {
       return true;
     }
   }
@@ -674,7 +139,7 @@ bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
     if (Alloca->getAllocatedType()->isPointerTy()) {
       if (hasMatchingTypeName(
               Alloca->getAllocatedType()->getPointerElementType(),
-              TSD->getTypeNameOfInterest())) {
+              IsTypeNameOfInterest)) {
         return true;
       }
     }
@@ -689,7 +154,7 @@ bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
                                   ->getType()
                                   ->getPointerElementType()
                                   ->getPointerElementType(),
-                              TSD->getTypeNameOfInterest())) {
+                              IsTypeNameOfInterest)) {
         return true;
       }
     }
@@ -699,7 +164,7 @@ bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
     if (Store->getValueOperand()->getType()->isPointerTy()) {
       if (hasMatchingTypeName(
               Store->getValueOperand()->getType()->getPointerElementType(),
-              TSD->getTypeNameOfInterest())) {
+              IsTypeNameOfInterest)) {
         return true;
       }
     }
@@ -708,85 +173,4 @@ bool IDETypeStateAnalysis::hasMatchingType(IDETypeStateAnalysis::d_t V) {
   return false;
 }
 
-void IDETypeStateAnalysis::emitTextReport(
-    const SolverResults<IDETypeStateAnalysis::n_t, IDETypeStateAnalysis::d_t,
-                        IDETypeStateAnalysis::l_t> &SR,
-    llvm::raw_ostream &OS) {
-
-  LLVMBasedCFG CFG;
-  OS << "\n======= TYPE STATE RESULTS =======\n";
-  for (const auto &F : IRDB->getAllFunctions()) {
-    OS << '\n' << getFunctionNameFromIR(F) << '\n';
-    for (const auto &BB : *F) {
-      for (const auto &I : BB) {
-        auto Results = SR.resultsAt(&I, true);
-        if (CFG.isExitInst(&I)) {
-          OS << "\nAt exit stmt: " << NToString(&I) << '\n';
-          for (auto Res : Results) {
-            if (const auto *Alloca =
-                    llvm::dyn_cast<llvm::AllocaInst>(Res.first)) {
-              if (Res.second == TSD->error()) {
-                OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
-                   << DToString(Res.first) << '\n';
-                for (const auto *Pred : CFG.getPredsOf(&I)) {
-                  OS << "\nPredecessor: " << NToString(Pred) << '\n';
-                  auto PredResults = SR.resultsAt(Pred, true);
-                  for (auto Res : PredResults) {
-                    if (Res.first == Alloca) {
-                      OS << "Pred State: " << LToString(Res.second) << '\n';
-                    }
-                  }
-                }
-                OS << "============================\n";
-              } else {
-                OS << "\nAlloca : " << DToString(Res.first)
-                   << "\nState  : " << LToString(Res.second) << '\n';
-              }
-            } else {
-              OS << "\nInst: " << NToString(&I) << '\n'
-                 << "Fact: " << DToString(Res.first) << '\n'
-                 << "State: " << LToString(Res.second) << '\n';
-            }
-          }
-        } else {
-          for (auto Res : Results) {
-            if (const auto *Alloca =
-                    llvm::dyn_cast<llvm::AllocaInst>(Res.first)) {
-              if (Res.second == TSD->error()) {
-                OS << "\n=== ERROR STATE DETECTED ===\nAlloca: "
-                   << DToString(Res.first) << '\n'
-                   << "\nAt IR Inst: " << NToString(&I) << '\n';
-                for (const auto *Pred : CFG.getPredsOf(&I)) {
-                  OS << "\nPredecessor: " << NToString(Pred) << '\n';
-                  auto PredResults = SR.resultsAt(Pred, true);
-                  for (auto Res : PredResults) {
-                    if (Res.first == Alloca) {
-                      OS << "Pred State: " << LToString(Res.second) << '\n';
-                    }
-                  }
-                }
-                OS << "============================\n";
-              }
-            } else {
-              OS << "\nInst: " << NToString(&I) << '\n'
-                 << "Fact: " << DToString(Res.first) << '\n'
-                 << "State: " << LToString(Res.second) << '\n';
-            }
-          }
-        }
-      }
-    }
-    OS << "\n--------------------------------------------\n";
-  }
-}
-
-} // namespace psr
-
-std::string psr::LToString(TypeState S) {
-  if (!S.Print) {
-    PHASAR_LOG_LEVEL(WARNING, "Printing default constructed TypeState");
-    return "TOP";
-  }
-
-  return S.Print(S.State);
-}
+} // namespace psr::detail

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
@@ -25,14 +25,14 @@ namespace psr {
  *
  *                TOP = no information
  */
-enum class CSTDFILEIOState {
-  TOP = 42,
-  UNINIT = 0,
-  OPENED = 1,
-  CLOSED = 2,
-  ERROR = 3,
-  BOT = 4
-};
+// enum class CSTDFILEIOState {
+//   TOP = 42,
+//   UNINIT = 0,
+//   OPENED = 1,
+//   CLOSED = 2,
+//   ERROR = 3,
+//   BOT = 4
+// };
 
 namespace {
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.cpp
@@ -9,14 +9,14 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/CSTDFILEIOTypeStateDescription.h"
 
+#include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
+
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #include <string>
 
 namespace psr {
-
-namespace {
 /**
  * We use the following lattice
  *                BOT = all information
@@ -25,7 +25,7 @@ namespace {
  *
  *                TOP = no information
  */
-enum CSTDFILEIOState {
+enum class CSTDFILEIOState {
   TOP = 42,
   UNINIT = 0,
   OPENED = 1,
@@ -33,6 +33,8 @@ enum CSTDFILEIOState {
   ERROR = 3,
   BOT = 4
 };
+
+namespace {
 
 /**
  * The STAR token represents all API functions besides fopen(), fdopen() and
@@ -71,7 +73,7 @@ const llvm::StringMap<std::set<int>> &getStdFileIOFuncs() noexcept {
   return StdFileIOFuncs;
 }
 
-CSTDFILEIOToken funcNameToToken(const std::string &F) {
+CSTDFILEIOToken funcNameToToken(llvm::StringRef F) {
   if (F == "fopen" || F == "fdopen") {
     return CSTDFILEIOToken::FOPEN;
   }
@@ -88,7 +90,7 @@ CSTDFILEIOToken funcNameToToken(const std::string &F) {
 // States: UNINIT = 0, OPENED = 1, CLOSED = 2, ERROR = 3, BOT = 4
 
 bool CSTDFILEIOTypeStateDescription::isFactoryFunction(
-    const std::string &F) const {
+    llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return getStdFileIOFuncs().lookup(F).count(-1);
   }
@@ -96,24 +98,25 @@ bool CSTDFILEIOTypeStateDescription::isFactoryFunction(
 }
 
 bool CSTDFILEIOTypeStateDescription::isConsumingFunction(
-    const std::string &F) const {
+    llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return !getStdFileIOFuncs().lookup(F).count(-1);
   }
   return false;
 }
 
-bool CSTDFILEIOTypeStateDescription::isAPIFunction(const std::string &F) const {
+bool CSTDFILEIOTypeStateDescription::isAPIFunction(llvm::StringRef F) const {
   return getStdFileIOFuncs().count(F);
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::getNextState(
-    std::string Tok, TypeStateDescription::State S) const {
+CSTDFILEIOState
+CSTDFILEIOTypeStateDescription::getNextState(llvm::StringRef Tok,
+                                             State S) const {
   if (isAPIFunction(Tok)) {
     auto X = static_cast<std::underlying_type_t<CSTDFILEIOToken>>(
         funcNameToToken(Tok));
 
-    auto Ret = Delta[X][S];
+    auto Ret = Delta[X][int(S)];
     // if (ret == error()) {
     //  std::cerr << "getNextState(" << Tok << ", " << stateToString(S)
     //            << ") = " << stateToString(Ret) << std::endl;
@@ -127,8 +130,8 @@ std::string CSTDFILEIOTypeStateDescription::getTypeNameOfInterest() const {
   return "struct._IO_FILE";
 }
 
-std::set<int> CSTDFILEIOTypeStateDescription::getConsumerParamIdx(
-    const std::string &F) const {
+std::set<int>
+CSTDFILEIOTypeStateDescription::getConsumerParamIdx(llvm::StringRef F) const {
   if (isConsumingFunction(F)) {
     return getStdFileIOFuncs().lookup(F);
   }
@@ -136,7 +139,7 @@ std::set<int> CSTDFILEIOTypeStateDescription::getConsumerParamIdx(
 }
 
 std::set<int>
-CSTDFILEIOTypeStateDescription::getFactoryParamIdx(const std::string &F) const {
+CSTDFILEIOTypeStateDescription::getFactoryParamIdx(llvm::StringRef F) const {
   if (isFactoryFunction(F)) {
     // Trivial here, since we only generate via return value
     return {-1};
@@ -144,53 +147,51 @@ CSTDFILEIOTypeStateDescription::getFactoryParamIdx(const std::string &F) const {
   return {};
 }
 
-auto CSTDFILEIOTypeStateDescription::getStateToString() const
-    -> std::string (*)(int) {
-  return [](TypeStateDescription::State S) -> std::string {
-    switch (S) {
-    case CSTDFILEIOState::TOP:
-      return "TOP";
-      break;
-    case CSTDFILEIOState::UNINIT:
-      return "UNINIT";
-      break;
-    case CSTDFILEIOState::OPENED:
-      return "OPENED";
-      break;
-    case CSTDFILEIOState::CLOSED:
-      return "CLOSED";
-      break;
-    case CSTDFILEIOState::ERROR:
-      return "ERROR";
-      break;
-    case CSTDFILEIOState::BOT:
-      return "BOT";
-      break;
-    default:
-      llvm::report_fatal_error("received unknown state!");
-      break;
-    }
-  };
+llvm::StringRef to_string(CSTDFILEIOState State) noexcept {
+  switch (State) {
+  case CSTDFILEIOState::TOP:
+    return "TOP";
+    break;
+  case CSTDFILEIOState::UNINIT:
+    return "UNINIT";
+    break;
+  case CSTDFILEIOState::OPENED:
+    return "OPENED";
+    break;
+  case CSTDFILEIOState::CLOSED:
+    return "CLOSED";
+    break;
+  case CSTDFILEIOState::ERROR:
+    return "ERROR";
+    break;
+  case CSTDFILEIOState::BOT:
+    return "BOT";
+    break;
+  }
+
+  llvm::report_fatal_error("received unknown state!");
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::bottom() const {
+CSTDFILEIOState CSTDFILEIOTypeStateDescription::bottom() const {
   return CSTDFILEIOState::BOT;
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::top() const {
+CSTDFILEIOState CSTDFILEIOTypeStateDescription::top() const {
   return CSTDFILEIOState::TOP;
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::uninit() const {
+CSTDFILEIOState CSTDFILEIOTypeStateDescription::uninit() const {
   return CSTDFILEIOState::UNINIT;
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::start() const {
+CSTDFILEIOState CSTDFILEIOTypeStateDescription::start() const {
   return CSTDFILEIOState::OPENED;
 }
 
-TypeStateDescription::State CSTDFILEIOTypeStateDescription::error() const {
+CSTDFILEIOState CSTDFILEIOTypeStateDescription::error() const {
   return CSTDFILEIOState::ERROR;
 }
+
+template class IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>;
 
 } // namespace psr

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.cpp
@@ -21,12 +21,11 @@
 namespace psr {
 
 // Return value is modeled as -1
-const std::map<std::string, std::set<int>>
-    OpenSSLEVPKDFCTXDescription::OpenSSLEVPKDFFuncs = {
-        {"EVP_KDF_CTX_new", {-1}},
-        {"EVP_KDF_CTX_set_params", {0}},
-        {"EVP_KDF_derive", {0}},
-        {"EVP_KDF_CTX_free", {0}}
+static const std::map<llvm::StringRef, std::set<int>> OpenSSLEVPKDFFuncs = {
+    {"EVP_KDF_CTX_new", {-1}},
+    {"EVP_KDF_CTX_set_params", {0}},
+    {"EVP_KDF_derive", {0}},
+    {"EVP_KDF_CTX_free", {0}}
 
 };
 
@@ -39,86 +38,82 @@ const std::map<std::string, std::set<int>>
 //
 // States: UNINIT = 5, CTX_ATTACHED =1, PARAM_INIT = 2,
 // DERIVED = 3, ERROR = 4, BOT = 0
-const OpenSSLEVPKDFCTXDescription::OpenSSLEVPKDFState
-    OpenSSLEVPKDFCTXDescription::Delta[5][6] = {
+const OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::Delta[5][6] = {
 
-        /* EVP_KDF_CTX_NEW */
-        {OpenSSLEVPKDFState::CTX_ATTACHED, OpenSSLEVPKDFState::CTX_ATTACHED,
-         OpenSSLEVPKDFState::CTX_ATTACHED, OpenSSLEVPKDFState::CTX_ATTACHED,
-         OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::CTX_ATTACHED},
-        /* EVP_KDF_CTX_SET_PARAMS */
-        {OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::PARAM_INIT,
-         OpenSSLEVPKDFState::PARAM_INIT, OpenSSLEVPKDFState::PARAM_INIT,
-         OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::ERROR},
-        /* DERIVE */
-        {OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::ERROR,
-         OpenSSLEVPKDFState::DERIVED, OpenSSLEVPKDFState::DERIVED,
-         OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::ERROR},
-        /* EVP_KDF_CTX_FREE */
-        {OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::UNINIT,
-         OpenSSLEVPKDFState::UNINIT, OpenSSLEVPKDFState::UNINIT,
-         OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::ERROR},
+    /* EVP_KDF_CTX_NEW */
+    {OpenSSLEVPKDFCTXState::CTX_ATTACHED, OpenSSLEVPKDFCTXState::CTX_ATTACHED,
+     OpenSSLEVPKDFCTXState::CTX_ATTACHED, OpenSSLEVPKDFCTXState::CTX_ATTACHED,
+     OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+    /* EVP_KDF_CTX_SET_PARAMS */
+    {OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::PARAM_INIT,
+     OpenSSLEVPKDFCTXState::PARAM_INIT, OpenSSLEVPKDFCTXState::PARAM_INIT,
+     OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::ERROR},
+    /* DERIVE */
+    {OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::ERROR,
+     OpenSSLEVPKDFCTXState::DERIVED, OpenSSLEVPKDFCTXState::DERIVED,
+     OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::ERROR},
+    /* EVP_KDF_CTX_FREE */
+    {OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::UNINIT,
+     OpenSSLEVPKDFCTXState::UNINIT, OpenSSLEVPKDFCTXState::UNINIT,
+     OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::ERROR},
 
-        /* STAR */
-        {OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::CTX_ATTACHED,
-         OpenSSLEVPKDFState::PARAM_INIT, OpenSSLEVPKDFState::DERIVED,
-         OpenSSLEVPKDFState::ERROR, OpenSSLEVPKDFState::ERROR},
+    /* STAR */
+    {OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::CTX_ATTACHED,
+     OpenSSLEVPKDFCTXState::PARAM_INIT, OpenSSLEVPKDFCTXState::DERIVED,
+     OpenSSLEVPKDFCTXState::ERROR, OpenSSLEVPKDFCTXState::ERROR},
 };
 
-bool OpenSSLEVPKDFCTXDescription::isFactoryFunction(
-    const std::string &F) const {
+bool OpenSSLEVPKDFCTXDescription::isFactoryFunction(llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return OpenSSLEVPKDFFuncs.at(F).find(-1) != OpenSSLEVPKDFFuncs.at(F).end();
   }
   return false;
 }
 
-bool OpenSSLEVPKDFCTXDescription::isConsumingFunction(
-    const std::string &F) const {
+bool OpenSSLEVPKDFCTXDescription::isConsumingFunction(llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return OpenSSLEVPKDFFuncs.at(F).find(-1) == OpenSSLEVPKDFFuncs.at(F).end();
   }
   return false;
 }
 
-bool OpenSSLEVPKDFCTXDescription::isAPIFunction(const std::string &F) const {
+bool OpenSSLEVPKDFCTXDescription::isAPIFunction(llvm::StringRef F) const {
   return OpenSSLEVPKDFFuncs.find(F) != OpenSSLEVPKDFFuncs.end();
 }
 
-TypeStateDescription::State
-OpenSSLEVPKDFCTXDescription::getNextState(std::string Tok,
+OpenSSLEVPKDFCTXState
+OpenSSLEVPKDFCTXDescription::getNextState(llvm::StringRef Tok,
                                           TypeStateDescription::State S) const {
   if (isAPIFunction(Tok)) {
     auto NameToTok = funcNameToToken(Tok);
     auto Ret = Delta[static_cast<std::underlying_type_t<OpenSSLEVTKDFToken>>(
-        NameToTok)][S];
+        NameToTok)][int(S)];
 
     // std::cout << "delta[" << Tok << ", " << stateToString(S)
     //           << "] = " << stateToString(ret) << std::endl;
     return Ret;
   }
-  return OpenSSLEVPKDFState::BOT;
+  return OpenSSLEVPKDFCTXState::BOT;
 }
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::getNextState(
-    const std::string &Tok, TypeStateDescription::State S,
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::getNextState(
+    llvm::StringRef Tok, TypeStateDescription::State S,
     const llvm::CallBase *CallSite) const {
   if (isAPIFunction(Tok)) {
     auto NameToTok = funcNameToToken(Tok);
     auto Ret = Delta[static_cast<std::underlying_type_t<OpenSSLEVTKDFToken>>(
-        NameToTok)][S];
+        NameToTok)][int(S)];
 
     if (NameToTok == OpenSSLEVTKDFToken::EVP_KDF_CTX_NEW) {
       // require the kdf here to be in KDF_FETCHED state
 
       // requiredKDFState[make_pair(CS.getInstruction(), CS.getArgOperand(0))] =
-      //     (OpenSSLEVPKDFDescription::OpenSSLEVPKDFState::KDF_FETCHED);
+      //     (OpenSSLEVPKDFDescription::OpenSSLEVPKDFCTXState::KDF_FETCHED);
       // cout << "## Factory-Call: ";
       // cout.flush();
       // cout << llvmIRToShortString(CS.getInstruction()) << endl;
       auto KdfState =
           KDFAnalysisResults.resultAt(CallSite, CallSite->getArgOperand(0));
-      if (KdfState !=
-          OpenSSLEVPKDFDescription::OpenSSLEVPKDFState::KDF_FETCHED) {
+      if (KdfState != OpenSSLEVPKDFState::KDF_FETCHED) {
         return error();
       }
     }
@@ -126,7 +121,7 @@ TypeStateDescription::State OpenSSLEVPKDFCTXDescription::getNextState(
     //           << "] = " << stateToString(ret) << std::endl;
     return Ret;
   }
-  return OpenSSLEVPKDFState::BOT;
+  return OpenSSLEVPKDFCTXState::BOT;
 }
 
 std::string OpenSSLEVPKDFCTXDescription::getTypeNameOfInterest() const {
@@ -134,7 +129,7 @@ std::string OpenSSLEVPKDFCTXDescription::getTypeNameOfInterest() const {
 }
 
 std::set<int>
-OpenSSLEVPKDFCTXDescription::getConsumerParamIdx(const std::string &F) const {
+OpenSSLEVPKDFCTXDescription::getConsumerParamIdx(llvm::StringRef F) const {
   if (isConsumingFunction(F)) {
     return OpenSSLEVPKDFFuncs.at(F);
   }
@@ -142,7 +137,7 @@ OpenSSLEVPKDFCTXDescription::getConsumerParamIdx(const std::string &F) const {
 }
 
 std::set<int>
-OpenSSLEVPKDFCTXDescription::getFactoryParamIdx(const std::string &F) const {
+OpenSSLEVPKDFCTXDescription::getFactoryParamIdx(llvm::StringRef F) const {
   if (isFactoryFunction(F)) {
     // Trivial here, since we only generate via return value
     return {-1};
@@ -150,61 +145,57 @@ OpenSSLEVPKDFCTXDescription::getFactoryParamIdx(const std::string &F) const {
   return {};
 }
 
-auto OpenSSLEVPKDFCTXDescription::getStateToString() const
-    -> std::string (*)(int) {
-  return [](TypeStateDescription::State S) -> std::string {
-    switch (S) {
-    case OpenSSLEVPKDFState::TOP:
-      return "TOP";
-      break;
-    case OpenSSLEVPKDFState::UNINIT:
-      return "UNINIT";
-      break;
+llvm::StringRef to_string(OpenSSLEVPKDFCTXState State) noexcept {
+  switch (State) {
+  case OpenSSLEVPKDFCTXState::TOP:
+    return "TOP";
+    break;
+  case OpenSSLEVPKDFCTXState::UNINIT:
+    return "UNINIT";
+    break;
 
-    case OpenSSLEVPKDFState::CTX_ATTACHED:
-      return "CTX_ATTACHED";
-      break;
-    case OpenSSLEVPKDFState::PARAM_INIT:
-      return "PARAM_INIT";
-      break;
-    case OpenSSLEVPKDFState::DERIVED:
-      return "DERIVED";
-      break;
-    case OpenSSLEVPKDFState::ERROR:
-      return "ERROR";
-      break;
-    case OpenSSLEVPKDFState::BOT:
-      return "BOT";
-      break;
-    default:
-      llvm::report_fatal_error("received unknown state!");
-      break;
-    }
-  };
+  case OpenSSLEVPKDFCTXState::CTX_ATTACHED:
+    return "CTX_ATTACHED";
+    break;
+  case OpenSSLEVPKDFCTXState::PARAM_INIT:
+    return "PARAM_INIT";
+    break;
+  case OpenSSLEVPKDFCTXState::DERIVED:
+    return "DERIVED";
+    break;
+  case OpenSSLEVPKDFCTXState::ERROR:
+    return "ERROR";
+    break;
+  case OpenSSLEVPKDFCTXState::BOT:
+    return "BOT";
+    break;
+  }
+
+  llvm::report_fatal_error("received unknown state!");
 }
 
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::bottom() const {
-  return OpenSSLEVPKDFState::BOT;
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::bottom() const {
+  return OpenSSLEVPKDFCTXState::BOT;
 }
 
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::top() const {
-  return OpenSSLEVPKDFState::TOP;
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::top() const {
+  return OpenSSLEVPKDFCTXState::TOP;
 }
 
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::uninit() const {
-  return OpenSSLEVPKDFState::UNINIT;
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::uninit() const {
+  return OpenSSLEVPKDFCTXState::UNINIT;
 }
 
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::start() const {
-  return OpenSSLEVPKDFState::CTX_ATTACHED;
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::start() const {
+  return OpenSSLEVPKDFCTXState::CTX_ATTACHED;
 }
 
-TypeStateDescription::State OpenSSLEVPKDFCTXDescription::error() const {
-  return OpenSSLEVPKDFState::ERROR;
+OpenSSLEVPKDFCTXState OpenSSLEVPKDFCTXDescription::error() const {
+  return OpenSSLEVPKDFCTXState::ERROR;
 }
 
 OpenSSLEVPKDFCTXDescription::OpenSSLEVTKDFToken
-OpenSSLEVPKDFCTXDescription::funcNameToToken(const std::string &F) {
+OpenSSLEVPKDFCTXDescription::funcNameToToken(llvm::StringRef F) {
   if (F == "EVP_KDF_CTX_new") {
     return OpenSSLEVTKDFToken::EVP_KDF_CTX_NEW;
   }

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
@@ -18,48 +18,45 @@ using namespace psr;
 namespace psr {
 
 // Return value is modeled as -1
-const std::map<std::string, std::set<int>>
-    OpenSSLSecureHeapDescription::OpenSSLSecureHeapFuncs = {
-        {"CRYPTO_secure_malloc", {-1}},
-        {"CRYPTO_secure_zalloc", {-1}},
-        {"CRYPTO_secure_free", {0}},
-        {"CRYPTO_secure_clear_free", {0}}};
+static const std::map<llvm::StringRef, std::set<int>> OpenSSLSecureHeapFuncs = {
+    {"CRYPTO_secure_malloc", {-1}},
+    {"CRYPTO_secure_zalloc", {-1}},
+    {"CRYPTO_secure_free", {0}},
+    {"CRYPTO_secure_clear_free", {0}}};
 
 // delta[Token][State] = next State
 // Token:  SECURE_MALLOC = 0, SECURE_ZALLOC = 1,  SECURE_FREE = 2,
 // SECURE_CLEAR_FREE = 3, STAR = 4
 //
 // States: BOT = 0, UNINIT = 1, ALLOCATED = 2, ZEROED = 3, FREED = 4, ERROR = 5
-const OpenSSLSecureHeapDescription::OpenSSLSecureHeapState
-    OpenSSLSecureHeapDescription::Delta[5][6] = {
-        // SECURE_MALLOC
-        {OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED,
-         OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED,
-         OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED},
-        // SECURE_ZALLOC
-        {OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED,
-         OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED,
-         OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED},
-        // SECURE_FREE
-        {OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR,
-         OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::FREED,
-         OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR},
-        // SECURE_CLEAR_FREE
-        {OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR,
-         OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::FREED,
-         OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR},
-        // STAR
-        {OpenSSLSecureHeapState::BOT, OpenSSLSecureHeapState::UNINIT,
-         OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ZEROED,
-         OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::ERROR},
+const OpenSSLSecureHeapState OpenSSLSecureHeapDescription::Delta[5][6] = {
+    // SECURE_MALLOC
+    {OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED,
+     OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED,
+     OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ALLOCATED},
+    // SECURE_ZALLOC
+    {OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED,
+     OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED,
+     OpenSSLSecureHeapState::ZEROED, OpenSSLSecureHeapState::ZEROED},
+    // SECURE_FREE
+    {OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR,
+     OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::FREED,
+     OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR},
+    // SECURE_CLEAR_FREE
+    {OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR,
+     OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::FREED,
+     OpenSSLSecureHeapState::ERROR, OpenSSLSecureHeapState::ERROR},
+    // STAR
+    {OpenSSLSecureHeapState::BOT, OpenSSLSecureHeapState::UNINIT,
+     OpenSSLSecureHeapState::ALLOCATED, OpenSSLSecureHeapState::ZEROED,
+     OpenSSLSecureHeapState::FREED, OpenSSLSecureHeapState::ERROR},
 };
 OpenSSLSecureHeapDescription::OpenSSLSecureHeapDescription(
     IDESolver<IDESecureHeapPropagationAnalysisDomain>
         &SecureHeapPropagationResults)
     : SecureHeapPropagationResults(SecureHeapPropagationResults) {}
 
-bool OpenSSLSecureHeapDescription::isFactoryFunction(
-    const std::string &F) const {
+bool OpenSSLSecureHeapDescription::isFactoryFunction(llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return OpenSSLSecureHeapFuncs.at(F).find(-1) !=
            OpenSSLSecureHeapFuncs.at(F).end();
@@ -68,7 +65,7 @@ bool OpenSSLSecureHeapDescription::isFactoryFunction(
 }
 
 bool OpenSSLSecureHeapDescription::isConsumingFunction(
-    const std::string &F) const {
+    llvm::StringRef F) const {
   if (isAPIFunction(F)) {
     return OpenSSLSecureHeapFuncs.at(F).find(-1) ==
            OpenSSLSecureHeapFuncs.at(F).end();
@@ -76,23 +73,23 @@ bool OpenSSLSecureHeapDescription::isConsumingFunction(
   return false;
 }
 
-bool OpenSSLSecureHeapDescription::isAPIFunction(const std::string &F) const {
+bool OpenSSLSecureHeapDescription::isAPIFunction(llvm::StringRef F) const {
   return OpenSSLSecureHeapFuncs.find(F) != OpenSSLSecureHeapFuncs.end();
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::getNextState(
-    std::string Tok, TypeStateDescription::State S) const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::getNextState(
+    llvm::StringRef Tok, TypeStateDescription::State S) const {
   if (isAPIFunction(Tok)) {
     auto Ftok = static_cast<std::underlying_type_t<OpenSSLSecureHeapToken>>(
         funcNameToToken(Tok));
 
-    return Delta[Ftok][S];
+    return Delta[Ftok][int(S)];
   }
   return OpenSSLSecureHeapState::BOT;
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::getNextState(
-    const std::string &Tok, TypeStateDescription::State S,
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::getNextState(
+    llvm::StringRef Tok, TypeStateDescription::State S,
     const llvm::CallBase *CallSite) const {
   if (isAPIFunction(Tok)) {
     auto Ftok = static_cast<std::underlying_type_t<OpenSSLSecureHeapToken>>(
@@ -104,7 +101,7 @@ TypeStateDescription::State OpenSSLSecureHeapDescription::getNextState(
       //          << llvmIRToShortString(CS.getInstruction()) << std::endl;
       return error();
     }
-    return Delta[Ftok][S];
+    return Delta[Ftok][int(S)];
   }
   return error();
 }
@@ -114,7 +111,7 @@ std::string OpenSSLSecureHeapDescription::getTypeNameOfInterest() const {
 }
 
 set<int>
-OpenSSLSecureHeapDescription::getConsumerParamIdx(const std::string &F) const {
+OpenSSLSecureHeapDescription::getConsumerParamIdx(llvm::StringRef F) const {
   if (isConsumingFunction(F)) {
     return OpenSSLSecureHeapFuncs.at(F);
   }
@@ -122,7 +119,7 @@ OpenSSLSecureHeapDescription::getConsumerParamIdx(const std::string &F) const {
 }
 
 set<int>
-OpenSSLSecureHeapDescription::getFactoryParamIdx(const std::string &F) const {
+OpenSSLSecureHeapDescription::getFactoryParamIdx(llvm::StringRef F) const {
   if (isFactoryFunction(F)) {
     // Trivial here, since we only generate via return value
     return {-1};
@@ -130,52 +127,49 @@ OpenSSLSecureHeapDescription::getFactoryParamIdx(const std::string &F) const {
   return {};
 }
 
-auto OpenSSLSecureHeapDescription::getStateToString() const
-    -> std::string (*)(int) {
-  return [](TypeStateDescription::State S) -> std::string {
-    switch (S) {
-    case OpenSSLSecureHeapState::TOP:
-      return "TOP";
-    case OpenSSLSecureHeapState::BOT:
-      return "BOT";
-    case OpenSSLSecureHeapState::ALLOCATED:
-      return "ALLOCATED";
-    case OpenSSLSecureHeapState::UNINIT:
-      return "UNINIT";
-    case OpenSSLSecureHeapState::FREED:
-      return "FREED";
-    case OpenSSLSecureHeapState::ERROR:
-      return "ERROR";
-    default:
-      llvm::report_fatal_error("received unknown state!");
-      break;
-    }
-  };
+llvm::StringRef to_string(OpenSSLSecureHeapState State) noexcept {
+  switch (State) {
+  case OpenSSLSecureHeapState::TOP:
+    return "TOP";
+  case OpenSSLSecureHeapState::BOT:
+    return "BOT";
+  case OpenSSLSecureHeapState::ALLOCATED:
+    return "ALLOCATED";
+  case OpenSSLSecureHeapState::UNINIT:
+    return "UNINIT";
+  case OpenSSLSecureHeapState::FREED:
+    return "FREED";
+  case OpenSSLSecureHeapState::ERROR:
+    return "ERROR";
+  case OpenSSLSecureHeapState::ZEROED:
+    return "ZEROED";
+  }
+  llvm::report_fatal_error("received unknown state!");
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::bottom() const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::bottom() const {
   return OpenSSLSecureHeapState::BOT;
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::top() const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::top() const {
   return OpenSSLSecureHeapState::TOP;
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::start() const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::start() const {
   llvm::report_fatal_error("TypeStateDescription::start() is deprecated");
   return OpenSSLSecureHeapState::BOT;
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::uninit() const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::uninit() const {
   return OpenSSLSecureHeapState::UNINIT;
 }
 
-TypeStateDescription::State OpenSSLSecureHeapDescription::error() const {
+OpenSSLSecureHeapState OpenSSLSecureHeapDescription::error() const {
   return OpenSSLSecureHeapState::ERROR;
 }
 
 OpenSSLSecureHeapDescription::OpenSSLSecureHeapToken
-OpenSSLSecureHeapDescription::funcNameToToken(const std::string &F) {
+OpenSSLSecureHeapDescription::funcNameToToken(llvm::StringRef F) {
   return llvm::StringSwitch<OpenSSLSecureHeapToken>(F)
       .Case("CRYPTO_secure_malloc", OpenSSLSecureHeapToken::SECURE_MALLOC)
       .Case("CRYPTO_secure_zalloc", OpenSSLSecureHeapToken::SECURE_ZALLOC)

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETSAnalysisFileIOTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETSAnalysisFileIOTest.cpp
@@ -37,7 +37,7 @@ protected:
 
   std::optional<HelperAnalyses> HA;
   CSTDFILEIOTypeStateDescription CSTDFILEIODesc{};
-  std::optional<IDETypeStateAnalysis> TSProblem;
+  std::optional<IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>> TSProblem;
   enum IOSTATE {
     TOP = 42,
     UNINIT = 0,
@@ -53,7 +53,8 @@ protected:
   void initialize(const llvm::Twine &IRFile) {
     HA.emplace(IRFile, EntryPoints);
 
-    TSProblem = createAnalysisProblem<IDETypeStateAnalysis>(
+    TSProblem = createAnalysisProblem<
+        IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>>(
         *HA, &CSTDFILEIODesc, EntryPoints);
   }
 
@@ -69,7 +70,8 @@ protected:
    */
   void compareResults(
       const std::map<std::size_t, std::map<std::string, int>> &GroundTruth,
-      IDESolver_P<IDETypeStateAnalysis> &Solver) {
+      IDESolver_P<IDETypeStateAnalysis<CSTDFILEIOTypeStateDescription>>
+          &Solver) {
     for (const auto &InstToGroundTruth : GroundTruth) {
       const auto *Inst =
           HA->getProjectIRDB().getInstruction(InstToGroundTruth.first);
@@ -80,7 +82,7 @@ protected:
       for (auto Result : Solver.resultsAt(Inst, true)) {
         if (GT.find(getMetaDataID(Result.first)) != GT.end()) {
           Results.insert(std::pair<std::string, int>(
-              getMetaDataID(Result.first), Result.second));
+              getMetaDataID(Result.first), int(Result.second)));
         }
       }
       EXPECT_EQ(Results, GT) << "At " << llvmIRToShortString(Inst);

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDETSAnalysisOpenSSLEVPKDFTest.cpp
@@ -20,6 +20,7 @@
 #include "phasar/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
 
+#include "TestConfig.h"
 #include "gtest/gtest.h"
 
 #include <memory>
@@ -30,44 +31,51 @@ using namespace psr;
 /* ============== TEST FIXTURE ============== */
 class IDETSAnalysisOpenSSLEVPKDFTest : public ::testing::Test {
 protected:
-  const std::string PathToLlFiles =
-      PhasarConfig::PhasarDirectory() +
-      "build/test/llvm_test_code/openssl/key_derivation/";
+  static constexpr auto PathToLlFiles =
+      PHASAR_BUILD_SUBFOLDER("openssl/key_derivation/");
   const std::vector<std::string> EntryPoints = {"main"};
 
   std::optional<HelperAnalyses> HA;
   std::optional<OpenSSLEVPKDFCTXDescription> OpenSSLEVPKeyDerivationDesc;
   OpenSSLEVPKDFDescription OpenSSLEVPKDFDesc{};
-  std::optional<IDETypeStateAnalysis> TSProblem, TSKDFProblem;
-  unique_ptr<IDESolver<IDETypeStateAnalysisDomain>> Llvmtssolver, KdfSolver;
+  std::optional<IDETypeStateAnalysis<OpenSSLEVPKDFCTXDescription>> TSProblem;
+  std::optional<IDETypeStateAnalysis<OpenSSLEVPKDFDescription>> TSKDFProblem;
+  unique_ptr<IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFCTXDescription>>>
+      Llvmtssolver;
+  unique_ptr<IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFDescription>>>
+      KdfSolver;
 
-  enum OpenSSLEVPKeyDerivationState {
-    TOP = 42,
-    UNINIT = 5,
-    CTX_ATTACHED = 1,
-    PARAM_INIT = 2,
-    DERIVED = 3,
-    ERROR = 4,
-    BOT = 0
-  };
+  // enum OpenSSLEVPKDFCTXState {
+  //   TOP = 42,
+  //   UNINIT = 5,
+  //   CTX_ATTACHED = 1,
+  //   PARAM_INIT = 2,
+  //   DERIVED = 3,
+  //   ERROR = 4,
+  //   BOT = 0
+  // };
   IDETSAnalysisOpenSSLEVPKDFTest() = default;
   ~IDETSAnalysisOpenSSLEVPKDFTest() override = default;
 
-  void initialize(const std::string &IRFile) {
-    HA.emplace(IRFile, EntryPoints);
+  void initialize(const llvm::Twine &IRFile) {
+    HA.emplace(PathToLlFiles + IRFile, EntryPoints);
 
-    TSKDFProblem = createAnalysisProblem<IDETypeStateAnalysis>(
-        *HA, &OpenSSLEVPKDFDesc, EntryPoints);
+    TSKDFProblem =
+        createAnalysisProblem<IDETypeStateAnalysis<OpenSSLEVPKDFDescription>>(
+            *HA, &OpenSSLEVPKDFDesc, EntryPoints);
 
-    KdfSolver = make_unique<IDESolver<IDETypeStateAnalysisDomain>>(
+    KdfSolver = make_unique<
+        IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFDescription>>>(
         *TSKDFProblem, &HA->getICFG());
 
     OpenSSLEVPKeyDerivationDesc.emplace(*KdfSolver);
 
-    TSProblem = createAnalysisProblem<IDETypeStateAnalysis>(
+    TSProblem = createAnalysisProblem<
+        IDETypeStateAnalysis<OpenSSLEVPKDFCTXDescription>>(
         *HA, &*OpenSSLEVPKeyDerivationDesc, EntryPoints);
 
-    Llvmtssolver = make_unique<IDESolver<IDETypeStateAnalysisDomain>>(
+    Llvmtssolver = make_unique<
+        IDESolver<IDETypeStateAnalysisDomain<OpenSSLEVPKDFCTXDescription>>>(
         *TSProblem, &HA->getICFG());
     KdfSolver->solve();
     Llvmtssolver->solve();
@@ -85,16 +93,17 @@ protected:
    * @param solver provides the results
    */
   void compareResults(
-      const std::map<std::size_t, std::map<std::string, int>> &GroundTruth) {
+      const std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>>
+          &GroundTruth) {
     for (const auto &InstToGroundTruth : GroundTruth) {
       const auto *Inst =
           HA->getProjectIRDB().getInstruction(InstToGroundTruth.first);
       auto GT = InstToGroundTruth.second;
-      std::map<std::string, int> Results;
+      std::map<std::string, OpenSSLEVPKDFCTXState> Results;
       for (auto Result : Llvmtssolver->resultsAt(Inst, true)) {
-        if (Result.second != OpenSSLEVPKeyDerivationState::BOT &&
+        if (Result.second != OpenSSLEVPKDFCTXState::BOT &&
             GT.count(getMetaDataID(Result.first))) {
-          Results.insert(std::pair<std::string, int>(
+          Results.insert(std::pair<std::string, OpenSSLEVPKDFCTXState>(
               getMetaDataID(Result.first), Result.second));
         }
       }
@@ -104,234 +113,234 @@ protected:
 }; // Test Fixture
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation1) {
-  initialize({PathToLlFiles + "key-derivation1_c.ll"});
+  initialize("key-derivation1_c.ll");
 
   // llvmtssolver->printReport();
 
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  Gt[48] = {{"46", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"20", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[50] = {{"46", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"20", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
+  Gt[48] = {{"46", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"20", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[50] = {{"46", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"20", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
 
-  Gt[92] = {{"46", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-            {"20", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-            {"88", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[98] = {{"95", OpenSSLEVPKeyDerivationState::DERIVED},
-            {"46", OpenSSLEVPKeyDerivationState::DERIVED},
-            {"20", OpenSSLEVPKeyDerivationState::DERIVED},
-            {"88", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[146] = {{"144", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"95", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"46", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"20", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"88", OpenSSLEVPKeyDerivationState::UNINIT}};
+  Gt[92] = {{"46", OpenSSLEVPKDFCTXState::PARAM_INIT},
+            {"20", OpenSSLEVPKDFCTXState::PARAM_INIT},
+            {"88", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[98] = {{"95", OpenSSLEVPKDFCTXState::DERIVED},
+            {"46", OpenSSLEVPKDFCTXState::DERIVED},
+            {"20", OpenSSLEVPKDFCTXState::DERIVED},
+            {"88", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[146] = {{"144", OpenSSLEVPKDFCTXState::UNINIT},
+             {"95", OpenSSLEVPKDFCTXState::UNINIT},
+             {"46", OpenSSLEVPKDFCTXState::UNINIT},
+             {"20", OpenSSLEVPKDFCTXState::UNINIT},
+             {"88", OpenSSLEVPKDFCTXState::UNINIT}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation2) {
-  initialize({PathToLlFiles + "key-derivation2_c.ll"});
+  initialize("key-derivation2_c.ll");
 
-  std::map<std::size_t, std::map<std::string, int>> Gt;
-  // gt[40] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT}}; // killed by
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
+  // gt[40] = {{"22", OpenSSLEVPKDFCTXState::UNINIT}}; // killed by
   // null-initialization
-  // gt[57] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT}}; // killed by
+  // gt[57] = {{"22", OpenSSLEVPKDFCTXState::UNINIT}}; // killed by
   // null-initialization
-  Gt[60] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[105] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"103", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[106] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[112] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"110", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[113] = {{"22", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"58", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"103", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"110", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[160] = {{"22", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"58", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"103", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"110", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"159", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[161] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"58", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"103", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"110", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"159", OpenSSLEVPKeyDerivationState::UNINIT}};
+  Gt[60] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[105] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"103", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[106] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[112] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"110", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[113] = {{"22", OpenSSLEVPKDFCTXState::DERIVED},
+             {"58", OpenSSLEVPKDFCTXState::DERIVED},
+             {"103", OpenSSLEVPKDFCTXState::DERIVED},
+             {"110", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[160] = {{"22", OpenSSLEVPKDFCTXState::DERIVED},
+             {"58", OpenSSLEVPKDFCTXState::DERIVED},
+             {"103", OpenSSLEVPKDFCTXState::DERIVED},
+             {"110", OpenSSLEVPKDFCTXState::DERIVED},
+             {"159", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[161] = {{"22", OpenSSLEVPKDFCTXState::UNINIT},
+             {"58", OpenSSLEVPKDFCTXState::UNINIT},
+             {"103", OpenSSLEVPKDFCTXState::UNINIT},
+             {"110", OpenSSLEVPKDFCTXState::UNINIT},
+             {"159", OpenSSLEVPKDFCTXState::UNINIT}};
   // Fails due to merge conflicts: ID43 and ID162 have both value UNINIT on 22,
   // but it is implicit at ID43, so merging gives BOT
 
-  // gt[164] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT}};
+  // gt[164] = {{"22", OpenSSLEVPKDFCTXState::UNINIT}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation3) {
-  initialize({PathToLlFiles + "key-derivation3_c.ll"});
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  initialize("key-derivation3_c.ll");
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  // gt[56] = {{"21", OpenSSLEVPKeyDerivationState::UNINIT}}; //
+  // gt[56] = {{"21", OpenSSLEVPKDFCTXState::UNINIT}}; //
   // null-initialization kills 21
-  Gt[58] = {{"56", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[93] = {{"56", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"91", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[94] = {{"56", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-            {"21", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-            {"91", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[100] = {{"56", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"21", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"91", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"98", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[101] = {{"56", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"21", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"91", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"98", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[148] = {{"56", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"21", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"91", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"98", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"147", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[149] = {{"56", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"21", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"91", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"98", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"147", OpenSSLEVPKeyDerivationState::UNINIT}};
+  Gt[58] = {{"56", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[93] = {{"56", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"91", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[94] = {{"56", OpenSSLEVPKDFCTXState::PARAM_INIT},
+            {"21", OpenSSLEVPKDFCTXState::PARAM_INIT},
+            {"91", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[100] = {{"56", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"21", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"91", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"98", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[101] = {{"56", OpenSSLEVPKDFCTXState::DERIVED},
+             {"21", OpenSSLEVPKDFCTXState::DERIVED},
+             {"91", OpenSSLEVPKDFCTXState::DERIVED},
+             {"98", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[148] = {{"56", OpenSSLEVPKDFCTXState::DERIVED},
+             {"21", OpenSSLEVPKDFCTXState::DERIVED},
+             {"91", OpenSSLEVPKDFCTXState::DERIVED},
+             {"98", OpenSSLEVPKDFCTXState::DERIVED},
+             {"147", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[149] = {{"56", OpenSSLEVPKDFCTXState::UNINIT},
+             {"21", OpenSSLEVPKDFCTXState::UNINIT},
+             {"91", OpenSSLEVPKDFCTXState::UNINIT},
+             {"98", OpenSSLEVPKDFCTXState::UNINIT},
+             {"147", OpenSSLEVPKDFCTXState::UNINIT}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation4) {
-  initialize({PathToLlFiles + "key-derivation4_c.ll"});
+  initialize("key-derivation4_c.ll");
 
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  // gt[57] = {{"21", OpenSSLEVPKeyDerivationState::UNINIT}}; //
+  // gt[57] = {{"21", OpenSSLEVPKDFCTXState::UNINIT}}; //
   // null-initialization kills 21
-  Gt[59] = {{"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"57", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[104] = {{"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"57", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"102", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[105] = {{"21", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"57", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"102", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
+  Gt[59] = {{"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"57", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[104] = {{"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"57", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"102", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[105] = {{"21", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"57", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"102", OpenSSLEVPKDFCTXState::PARAM_INIT}};
 
   // TODO: Should FREE on PARAM_INIT result in UNINIT, or in ERROR? (currently
   // it is UNINIT)
 
-  Gt[152] = {{"21", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"57", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"102", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"151", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[153] = {{"21", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"57", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"102", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"151", OpenSSLEVPKeyDerivationState::UNINIT}};
+  Gt[152] = {{"21", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"57", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"102", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"151", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[153] = {{"21", OpenSSLEVPKDFCTXState::UNINIT},
+             {"57", OpenSSLEVPKDFCTXState::UNINIT},
+             {"102", OpenSSLEVPKDFCTXState::UNINIT},
+             {"151", OpenSSLEVPKDFCTXState::UNINIT}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation5) {
-  initialize({PathToLlFiles + "key-derivation5_c.ll"});
+  initialize("key-derivation5_c.ll");
 
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  // gt[58] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT}};//
+  // gt[58] = {{"22", OpenSSLEVPKDFCTXState::UNINIT}};//
   // null-initialization kills 22
-  Gt[60] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[105] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"103", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[106] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[112] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"110", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[113] = Gt[160] = {{"22", OpenSSLEVPKeyDerivationState::DERIVED},
-                       {"58", OpenSSLEVPKeyDerivationState::DERIVED},
-                       {"103", OpenSSLEVPKeyDerivationState::DERIVED},
-                       {"110", OpenSSLEVPKeyDerivationState::DERIVED}};
+  Gt[60] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[105] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"103", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[106] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[112] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"110", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[113] = Gt[160] = {{"22", OpenSSLEVPKDFCTXState::DERIVED},
+                       {"58", OpenSSLEVPKDFCTXState::DERIVED},
+                       {"103", OpenSSLEVPKDFCTXState::DERIVED},
+                       {"110", OpenSSLEVPKDFCTXState::DERIVED}};
   // should report an error at 160? (kdf_ctx is not freed)
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, DISABLED_KeyDerivation6) {
-  initialize({PathToLlFiles + "key-derivation6_c.ll"});
+  initialize("key-derivation6_c.ll");
   // llvmtssolver->printReport();
-  std::map<std::size_t, std::map<std::string, int>> Gt;
-  Gt[102] = {{"100", OpenSSLEVPKeyDerivationState::BOT},
-             {"22", OpenSSLEVPKeyDerivationState::BOT}};
-  Gt[103] = {{"100", OpenSSLEVPKeyDerivationState::ERROR},
-             {"22", OpenSSLEVPKeyDerivationState::ERROR}};
-  Gt[109] = Gt[110] = {{"100", OpenSSLEVPKeyDerivationState::ERROR},
-                       {"22", OpenSSLEVPKeyDerivationState::ERROR},
-                       {"107", OpenSSLEVPKeyDerivationState::ERROR}};
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
+  Gt[102] = {{"100", OpenSSLEVPKDFCTXState::BOT},
+             {"22", OpenSSLEVPKDFCTXState::BOT}};
+  Gt[103] = {{"100", OpenSSLEVPKDFCTXState::ERROR},
+             {"22", OpenSSLEVPKDFCTXState::ERROR}};
+  Gt[109] = Gt[110] = {{"100", OpenSSLEVPKDFCTXState::ERROR},
+                       {"22", OpenSSLEVPKDFCTXState::ERROR},
+                       {"107", OpenSSLEVPKDFCTXState::ERROR}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation7) {
-  initialize({PathToLlFiles + "key-derivation7_c.ll"});
+  initialize("key-derivation7_c.ll");
   // llvmtssolver->printReport();
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  // gt[57] = {{"21", OpenSSLEVPKeyDerivationState::UNINIT}}; //
+  // gt[57] = {{"21", OpenSSLEVPKDFCTXState::UNINIT}}; //
   // null-initialization kills 21
-  Gt[59] = {{"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"57", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[104] = {{"21", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"57", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"102", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[105] = {{"21", OpenSSLEVPKeyDerivationState::ERROR},
-             {"57", OpenSSLEVPKeyDerivationState::ERROR},
-             {"102", OpenSSLEVPKeyDerivationState::ERROR}};
-  Gt[152] = Gt[153] = {{"21", OpenSSLEVPKeyDerivationState::ERROR},
-                       {"57", OpenSSLEVPKeyDerivationState::ERROR},
-                       {"102", OpenSSLEVPKeyDerivationState::ERROR},
-                       {"151", OpenSSLEVPKeyDerivationState::ERROR}};
+  Gt[59] = {{"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"57", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[104] = {{"21", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"57", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"102", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[105] = {{"21", OpenSSLEVPKDFCTXState::ERROR},
+             {"57", OpenSSLEVPKDFCTXState::ERROR},
+             {"102", OpenSSLEVPKDFCTXState::ERROR}};
+  Gt[152] = Gt[153] = {{"21", OpenSSLEVPKDFCTXState::ERROR},
+                       {"57", OpenSSLEVPKDFCTXState::ERROR},
+                       {"102", OpenSSLEVPKDFCTXState::ERROR},
+                       {"151", OpenSSLEVPKDFCTXState::ERROR}};
   compareResults(Gt);
 }
 
 TEST_F(IDETSAnalysisOpenSSLEVPKDFTest, KeyDerivation8) {
-  initialize({PathToLlFiles + "key-derivation8_c.ll"});
+  initialize("key-derivation8_c.ll");
   // llvmtssolver->printReport();
-  std::map<std::size_t, std::map<std::string, int>> Gt;
+  std::map<std::size_t, std::map<std::string, OpenSSLEVPKDFCTXState>> Gt;
 
-  // gt[58] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT}}; //
+  // gt[58] = {{"22", OpenSSLEVPKDFCTXState::UNINIT}}; //
   // null-initialization kills 22
-  Gt[60] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-            {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[105] = {{"22", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"58", OpenSSLEVPKeyDerivationState::CTX_ATTACHED},
-             {"103", OpenSSLEVPKeyDerivationState::CTX_ATTACHED}};
-  Gt[107] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[112] = {{"22", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"58", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"103", OpenSSLEVPKeyDerivationState::PARAM_INIT},
-             {"110", OpenSSLEVPKeyDerivationState::PARAM_INIT}};
-  Gt[113] = {{"22", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"58", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"103", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"110", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[160] = {{"22", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"58", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"103", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"110", OpenSSLEVPKeyDerivationState::DERIVED},
-             {"159", OpenSSLEVPKeyDerivationState::DERIVED}};
-  Gt[161] = {{"22", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"58", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"103", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"110", OpenSSLEVPKeyDerivationState::UNINIT},
-             {"159", OpenSSLEVPKeyDerivationState::UNINIT}};
+  Gt[60] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+            {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[105] = {{"22", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"58", OpenSSLEVPKDFCTXState::CTX_ATTACHED},
+             {"103", OpenSSLEVPKDFCTXState::CTX_ATTACHED}};
+  Gt[107] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[112] = {{"22", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"58", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"103", OpenSSLEVPKDFCTXState::PARAM_INIT},
+             {"110", OpenSSLEVPKDFCTXState::PARAM_INIT}};
+  Gt[113] = {{"22", OpenSSLEVPKDFCTXState::DERIVED},
+             {"58", OpenSSLEVPKDFCTXState::DERIVED},
+             {"103", OpenSSLEVPKDFCTXState::DERIVED},
+             {"110", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[160] = {{"22", OpenSSLEVPKDFCTXState::DERIVED},
+             {"58", OpenSSLEVPKDFCTXState::DERIVED},
+             {"103", OpenSSLEVPKDFCTXState::DERIVED},
+             {"110", OpenSSLEVPKDFCTXState::DERIVED},
+             {"159", OpenSSLEVPKDFCTXState::DERIVED}};
+  Gt[161] = {{"22", OpenSSLEVPKDFCTXState::UNINIT},
+             {"58", OpenSSLEVPKDFCTXState::UNINIT},
+             {"103", OpenSSLEVPKDFCTXState::UNINIT},
+             {"110", OpenSSLEVPKDFCTXState::UNINIT},
+             {"159", OpenSSLEVPKDFCTXState::UNINIT}};
   compareResults(Gt);
 }
 


### PR DESCRIPTION
The typestate analysis is the only analysis in phasar where one printer function (`LToString`) depends on the concrete analysis instance. This is, because the TypestateDescription defines, how a type state should be printed.
Moving to free-printers (#652) would then require to make the type state itself a virtual type that knows how it should printed. This is not only ugly, but may also have a performance impact.

To fix this issue, this PR makes the typestate analysis a template enabling type-safe type states.