### PR TITLE
Fix EdgeFunction SemiRing

### DIFF
--- a/include/phasar/DataFlow/IfdsIde/EdgeFunction.h
+++ b/include/phasar/DataFlow/IfdsIde/EdgeFunction.h
@@ -547,6 +547,17 @@ public:
     return this->template isa<ConcreteEF>() ? getPtr<ConcreteEF>(EF) : nullptr;
   }
 
+  template <typename ConcreteEF>
+  [[nodiscard]] std::optional<EdgeFunctionRef<ConcreteEF>>
+  asRef() const noexcept {
+    if (isa<ConcreteEF>()) {
+      return EdgeFunctionRef<ConcreteEF>(
+          EF, getAllocationPolicy() == AllocationPolicy::CustomHeapAllocated);
+    }
+
+    return std::nullopt;
+  }
+
   // -- misc
 
   /// True, iff this edge function is not small-object-optimized and thus its
@@ -738,17 +749,17 @@ private:
 namespace llvm {
 
 template <typename L> struct DenseMapInfo<psr::EdgeFunction<L>> {
-  static inline auto getEmptyKey() noexcept {
+  static auto getEmptyKey() noexcept {
     return psr::EdgeFunction<L>::getEmptyKey();
   }
-  static inline auto getTombstoneKey() noexcept {
+  static auto getTombstoneKey() noexcept {
     return psr::EdgeFunction<L>::getTombstoneKey();
   }
-  static inline auto getHashValue(const psr::EdgeFunction<L> &EF) noexcept {
+  static auto getHashValue(const psr::EdgeFunction<L> &EF) noexcept {
     return EF.getHashCode();
   }
-  static inline auto isEqual(const psr::EdgeFunction<L> &EF1,
-                             const psr::EdgeFunction<L> &EF2) noexcept {
+  static auto isEqual(const psr::EdgeFunction<L> &EF1,
+                      const psr::EdgeFunction<L> &EF2) noexcept {
     if (EF1.referenceEquals(EF2)) {
       return true;
     }

--- a/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
@@ -173,7 +173,7 @@ template <typename L> struct AllTop final {
   [[nodiscard]] static EdgeFunction<l_t>
   compose(EdgeFunctionRef<AllTop> This,
           const EdgeFunction<l_t> &SecondFunction) {
-    return llvm::isa<EdgeIdentity<l_t>>(SecondFunction) ? This : SecondFunction;
+    return SecondFunction.isConstant() ? SecondFunction : This;
   }
 
   [[nodiscard]] static EdgeFunction<l_t>
@@ -211,13 +211,16 @@ defaultComposeOrNull(const EdgeFunction<L> &This,
   if (llvm::isa<EdgeIdentity<L>>(SecondFunction)) {
     return This;
   }
-  if (SecondFunction.isConstant() || llvm::isa<AllTop<L>>(This) ||
-      llvm::isa<EdgeIdentity<L>>(This)) {
+  if (SecondFunction.isConstant() || llvm::isa<EdgeIdentity<L>>(This)) {
     return SecondFunction;
   }
-  if (llvm::isa<AllBottom<L>>(This)) {
+  if (llvm::isa<AllTop<L>>(This)) {
     return This;
   }
+  if (auto BotEF = This.template asRef<AllBottom<L>>()) {
+    return AllBottom<L>::compose(*BotEF, SecondFunction);
+  }
+
   return nullptr;
 }
 
@@ -471,12 +474,10 @@ ConstantEdgeFunction<L>::compose(EdgeFunctionRef<ConcreteEF> This,
 
   if constexpr (AreEqualityComparable<decltype(JLattice::top()), L>) {
     if (JLattice::top() == ConstVal) {
-      /// TODO: Can this ever happen?
       return AllTop<L>{};
     }
   } else {
     if (L(JLattice::top()) == ConstVal) {
-      /// TODO: Can this ever happen?
       return AllTop<L>{};
     }
   }
@@ -505,7 +506,7 @@ ConstantEdgeFunction<L>::join(EdgeFunctionRef<ConcreteEF> This,
     return OtherFunction.joinWith(This);
   }
 
-  auto OtherVal = OtherFunction.computeTarget(JLattice::top());
+  auto OtherVal = OtherFunction.computeTarget(JLattice::bottom());
   auto JoinedVal = JLattice::join(This->Value, OtherVal);
 
   if constexpr (AreEqualityComparable<decltype(JLattice::bottom()), l_t>) {

--- a/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
+++ b/include/phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h
@@ -96,6 +96,19 @@ operator<<(llvm::raw_ostream &OS, ByConstRef<ConstantEdgeFunction<L>> Id) {
   return OS;
 }
 
+template <typename L>
+  requires(is_std_hashable_v<typename NonTopBotValue<L>::type> ||
+           is_llvm_hashable_v<typename NonTopBotValue<L>::type>)
+[[nodiscard]] auto hash_value(const ConstantEdgeFunction<L> &CEF) noexcept {
+  using value_type = typename ConstantEdgeFunction<L>::value_type;
+  if constexpr (is_std_hashable_v<value_type>) {
+    return std::hash<value_type>{}(CEF.Value);
+  } else {
+    using llvm::hash_value;
+    return hash_value(CEF.Value);
+  }
+}
+
 template <typename L> struct AllBottom final {
   using l_t = L;
   using JLattice = JoinLatticeTraits<L>;
@@ -277,6 +290,11 @@ template <typename L> struct EdgeFunctionComposer {
 };
 
 static_assert(HasDepth<EdgeFunctionComposer<int>>);
+
+template <typename L>
+auto hash_value(const EdgeFunctionComposer<L> &EFC) noexcept {
+  return llvm::hash_combine(EFC.First, EFC.Second);
+}
 
 template <typename L, uint8_t N> struct JoinEdgeFunction {
   using l_t = L;

--- a/include/phasar/DataFlow/IfdsIde/Solver/IterativeIDESolver.h
+++ b/include/phasar/DataFlow/IfdsIde/Solver/IterativeIDESolver.h
@@ -519,6 +519,13 @@ private:
                                 uint32_t FunId, EdgeFunctionPtrType LocalEF)
     requires ComputeValues
   {
+
+    if (llvm::isa<AllTop<l_t>>(LocalEF)) {
+      // Don't store the default edge-function, which essentially denotes a
+      // killed fact
+      return false;
+    }
+
     auto &EF = JumpFns.getOrCreate(combineIds(SourceFact, LocalFact));
     if (!EF) {
       EF = std::move(LocalEF);

--- a/lib/DataFlow/IfdsIde/IfdsIde.cppm
+++ b/lib/DataFlow/IfdsIde/IfdsIde.cppm
@@ -46,7 +46,6 @@ using psr::addSeedsForStartingPoints;
 using psr::AllTopFnProvider;
 using psr::checkSREquality;
 using psr::Compressor;
-using psr::ConstantEdgeFunction;
 using psr::defaultJoinOrNull;
 using psr::DefaultMapKeyCompressor;
 using psr::EdgeFunctionCache;

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/Problems/IDELinearConstantAnalysis.cpp
@@ -66,17 +66,9 @@ struct LCAEdgeFunctionComposer : EdgeFunctionComposer<l_t> {
   }
 };
 
-auto hash_value(const LCAEdgeFunctionComposer &EF) noexcept {
-  return llvm::hash_combine(EF.First, EF.Second);
-}
-
 static_assert(is_llvm_hashable_v<LCAEdgeFunctionComposer>);
 
-struct GenConstant : ConstantEdgeFunction<l_t> {};
-
-llvm::hash_code hash_value(const GenConstant &EF) noexcept {
-  return llvm::hash_value(EF.Value);
-}
+using GenConstant = ConstantEdgeFunction<l_t>;
 
 using TTT = decltype(hash_value(std::declval<GenConstant>()));
 static_assert(is_llvm_hashable_v<GenConstant>);


### PR DESCRIPTION
This PR primarily fixes the EdgeFunction's SemiRing. According to the definition of semi-rings, the neutral element of the combine-operation (here `AllTop`) must be an annihilator of the extend-operation on both sides, left and right.
As `AllTop` is a constant edge-function, the right-annihilation is satisfied; however, left-annihilation is not.

As a consequence of this bug, one cannot just return an `AllTop` edge-function to kill a data-flow fact. The fact still holds and has a non-top edge-function attached.

ThisPR fixes that issue + some minor things.