### PR TITLE
Misc Fixes

### DIFF
--- a/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
+++ b/include/phasar/DataFlow/IfdsIde/Solver/IDESolver.h
@@ -725,7 +725,10 @@ protected:
                                     << ", value: " << LToString(Value));
         // initialize the initial seeds with the top element as we have no
         // information at the beginning of the value computation problem
-        setVal(StartPoint, Fact, Value);
+        l_t OldVal = val(StartPoint, Fact);
+        auto NewVal = IDEProblem.join(Value, std::move(OldVal));
+        setVal(StartPoint, Fact, std::move(NewVal));
+
         std::pair<n_t, d_t> SuperGraphNode(StartPoint, Fact);
         valuePropagationTask(std::move(SuperGraphNode));
       }

--- a/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/LLVMBasedICFG.h
@@ -96,6 +96,7 @@ public:
                          const nlohmann::json &SerializedCG,
                          LLVMTypeHierarchy *TH = nullptr);
 
+  // Deleter of LLVMTypeHierarchy may be unknown here...
   ~LLVMBasedICFG();
 
   LLVMBasedICFG(const LLVMBasedICFG &) = delete;

--- a/include/phasar/PhasarLLVM/DB/LLVMProjectIRDB.h
+++ b/include/phasar/PhasarLLVM/DB/LLVMProjectIRDB.h
@@ -109,7 +109,7 @@ private:
   [[nodiscard]] m_t getModuleImpl() const noexcept { return Mod.get(); }
   [[nodiscard]] bool debugInfoAvailableImpl() const;
   [[nodiscard]] FunctionRange getAllFunctionsImpl() const {
-    return llvm::map_range(Mod->functions(),
+    return llvm::map_range(ProjectIRDBBase::getModule()->functions(),
                            Ref2PointerConverter<llvm::Function>{});
   }
   [[nodiscard]] f_t getFunctionImpl(llvm::StringRef FunctionName) const {

--- a/include/phasar/Utils/DFAMinimizer.h
+++ b/include/phasar/Utils/DFAMinimizer.h
@@ -110,8 +110,6 @@ template <typename GraphTy>
     }
   }
 
-  size_t Idx = 0;
-
   llvm::IntEqClasses Equiv(traits_t::size(G));
 
   auto isEquivalent = [&Equiv](edge_t LHS, edge_t RHS) {

--- a/lib/PhasarLLVM/TaintConfig/LLVMTaintConfig.cpp
+++ b/lib/PhasarLLVM/TaintConfig/LLVMTaintConfig.cpp
@@ -130,7 +130,6 @@ LLVMTaintConfig::LLVMTaintConfig(const psr::LLVMProjectIRDB &Code,
   std::unordered_map<const llvm::Type *, const std::string> StructConfigMap;
 
   // read all struct types from config
-  size_t Counter = 0;
   for (const auto &VarDesc : Config.Variables) {
     llvm::DebugInfoFinder DIF;
     const auto *M = Code.getModule();

--- a/unittests/Utils/CMakeLists.txt
+++ b/unittests/Utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(UtilsSources
+  CompilationTests.cpp
   BitVectorSetTest.cpp
   EquivalenceClassMapTest.cpp
   IOTest.cpp
@@ -16,3 +17,5 @@ endif()
 foreach(TEST_SRC ${UtilsSources})
   add_phasar_unittest(${TEST_SRC})
 endforeach(TEST_SRC)
+
+target_compile_options(CompilationTests PRIVATE -Wno-delete-incomplete)

--- a/unittests/Utils/CompilationTests.cpp
+++ b/unittests/Utils/CompilationTests.cpp
@@ -1,0 +1,14 @@
+
+#include "phasar/Utils/MaybeUniquePtr.h"
+
+#include <memory>
+
+struct IncompleteType;
+
+using MUP = psr::MaybeUniquePtr<IncompleteType, true>;
+MUP maybeUniquePtrSupportsIncompleteTypes(
+    std::unique_ptr<IncompleteType> &&UP) {
+  return std::move(UP);
+}
+
+int main() {}


### PR DESCRIPTION
Fixes the initial values handling in IDESolver to handle the case that a seed location can be reached from another path.

Additionally fixes the MaybeUniquePtr with incomplete types