### PR TITLE
Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,10 @@ if (NOT MSVC)
   string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -fno-omit-frame-pointer")
   string(APPEND CMAKE_CXX_FLAGS_RELEASE "")
 else()
-  string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus /bigobj")
+  string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus /bigobj") # /D_ITERATOR_DEBUG_LEVEL=0 /VERBOSE:LIB
+  if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+  endif()
 endif()
 
 option(CMAKE_VISIBILITY_INLINES_HIDDEN "Hide inlined functions from the DSO table (default ON)" ON)
@@ -167,6 +170,12 @@ option(PHASAR_DEBUG_LIBDEPS "Debug internal library dependencies (private linkag
 
 #option(BUILD_SHARED_LIBS "Build shared libraries (default is ON)" ON)
 option(PHASAR_BUILD_DYNLIB "Build one fat shared library. Requires BUILD_SHARED_LIBS to be turned OFF (default is OFF)" OFF)
+
+if (BUILD_SHARED_LIBS)
+  message(STATUS "Build shared libraries")
+else()
+  message(STATUS "Build static libraries")
+endif()
 
 if(PHASAR_BUILD_DYNLIB AND BUILD_SHARED_LIBS)
   message(FATAL_ERROR "PHASAR_BUILD_DYNLIB is incompatible with BUILD_SHARED_LIBS")
@@ -283,6 +292,11 @@ add_subdirectory(external/json-schema-validator)
 if (NOT PHASAR_IN_TREE)
   set(BUILD_GMOCK OFF)
   set(INSTALL_GTEST OFF)
+
+  if (MSVC AND CMAKE_MSVC_RUNTIME_LIBRARY MATCHES "DLL$")
+    set(gtest_force_shared_crt ON)
+  endif()
+
   add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
   set(GTEST_INCLUDE_DIR "external/googletest/googletest/include")
 else()
@@ -476,6 +490,12 @@ endif()
 # Build all IR test code
 if (PHASAR_BUILD_IR)
   message("Building IR test code")
+
+  message(STATUS "Searching for clang in ${LLVM_BINARY_DIR}")
+  find_program(CLANG_EXE clang HINTS ${LLVM_BINARY_DIR} REQUIRED)
+  find_program(CLANGXX_EXE clang++ HINTS ${LLVM_BINARY_DIR} REQUIRED)
+  find_program(LLVMOPT_EXE opt HINTS ${LLVM_BINARY_DIR} REQUIRED)
+
   add_subdirectory(test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,15 @@ set(RELEASE_CONFIGURATIONS RELWITHDEBINFO RELEASE CACHE INTERNAL "" FORCE)
 # TODO: Once available, we may want to use -fextend-lifetimes on Debug- and RelWithDebInfo builds to improve debugging experience
 # https://reviews.llvm.org/D157613
 
-string(APPEND CMAKE_CXX_FLAGS " -MP -fstack-protector-strong -ffunction-sections -fdata-sections -pipe")
-string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Og -fno-omit-frame-pointer")
-string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -fno-omit-frame-pointer")
-string(APPEND CMAKE_CXX_FLAGS_RELEASE "")
+
+if (NOT MSVC)
+  string(APPEND CMAKE_CXX_FLAGS " -MP -fstack-protector-strong -ffunction-sections -fdata-sections -pipe")
+  string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Og -fno-omit-frame-pointer")
+  string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -fno-omit-frame-pointer")
+  string(APPEND CMAKE_CXX_FLAGS_RELEASE "")
+else()
+  string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus /bigobj")
+endif()
 
 option(CMAKE_VISIBILITY_INLINES_HIDDEN "Hide inlined functions from the DSO table (default ON)" ON)
 
@@ -214,7 +219,7 @@ endif()
 # Filesystem
 if (LLVM_ENABLE_LIBCXX)
   set(PHASAR_STD_FILESYSTEM c++fs)
-else()
+elseif(NOT MSVC)
   set(PHASAR_STD_FILESYSTEM stdc++fs)
 endif()
 
@@ -289,9 +294,17 @@ endif()
 find_path(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
 find_library(SQLITE3_LIBRARY NAMES sqlite3)
 
-option(USE_LLVM_FAT_LIB  "Link against libLLVM.so instead of the individual LLVM libraries if possible (default is OFF; always on if BUILD_SHARED_LIBS is ON)" OFF)
+if(NOT "${SQLITE3_LIBRARY}" STREQUAL "SQLITE3_LIBRARY-NOTFOUND")
+  # include_directories(SYSTEM ${SQLITE3_INCLUDE_DIR})
+  # link_libraries(${SQLITE3_LIBRARY})
+  set(PHASAR_HAS_SQLITE3 ON)
+endif()
+
 
 # LLVM
+
+option(USE_LLVM_FAT_LIB  "Link against libLLVM.so instead of the individual LLVM libraries if possible (default is OFF; always on if BUILD_SHARED_LIBS is ON)" OFF)
+
 if (NOT PHASAR_IN_TREE)
   # Only search for LLVM if we build out of tree
   find_package(LLVM 14 REQUIRED CONFIG)

--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -110,10 +110,10 @@ function(generate_ll_file)
 
   # define .ll file generation command
   if(${test_code_file_ext} STREQUAL ".cpp")
-    set(GEN_CMD ${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER})
+    set(GEN_CMD ${CLANGXX_EXE})
     list(APPEND GEN_CMD ${GEN_CXX_FLAGS})
   else()
-    set(GEN_CMD ${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER})
+    set(GEN_CMD ${CLANG_EXE})
     list(APPEND GEN_CMD ${GEN_C_FLAGS})
   endif()
 
@@ -121,7 +121,7 @@ function(generate_ll_file)
     add_custom_command(
       OUTPUT ${test_code_ll_file}
       COMMAND ${GEN_CMD} ${test_code_file_path} -o ${test_code_ll_file}
-      COMMAND ${CMAKE_CXX_COMPILER_LAUNCHER} opt -mem2reg -S ${test_code_ll_file} -o ${test_code_ll_file}
+      COMMAND ${LLVMOPT_EXE} -mem2reg -S ${test_code_ll_file} -o ${test_code_ll_file}
       COMMENT ${GEN_CMD_COMMENT}
       DEPENDS ${GEN_LL_FILE}
       VERBATIM

--- a/config.h.in
+++ b/config.h.in
@@ -7,5 +7,6 @@
 #cmakedefine PAMM_FULL
 
 #cmakedefine DYNAMIC_LOG
+#cmakedefine PHASAR_HAS_SQLITE3
 
 #endif /* PHASAR_CONFIG_CONFIG_H  */

--- a/include/phasar/ControlFlow/CFGBase.h
+++ b/include/phasar/ControlFlow/CFGBase.h
@@ -15,6 +15,10 @@
 
 #include "nlohmann/json.hpp"
 
+#include <type_traits>
+
+#include <llvm/ADT/StringRef.h>
+
 namespace psr {
 
 enum class SpecialMemberFunctionType;
@@ -119,6 +123,7 @@ public:
     return self().getStatementIdImpl(Inst);
   }
   [[nodiscard]] decltype(auto) getFunctionName(ByConstRef<f_t> Fun) const {
+    static_assert(__cplusplus > 201402L);
     static_assert(is_string_like_v<decltype(self().getFunctionNameImpl(Fun))>);
     return self().getFunctionNameImpl(Fun);
   }
@@ -144,9 +149,10 @@ private:
 
 template <typename ICF, typename Domain>
 // NOLINTNEXTLINE(readability-identifier-naming)
-constexpr bool is_cfg_v = is_crtp_base_of_v<CFGBase, ICF>
-    &&std::is_same_v<typename ICF::n_t, typename Domain::n_t>
-        &&std::is_same_v<typename ICF::f_t, typename Domain::f_t>;
+constexpr bool is_cfg_v =
+    is_crtp_base_of_v<CFGBase, ICF> &&
+    std::is_same_v<typename ICF::n_t, typename Domain::n_t> &&
+    std::is_same_v<typename ICF::f_t, typename Domain::f_t>;
 
 } // namespace psr
 

--- a/include/phasar/ControlFlow/CallGraph.h
+++ b/include/phasar/ControlFlow/CallGraph.h
@@ -14,7 +14,6 @@
 #include "phasar/Utils/ByRef.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/StableVector.h"
-#include "phasar/Utils/Utilities.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"

--- a/include/phasar/DB.h
+++ b/include/phasar/DB.h
@@ -10,7 +10,10 @@
 #ifndef PHASAR_DB_H
 #define PHASAR_DB_H
 
+#ifdef PHASAR_HAS_SQLITE3
 #include "phasar/DB/Hexastore.h"
+#endif
+
 #include "phasar/DB/ProjectIRDBBase.h"
 #include "phasar/DB/Queries.h"
 

--- a/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
@@ -71,11 +71,13 @@ template <typename L> struct AllBottom final {
 
   [[nodiscard]] constexpr bool isConstant() const noexcept { return true; }
 
-  template <typename LL = L,
-            typename = std::enable_if_t<!HasJoinLatticeTraits<LL>>>
   friend bool operator==(const AllBottom<L> &LHS,
                          const AllBottom<L> &RHS) noexcept {
-    return LHS.BottomValue == RHS.BottomValue;
+    if constexpr (HasJoinLatticeTraits<L>) {
+      return true;
+    } else {
+      return LHS.BottomValue == RHS.BottomValue;
+    }
   }
 };
 
@@ -111,10 +113,12 @@ template <typename L> struct AllTop final {
 
   [[nodiscard]] constexpr bool isConstant() const noexcept { return true; }
 
-  template <typename LL = L,
-            typename = std::enable_if_t<!HasJoinLatticeTraits<LL>>>
   friend bool operator==(const AllTop<L> &LHS, const AllTop<L> &RHS) noexcept {
-    return LHS.TopValue == RHS.TopValue;
+    if constexpr (HasJoinLatticeTraits<L>) {
+      return true;
+    } else {
+      return LHS.TopValue == RHS.TopValue;
+    }
   }
 };
 
@@ -310,7 +314,7 @@ template <typename L, uint8_t N> struct JoinEdgeFunction {
       }
     };
 
-    return DefaultJoinEdgeFunctionComposer{This, SecondFunction};
+    return DefaultJoinEdgeFunctionComposer{{This, SecondFunction}};
   }
 
   [[nodiscard]] static EdgeFunction<l_t>

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedBackwardICFG.h
@@ -41,14 +41,17 @@ class LLVMBasedBackwardICFG : public LLVMBasedBackwardCFG,
     }
   };
 
+public:
+  using typename LLVMBasedBackwardCFG::f_t;
+  using typename LLVMBasedBackwardCFG::n_t;
+
+  LLVMBasedBackwardICFG(LLVMBasedICFG *ForwardICFG);
+
   using CFGBase::print;
   using ICFGBase::print;
 
   using CFGBase::getAsJson;
   using ICFGBase::getAsJson;
-
-public:
-  LLVMBasedBackwardICFG(LLVMBasedICFG *ForwardICFG);
 
 private:
   [[nodiscard]] FunctionRange getAllFunctionsImpl() const;

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedCFG.h
@@ -14,6 +14,7 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
@@ -86,7 +87,7 @@ protected:
   [[nodiscard]] SpecialMemberFunctionType
   getSpecialMemberFunctionTypeImpl(f_t Fun) const;
   [[nodiscard]] std::string getStatementIdImpl(n_t Inst) const;
-  [[nodiscard]] auto getFunctionNameImpl(f_t Fun) const {
+  [[nodiscard]] llvm::StringRef getFunctionNameImpl(f_t Fun) const {
     return Fun->getName();
   }
   [[nodiscard]] std::string getDemangledFunctionNameImpl(f_t Fun) const;

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -52,6 +52,9 @@ class LLVMBasedICFG : public LLVMBasedCFG, public ICFGBase<LLVMBasedICFG> {
   struct Builder;
 
 public:
+  using typename LLVMBasedCFG::f_t;
+  using typename LLVMBasedCFG::n_t;
+
   static constexpr llvm::StringLiteral GlobalCRuntimeModelName =
       "__psrCRuntimeGlobalCtorsModel";
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h
@@ -19,12 +19,10 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Value.h"
 
 #include <memory>
-
-namespace llvm {
-class Value;
-} // namespace llvm
+#include <type_traits>
 
 namespace psr {
 
@@ -52,10 +50,17 @@ public:
   // Do not specify a destructor (at all)!
   static const LLVMZeroValue *getInstance();
 
+#ifndef _MSC_VER
   // NOLINTNEXTLINE(readability-identifier-naming)
   static constexpr auto isLLVMZeroValue = [](const llvm::Value *V) noexcept {
     return V == getInstance();
   };
+#else
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static bool isLLVMZeroValue(const llvm::Value *V) noexcept {
+    return V == getInstance();
+  }
+#endif
 };
 } // namespace psr
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEInstInteractionAnalysis.h
@@ -1218,6 +1218,13 @@ protected:
     return LLVMZeroValue::isLLVMZeroValue(d);
   }
 
+  // Apparently, a friend function cannot access friends:
+  // https://stackoverflow.com/a/67773627
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                       const IIAAKillOrReplaceEF &EF);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                       const IIAAAddLabelsEF &EF);
+
   static void printEdgeFactImpl(llvm::raw_ostream &OS,
                                 ByConstRef<l_t> EdgeFact) {
     if (std::holds_alternative<Top>(EdgeFact)) {

--- a/include/phasar/PhasarLLVM/Pointer/LLVMAliasGraph.h
+++ b/include/phasar/PhasarLLVM/Pointer/LLVMAliasGraph.h
@@ -182,14 +182,14 @@ public:
 
   class PointerVertexOrEdgePrinter {
   public:
-    PointerVertexOrEdgePrinter(const graph_t &PAG) : PAG(PAG) {}
+    PointerVertexOrEdgePrinter(const graph_t &PAG) : PAG(&PAG) {}
     template <class VertexOrEdge>
     void operator()(std::ostream &Out, const VertexOrEdge &V) const {
-      Out << "[label=\"" << PAG[V].getValueAsString() << "\"]";
+      Out << "[label=\"" << (*PAG)[V].getValueAsString() << "\"]";
     }
 
   private:
-    const graph_t &PAG;
+    const graph_t *PAG;
   };
 
   static inline PointerVertexOrEdgePrinter

--- a/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
+++ b/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
@@ -17,9 +17,8 @@
 #ifndef PHASAR_PHASARLLVM_UTILS_LLVMSHORTHANDS_H
 #define PHASAR_PHASARLLVM_UTILS_LLVMSHORTHANDS_H
 
-#include "phasar/Utils/Utilities.h"
-
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <string>
 #include <vector>
@@ -35,6 +34,7 @@ class StoreInst;
 class BranchInst;
 class Module;
 class CallInst;
+class Type;
 } // namespace llvm
 
 namespace psr {

--- a/include/phasar/Utils/DOTGraph.h
+++ b/include/phasar/Utils/DOTGraph.h
@@ -18,7 +18,7 @@
 #define PHASAR_UTILS_DOTGRAPH_H
 
 #include "phasar/Config/Configuration.h"
-#include "phasar/Utils/Utilities.h"
+#include "phasar/Utils/StringIDLess.h"
 
 #include <map>
 #include <set>

--- a/include/phasar/Utils/StringIDLess.h
+++ b/include/phasar/Utils/StringIDLess.h
@@ -1,0 +1,22 @@
+
+/******************************************************************************
+ * Copyright (c) 2017 Philipp Schubert.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Philipp Schubert and others
+ *****************************************************************************/
+
+#ifndef PHASAR_UTILS_STRINGIDLESS_H_
+#define PHASAR_UTILS_STRINGIDLESS_H_
+
+#include <string>
+
+namespace psr {
+struct StringIDLess {
+  bool operator()(const std::string &LHS, const std::string &RHS) const;
+};
+} // namespace psr
+
+#endif // PHASAR_UTILS_STRINGIDLESS_H_

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -11,6 +11,7 @@
 #define PHASAR_UTILS_UTILITIES_H_
 
 #include "phasar/Utils/BitVectorSet.h"
+#include "phasar/Utils/StringIDLess.h"
 #include "phasar/Utils/TypeTraits.h"
 
 #include "llvm/ADT/Hashing.h"
@@ -153,10 +154,6 @@ void intersectWith(BitVectorSet<T> &Dest, const BitVectorSet<T> &Src) {
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                               const std::vector<bool> &Bits);
 
-struct StringIDLess {
-  bool operator()(const std::string &LHS, const std::string &RHS) const;
-};
-
 /// See "https://en.cppreference.com/w/cpp/experimental/scope_exit/scope_exit"
 template <typename Fn> class scope_exit { // NOLINT
 public:
@@ -179,7 +176,9 @@ private:
 template <typename Fn> scope_exit(Fn) -> scope_exit<Fn>;
 
 // Copied from "https://en.cppreference.com/w/cpp/utility/variant/visit"
-template <class... Ts> struct Overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
 
 // explicit deduction guide (not needed as of C++20)
 template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -42,7 +42,7 @@ add_phasar_library(phasar ${PHASAR_DYNLIB_KIND}
         phasar_llvm_ifdside
         phasar_analysis_strategy
         phasar_controller
-    LINK_PRIVATE
+    LINK_PUBLIC
         ${Boost_LIBRARIES}
     LLVM_LINK_COMPONENTS
         Core

--- a/lib/Config/CMakeLists.txt
+++ b/lib/Config/CMakeLists.txt
@@ -3,6 +3,6 @@ file(GLOB_RECURSE CONFIG_SRC *.h *.cpp)
 add_phasar_library(phasar_config
   ${CONFIG_SRC}
   LINKS phasar_utils
-  LINK_PRIVATE ${Boost_LIBRARIES}
+  LINK_PUBLIC ${Boost_LIBRARIES}
   LLVM_LINK_COMPONENTS Support
 )

--- a/lib/DB/CMakeLists.txt
+++ b/lib/DB/CMakeLists.txt
@@ -1,12 +1,20 @@
-file(GLOB_RECURSE DB_SRC *.h *.cpp)
+if(PHASAR_HAS_SQLITE3)
+  file(GLOB_RECURSE DB_SRC *.h *.cpp)
+else()
+  set(DB_SRC DB.cpp)
+endif()
 
 add_phasar_library(phasar_db
   ${DB_SRC}
   LINKS phasar_passes phasar_utils
   LLVM_LINK_COMPONENTS Support
-  LINK_PRIVATE ${SQLITE3_LIBRARY}
 )
 
-target_include_directories(phasar_db
-  PRIVATE ${SQLITE3_INCLUDE_DIR}
-)
+if(PHASAR_HAS_SQLITE3)
+  target_link_libraries(phasar_db 
+    PRIVATE ${SQLITE3_LIBRARY}
+  )
+  target_include_directories(phasar_db
+    PRIVATE ${SQLITE3_INCLUDE_DIR}
+  )
+endif()

--- a/lib/DB/DB.cpp
+++ b/lib/DB/DB.cpp
@@ -1,0 +1,1 @@
+// dummy, such that phasar_db compiles even if Hexastore is disabled

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CMakeLists.txt
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CMakeLists.txt
@@ -19,6 +19,6 @@ add_phasar_library(phasar_llvm_ifdside
     Support
     Demangle
 
-  LINK_PRIVATE
+  LINK_PUBLIC
     ${Boost_LIBRARIES}
 )

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/AbstractMemoryLocationFactory.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/AbstractMemoryLocationFactory.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/AbstractMemoryLocationFactory.h"
 
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/ExtendedTaintAnalysis/AbstractMemoryLocation.h"
 #include "phasar/Utils/Logger.h"
 
 #include "llvm/IR/Instructions.h"
@@ -35,8 +36,9 @@ auto AbstractMemoryLocationFactoryBase::Allocator::Block::create(
     std::terminate();
   }
 
-  auto *Ret = reinterpret_cast<Block *>(new (std::align_val_t{
-      alignof(AbstractMemoryLocationImpl)}) size_t[1 + NumPointerEntries]);
+  static_assert(alignof(AbstractMemoryLocationImpl) <= alignof(size_t));
+
+  auto *Ret = reinterpret_cast<Block *>(new size_t[1 + NumPointerEntries]);
 
   new (Ret) Block(Next);
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCA/EdgeValue.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCA/EdgeValue.cpp
@@ -411,10 +411,10 @@ int EdgeValue::compare(const EdgeValue &Lhs, const EdgeValue &Rhs) {
     int64_t Rhsval;
     double RhsvalFp;
     if (Rhs.tryGetInt(Rhsval)) {
-      return +std::signbit(Lhsval - Rhsval);
+      return (Lhsval > Rhsval) * 2 - 1;
     }
     if (Rhs.tryGetFP(RhsvalFp)) {
-      return +std::signbit(double(Lhsval) - RhsvalFp);
+      return (double(Lhsval) > RhsvalFp) * 2 - 1;
     }
     break;
   }
@@ -428,7 +428,7 @@ int EdgeValue::compare(const EdgeValue &Lhs, const EdgeValue &Rhs) {
         RhsvalFp = double(Rhsval);
       }
 
-      return +std::signbit(Lhsval - RhsvalFp);
+      return (Lhsval > RhsvalFp) * 2 - 1;
     }
 
     break;

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -221,7 +221,7 @@ struct BinOp {
 
     // TODO: Optimize Binop::composeWith(BinOp)
 
-    return LCAEdgeFunctionComposer{This, SecondFunction};
+    return LCAEdgeFunctionComposer{{This, SecondFunction}};
   }
 
   static EdgeFunction<l_t> join(EdgeFunctionRef<BinOp> This,

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSUninitializedVariables.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSUninitializedVariables.cpp
@@ -201,7 +201,7 @@ IFDSUninitializedVariables::getNormalFlowFunction(
       for (const auto &Operand : Inst->operands()) {
         const llvm::UndefValue *Undef =
             llvm::dyn_cast<llvm::UndefValue>(Operand);
-        if (Operand == Source || Operand == Undef) {
+        if (Operand.get() == Source || Operand.get() == Undef) {
           //----------------------------------------------------------------
           // It is not necessary and (from my point of view) not intended to
           // report a leak on EVERY kind of instruction.

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.cpp
@@ -9,6 +9,7 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFCTXDescription.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLEVPKDFDescription.h"
 
 #include "llvm/IR/Instruction.h"
@@ -17,6 +18,7 @@
 
 #include <set>
 #include <string>
+
 
 namespace psr {
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.cpp
@@ -9,6 +9,8 @@
 
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureHeapDescription.h"
 
+#include "phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h"
+
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureMemoryDescription.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/TypeStateDescriptions/OpenSSLSecureMemoryDescription.cpp
@@ -115,7 +115,8 @@ std::string OpenSSLSecureMemoryDescription::getTypeNameOfInterest() const {
 
 set<int>
 OpenSSLSecureMemoryDescription::getConsumerParamIdx(llvm::StringRef F) const {
-  if (const auto *It = llvm::find_if(
+  // NOTE: On MSVC, the array iterator is no pointer!
+  if (auto It = llvm::find_if( // NOLINT
           ConsumingFuncs, [&F](const auto &Pair) { return F == Pair.first; });
       It != ConsumingFuncs.end()) {
     return {It->second};

--- a/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
+++ b/lib/PhasarLLVM/Passes/GeneralStatisticsAnalysis.cpp
@@ -344,7 +344,7 @@ template <typename T> struct AlignNum {
   }
 };
 template <typename T> AlignNum(llvm::StringRef, T) -> AlignNum<T>;
-AlignNum(llvm::StringRef, size_t, size_t)->AlignNum<double>;
+AlignNum(llvm::StringRef, size_t, size_t) -> AlignNum<double>;
 } // namespace
 
 llvm::raw_ostream &psr::operator<<(llvm::raw_ostream &OS,

--- a/lib/PhasarLLVM/Pointer/CMakeLists.txt
+++ b/lib/PhasarLLVM/Pointer/CMakeLists.txt
@@ -17,6 +17,6 @@ add_phasar_library(phasar_llvm_pointer
     Passes
     Demangle
 
-  LINK_PRIVATE
+  LINK_PUBLIC
     ${Boost_LIBRARIES}
 )

--- a/lib/PhasarLLVM/Pointer/LLVMAliasGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMAliasGraph.cpp
@@ -217,14 +217,14 @@ void LLVMAliasGraph::computeAliasGraph(llvm::Function *F) {
     llvm::Type *I1ElTy =
         llvm::cast<llvm::PointerType>(I1->first->getType())->getElementType();
     const uint64_t I1Size = I1ElTy->isSized()
-                                ? DL.getTypeStoreSize(I1ElTy)
+                                ? DL.getTypeStoreSize(I1ElTy).getKnownMinSize()
                                 : llvm::MemoryLocation::UnknownSize;
     for (auto I2 = std::next(I1); I2 != MapEnd; ++I2) {
       llvm::Type *I2ElTy =
           llvm::cast<llvm::PointerType>(I2->first->getType())->getElementType();
-      const uint64_t I2Size = I2ElTy->isSized()
-                                  ? DL.getTypeStoreSize(I2ElTy)
-                                  : llvm::MemoryLocation::UnknownSize;
+      const uint64_t I2Size =
+          I2ElTy->isSized() ? DL.getTypeStoreSize(I2ElTy).getKnownMinSize()
+                            : llvm::MemoryLocation::UnknownSize;
       switch (AA.alias(I1->first, I1Size, I2->first, I2Size)) {
       case llvm::AliasResult::NoAlias:
         break;
@@ -414,10 +414,10 @@ void LLVMAliasGraph::print(llvm::raw_ostream &OS) const {
 }
 
 void LLVMAliasGraph::printAsDot(llvm::raw_ostream &OS) const {
-  std::stringstream S;
-  boost::write_graphviz(S, PAG, makePointerVertexOrEdgePrinter(PAG),
-                        makePointerVertexOrEdgePrinter(PAG));
-  OS << S.str();
+  // std::stringstream S;
+  // boost::write_graphviz(S, PAG, makePointerVertexOrEdgePrinter(PAG),
+  //                       makePointerVertexOrEdgePrinter(PAG));
+  // OS << S.str();
 }
 
 nlohmann::json LLVMAliasGraph::getAsJson() const {

--- a/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
@@ -17,6 +17,7 @@
 #include "phasar/Utils/BoxedPointer.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/NlohmannLogging.h"
+#include "phasar/Utils/Utilities.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"

--- a/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
+++ b/lib/PhasarLLVM/Pointer/LLVMAliasSet.cpp
@@ -322,12 +322,14 @@ static bool mayAlias(llvm::AAResults &AA, const llvm::DataLayout &DL,
 
   auto VSize = V->getType()->getPointerElementType()->isSized()
                    ? DL.getTypeStoreSize(V->getType()->getPointerElementType())
+                         .getKnownMinSize()
                    : llvm::MemoryLocation::UnknownSize;
 
   auto RepSize =
       Rep->getType()->getPointerElementType()->isSized()
           ? DL.getTypeStoreSize(Rep->getType()->getPointerElementType())
-          : llvm::MemoryLocation::UnknownSize;
+                .getKnownMinSize()
+          : llvm::TypeSize(llvm::MemoryLocation::UnknownSize, false);
 
   if (AA.alias(V, VSize, Rep, RepSize) != llvm::AliasResult::NoAlias) {
     return true;

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/CachedTypeGraph.cpp
@@ -66,7 +66,7 @@ CachedTypeGraph::vertex_t
 CachedTypeGraph::addType(const llvm::StructType *NewType) {
   std::string Name;
   if (!NewType->isLiteral()) {
-    Name = NewType->getName();
+    Name = NewType->getName().str();
   } else {
     std::stringstream StrS;
     StrS << "literal_" << NewType;
@@ -123,9 +123,10 @@ bool CachedTypeGraph::addLinkWithoutReversePropagation(
 }
 
 void CachedTypeGraph::printAsDot(const std::string &Path) const {
-  std::ofstream Ofs(Path);
-  boost::write_graphviz(
-      Ofs, G, boost::make_label_writer(boost::get(&VertexProperties::Name, G)));
+  // std::ofstream Ofs(Path);
+  // boost::write_graphviz(
+  //     Ofs, G, boost::make_label_writer(boost::get(&VertexProperties::Name,
+  //     G)));
 }
 
 void CachedTypeGraph::aggregateTypes() {

--- a/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
+++ b/lib/PhasarLLVM/Pointer/TypeGraphs/LazyTypeGraph.cpp
@@ -75,10 +75,14 @@ bool LazyTypeGraph::addLink(const llvm::StructType *From,
 }
 
 void LazyTypeGraph::printAsDot(const std::string &Path) const {
+  // TODO: There seems to be a problem with MSVC accessing
+  // LazyTypeGraph::VertexProperties::Name
+#ifndef _MSC_VER
   std::ofstream Ofs(Path);
   boost::write_graphviz(Ofs, Graph,
                         boost::make_label_writer(boost::get(
                             &LazyTypeGraph::VertexProperties::Name, Graph)));
+#endif
 }
 
 std::set<const llvm::StructType *>

--- a/lib/PhasarLLVM/TypeHierarchy/CMakeLists.txt
+++ b/lib/PhasarLLVM/TypeHierarchy/CMakeLists.txt
@@ -13,6 +13,6 @@ add_phasar_library(phasar_llvm_typehierarchy
     Support
     Analysis
 
-  LINK_PRIVATE
+  LINK_PUBLIC
     ${Boost_LIBRARIES}
 )

--- a/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
+++ b/lib/PhasarLLVM/TypeHierarchy/LLVMTypeHierarchy.cpp
@@ -397,9 +397,9 @@ nlohmann::json LLVMTypeHierarchy::getAsJson() const {
 // }
 
 void LLVMTypeHierarchy::printAsDot(llvm::raw_ostream &OS) const {
-  std::stringstream S;
-  boost::write_graphviz(S, TypeGraph, TypeHierarchyVertexWriter(TypeGraph));
-  OS << S.str();
+  // std::stringstream S;
+  // boost::write_graphviz(S, TypeGraph, TypeHierarchyVertexWriter(TypeGraph));
+  // OS << S.str();
 }
 
 void LLVMTypeHierarchy::printAsJson(llvm::raw_ostream &OS) const {

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -19,6 +19,7 @@ add_phasar_library(phasar_utils
     ${PHASAR_STD_FILESYSTEM}
   LINK_PUBLIC
     nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
 )
 
 set_target_properties(phasar_utils

--- a/lib/Utils/DOTGraph.cpp
+++ b/lib/Utils/DOTGraph.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <iterator>
 #include <ostream>
+#include <sstream>
 #include <utility>
 
 namespace psr {

--- a/lib/Utils/IO.cpp
+++ b/lib/Utils/IO.cpp
@@ -18,7 +18,6 @@
 
 #include "phasar/Utils/ErrorHandling.h"
 #include "phasar/Utils/Logger.h"
-#include "phasar/Utils/Utilities.h"
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"

--- a/tools/example-tool/CMakeLists.txt
+++ b/tools/example-tool/CMakeLists.txt
@@ -23,6 +23,10 @@ else()
   llvm_config(myphasartool ${LLVM_LINK_COMPONENTS})
 endif()
 
+if(BUILD_PHASAR_CLANG)
+  target_link_libraries(myphasartool PRIVATE ${CLANG_LIBRARY})
+endif()
+
 install(TARGETS myphasartool
   RUNTIME DESTINATION bin
 )

--- a/tools/example-tool/CMakeLists.txt
+++ b/tools/example-tool/CMakeLists.txt
@@ -17,6 +17,12 @@ target_link_libraries(myphasartool
     ${PHASAR_STD_FILESYSTEM}
 )
 
+if(USE_LLVM_FAT_LIB)
+  llvm_config(myphasartool USE_SHARED ${LLVM_LINK_COMPONENTS})
+else()
+  llvm_config(myphasartool ${LLVM_LINK_COMPONENTS})
+endif()
+
 install(TARGETS myphasartool
   RUNTIME DESTINATION bin
 )

--- a/tools/phasar-cli/phasar-cli.cpp
+++ b/tools/phasar-cli/phasar-cli.cpp
@@ -260,7 +260,8 @@ void validateParamModule() {
   if (!(std::filesystem::exists(ModulePath) &&
         !std::filesystem::is_directory(ModulePath) &&
         (ModulePath.extension() == ".ll" || ModulePath.extension() == ".bc"))) {
-    llvm::errs() << "LLVM module '" << std::filesystem::canonical(ModulePath)
+    llvm::errs() << "LLVM module '"
+                 << std::filesystem::canonical(ModulePath).string()
                  << "' does not exist!\n";
     exit(1);
   }
@@ -352,7 +353,8 @@ int main(int Argc, const char **Argv) {
   if (ProjectIdOpt.empty()) {
     ProjectIdOpt = std::filesystem::path(ModuleOpt.getValue())
                        .filename()
-                       .replace_extension();
+                       .replace_extension()
+                       .string();
     if (ProjectIdOpt.empty()) {
       ProjectIdOpt = "default-phasar-project";
     }

--- a/unittests/DB/CMakeLists.txt
+++ b/unittests/DB/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(DBSources
-	HexastoreTest.cpp
-)
 
-foreach(TEST_SRC ${DBSources})
-	add_phasar_unittest(${TEST_SRC})
-endforeach(TEST_SRC)
+if(NOT "${SQLITE3_LIBRARY}" STREQUAL "SQLITE3_LIBRARY-NOTFOUND")
+  set(DBSources
+  	HexastoreTest.cpp
+  )  
+  foreach(TEST_SRC ${DBSources})
+  	add_phasar_unittest(${TEST_SRC})
+  endforeach(TEST_SRC)
+endif()

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCATest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCATest.cpp
@@ -129,9 +129,10 @@ TEST_F(IDEGeneralizedLCATest, StringTestCpp) {
   std::vector<groundTruth_t> GroundTruth;
   const auto *LastMainInstruction =
       getLastInstructionOf(HA->getProjectIRDB().getFunction("main"));
-  GroundTruth.push_back({{EdgeValue("Hello, World")},
-                         3U,
-                         std::stoi(getMetaDataID(LastMainInstruction))});
+  GroundTruth.push_back(
+      {{EdgeValue("Hello, World")},
+       3U,
+       unsigned(std::stoi(getMetaDataID(LastMainInstruction)))});
   compareResults(GroundTruth);
 }
 

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCATest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/Problems/IDEGeneralizedLCATest.cpp
@@ -130,7 +130,7 @@ TEST_F(IDEGeneralizedLCATest, StringTestCpp) {
   const auto *LastMainInstruction =
       getLastInstructionOf(HA->getProjectIRDB().getFunction("main"));
   GroundTruth.push_back({{EdgeValue("Hello, World")},
-                         3,
+                         3U,
                          std::stoi(getMetaDataID(LastMainInstruction))});
   compareResults(GroundTruth);
 }


### PR DESCRIPTION
This PR adds basic support for Windows.

Things that work:
- Building phasar-cli and myphasartool in Release mode
- Building static phasar libraries in Release mode
- Building the unittests in Release mode

Things that do not work:
- Building phasar in anything other than Release mode (conflicting runtime libraries with LLVM then -- probably you then also need an extra debug-llvm installation)
- Building the IR testing files (the MSVC19 STL requires at least clang-15)