### PR TITLE
Fix unexpected subshell execution in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,7 +108,7 @@ if [ ! -z "${DESIRED_BOOST_DIR}" ]; then
 else
 # New way of installing boost:
 # Check whether we have the required boost packages installed
-    (BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"')) || true
+    { BOOST_VERSION=$(echo -e '#include <boost/version.hpp>\nBOOST_LIB_VERSION' | gcc -s -x c++ -E - 2>/dev/null| grep "^[^#;]" | tr -d '\"'); } || true
 
 	if [ -z "$BOOST_VERSION" ] ;then
         if [ -x "$(command -v pacman)" ]; then


### PR DESCRIPTION
For `(list)` in bash, `list` is executed in a subshell environment. Variable assignments do not remain in effect after the command completes.

Fix by using `{ list; }`, where `list` is executed in the current shell environment.