### PR TITLE
LLVM 17 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         if: matrix.build == 'DebugCov'
         uses: actions/upload-artifact@v4
         with:
-          name: CoverageReport
+          name: phasar-coverage-report-llvm-${{ matrix.llvm-version }}
           path: ./build/ccov/all-merged/
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         compiler: [ [clang++-19, clang-19, "clang-19 libclang-rt-19-dev clang-tools-19"] ]
         build: [ Debug, Release, DebugLibdeps, DebugCov ]
+        llvm-version: [ 16, 17 ]
         include:
           - build: Debug
             cmake_build_type: Debug
@@ -55,7 +56,7 @@ jobs:
       - name: Install Phasar Dependencies
         shell: bash
         run: |
-          ./utils/InstallAptDependencies.sh --noninteractive tzdata ccache ${{ matrix.compiler[2] }} ${{ matrix.extra_dependencies }}
+          ./utils/InstallAptDependencies.sh --llvm-version ${{ matrix.llvm-version }} --noninteractive tzdata ccache ${{ matrix.compiler[2] }} ${{ matrix.extra_dependencies }}
 
       - name: Building Phasar in ${{ matrix.build }} with ${{ matrix.compiler[0] }}
         env:
@@ -69,6 +70,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_PHASAR_CLANG=OFF \
             -DPHASAR_USE_Z3=ON \
+            -DPHASAR_LLVM_VERSION=${{ matrix.llvm-version }} \
             ${{ matrix.flags }} \
             -G Ninja
           ninja -C build

--- a/BUILD.md
+++ b/BUILD.md
@@ -80,6 +80,7 @@ When using CMake to compile PhASAR the following optional parameters can be used
 | **PHASAR_ENABLE_PIC** : BOOL | Build Position-Independed Code (default is ON) |
 | **PHASAR_ENABLE_WARNINGS** : BOOL | Enable compiler warnings (default is ON) |
 | **CMAKE_CXX_STANDARD** : INT|Adapt the used C++ standard (minimum required is 20)|
+| **PHASAR_LLVM_VERSION** : INT|The LLVM major-version to use. Can be 16 or 17 (default is 16)|
 
 You can use these parameters either directly or modify the installer-script `bootstrap.sh`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,9 +334,8 @@ endif()
 option(USE_LLVM_FAT_LIB  "Link against libLLVM.so instead of the individual LLVM libraries if possible (default is OFF; always on if BUILD_SHARED_LIBS is ON)" OFF)
 
 # LLVM
-if (NOT PHASAR_LLVM_VERSION)
-  set(PHASAR_LLVM_VERSION 16)
-endif()
+set(PHASAR_LLVM_VERSION 16 CACHE STRING "The LLVM major-version that PhASAR should use")
+
 include(add_llvm)
 add_llvm()
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ PhASAR supports C++20 modules as an experimental feature.
 
 ## Currently Supported Version of LLVM
 
-PhASAR is currently set up to support LLVM-16.0.*
+**NEW**: PhASAR is currently set up to support **LLVM-16 and 17**, using LLVM 16 by default.<br>
+Specify the `PHASAR_LLVM_VERSION` cmake-variable to change the LLVM version to use.
+
 
 ## Breaking Changes
 

--- a/include/phasar/Utils/BitSet.h
+++ b/include/phasar/Utils/BitSet.h
@@ -12,8 +12,8 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
-#include "llvm/Support/MathExtras.h"
 
+#include <bit>
 #include <climits>
 #include <concepts>
 #include <cstddef>
@@ -189,7 +189,7 @@ public:
     uint32_t Offset = 0;
     for (auto W : Words) {
       while (W) {
-        auto Curr = llvm::countTrailingZeros(W) + Offset;
+        auto Curr = std::countr_zero(W) + Offset;
         W &= W - 1;
         std::invoke(Handler, IdT(Curr));
       }

--- a/lib/PhasarLLVM/DB/LLVMProjectIRDB.cpp
+++ b/lib/PhasarLLVM/DB/LLVMProjectIRDB.cpp
@@ -34,9 +34,6 @@ static void setOpaquePointersForCtx(llvm::LLVMContext &Ctx, bool Enable) {
   if (Enable) {
     Ctx.enableOpaquePointers();
   }
-#else // LLVM_VERSION_MAJOR >= 17
-#error                                                                         \
-    "Non-opaque pointers are not supported anymore. Refactor PhASAR to remove typed pointer support."
 #endif
 }
 

--- a/lib/PhasarLLVM/Pointer/FilteredAliasesUtils.h
+++ b/lib/PhasarLLVM/Pointer/FilteredAliasesUtils.h
@@ -6,7 +6,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/Compiler.h"
 
-inline LLVM_LIBRARY_VISIBILITY const llvm::Function *
+LLVM_LIBRARY_VISIBILITY inline const llvm::Function *
 getFunction(const llvm::Value *V) {
   if (const auto *Inst = llvm::dyn_cast<llvm::Instruction>(V)) {
     return Inst->getFunction();
@@ -17,7 +17,7 @@ getFunction(const llvm::Value *V) {
   return nullptr;
 }
 
-[[nodiscard]] inline LLVM_LIBRARY_VISIBILITY bool
+[[nodiscard]] LLVM_LIBRARY_VISIBILITY inline bool
 isConstantGlobalValue(const llvm::GlobalValue *GlobV) {
   if (const auto *Glob = llvm::dyn_cast<llvm::GlobalVariable>(GlobV)) {
     return Glob->isConstant();
@@ -31,7 +31,7 @@ isConstantGlobalValue(const llvm::GlobalValue *GlobV) {
   return true;
 }
 
-inline LLVM_LIBRARY_VISIBILITY bool mustNoalias(const llvm::Value *P1,
+LLVM_LIBRARY_VISIBILITY inline bool mustNoalias(const llvm::Value *P1,
                                                 const llvm::Value *P2) {
   if (P1 == P2) {
     return false;

--- a/utils/InstallAptDependencies.sh
+++ b/utils/InstallAptDependencies.sh
@@ -1,13 +1,53 @@
 #!/bin/bash
 set -euo pipefail
 
-if printf "%s\n" "$@" | grep -Eqe '^--noninteractive|-ni$'; then
-    readonly noninteractive="true"
-    shift
-else
-    readonly noninteractive="false"
+noninteractive="false"
+LLVM_IR_VERSION=16
+
+# Parsing command-line-parameters
+# See "https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash" as a reference
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --noninteractive|-ni)
+    noninteractive="true"
+    shift # past argument
+    ;;
+    --llvm-version)
+    LLVM_IR_VERSION=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --llvm-version=*)
+    LLVM_IR_VERSION="${key#*=}"
+    shift # past argument=value
+    ;;
+    --help|-h)
+    echo "USAGE: ./InstallAptDependencies.sh [options] [additional deps]"
+    echo ""
+    echo "OPTIONS:"
+    echo -e "\t--noninteractive,-ni\t- Non-interactive mode for apt"
+    echo -e "\t--llvm-version=<value>\t- The LLVM major-version to use (16 or 17, default is 16)"
+    exit 0
+    ;;
+    *) # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+# End - Parsing command-line-parameters
+
+if [ "$LLVM_IR_VERSION" -ne "16" ] && [ "$LLVM_IR_VERSION" -ne "17" ]; then
+    echo "Invalid LLVM version: $LLVM_IR_VERSION, expected 16 or 17" >&2
+    exit 1
 fi
-readonly LLVM_IR_VERSION=16
+
 additional_dependencies=("$@")
 
 (


### PR DESCRIPTION
LLVM 17 Compatibility:

- [x] Make phasar compile and run with both llvm 16 and 17
- [x] Adapt the CI to test for llvm 16 and 17

