### PR TITLE
TaintConfigData need include cstdint for uint32_t

### DIFF
--- a/include/phasar/PhasarLLVM/TaintConfig/TaintConfigData.h
+++ b/include/phasar/PhasarLLVM/TaintConfig/TaintConfigData.h
@@ -10,6 +10,7 @@
 #ifndef PHASAR_PHASARLLVM_TAINTCONFIG_TAINTCONFIGDATA_H
 #define PHASAR_PHASARLLVM_TAINTCONFIG_TAINTCONFIGDATA_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
On my system (Debian Testing aka 13/Trixie), I have to explicitly include cstdint to make Phasar compile.