### PR TITLE
Pin Swift Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
               libclang-rt-14-dev
 
       - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "5.8.1"
       - name: Building Phasar in ${{ matrix.build }} with ${{ matrix.compiler[0] }}
         env:
           BUILD_TYPE: ${{ matrix.build }}


### PR DESCRIPTION
The new Swift version 5.9 produces LLVM IR that is incompatible with the version we use. So pin Swift in the CI to the latest supported  version 5.8.1