### PR TITLE
Mark Hexastore as deprecated

### DIFF
--- a/include/phasar/DB/Hexastore.h
+++ b/include/phasar/DB/Hexastore.h
@@ -73,7 +73,8 @@ struct HSResult {
  *
  * @brief Efficient data structure for holding graphs in databases.
  */
-class Hexastore {
+class [[deprecated("This ancient API is not maintained for long and sholud not "
+                   "be used anymore!")]] Hexastore {
 private:
   sqlite3 *HSInternalDB{};
   static int callback(void * /*NotUsed*/, int Argc, char **Argv,

--- a/include/phasar/DB/Hexastore.h
+++ b/include/phasar/DB/Hexastore.h
@@ -73,7 +73,7 @@ struct HSResult {
  *
  * @brief Efficient data structure for holding graphs in databases.
  */
-class [[deprecated("This ancient API is not maintained for long and sholud not "
+class [[deprecated("This ancient API is not maintained for long and should not "
                    "be used anymore!")]] Hexastore {
 private:
   sqlite3 *HSInternalDB{};

--- a/unittests/DB/CMakeLists.txt
+++ b/unittests/DB/CMakeLists.txt
@@ -1,9 +1,9 @@
-if(SQLite3_FOUND)
-	set(DBSources
-		HexastoreTest.cpp
-	)
+# if(SQLite3_FOUND)
+# 	set(DBSources
+# 		HexastoreTest.cpp
+# 	)
 
-	foreach(TEST_SRC ${DBSources})
-		add_phasar_unittest(${TEST_SRC})
-	endforeach(TEST_SRC)
-endif()
+# 	foreach(TEST_SRC ${DBSources})
+# 		add_phasar_unittest(${TEST_SRC})
+# 	endforeach(TEST_SRC)
+# endif()


### PR DESCRIPTION
`Hexastore` is old and not used by anyone. So, mark it as deprecated.