### PR TITLE
Fix Linker RUNPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,16 +225,6 @@ endif()
 
 if (PHASAR_USE_CONAN)
 elseif (NOT PHASAR_IN_TREE)
-  # RPATH
-  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-
-  if (NOT "${CMAKE_INSTALL_LIBDIR}" STREQUAL "lib")
-    message(STATUS "Detected CMAKE_INSTALL_LIBDIR that deviates from 'lib': ${CMAKE_INSTALL_LIBDIR}. Add ${CMAKE_INSTALL_PREFIX}/lib to the RPATH as json-schema-validator needs it")
-    list(APPEND CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
-  endif()
-
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
   # Export set
   set(PHASAR_DEPS_EXPORT_SET PhasarDepsExports)
 else()

--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -281,6 +281,15 @@ function(add_phasar_library name)
 
   target_compile_features(${name} PUBLIC cxx_std_20)
 
+  if (BUILD_SHARED_LIBS AND UNIX)
+    target_link_options(${name} INTERFACE "LINKER:-rpath,\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:\$ORIGIN/../${PHASAR_DEPS_INSTALL_DESTINATION}/lib")
+
+    set_target_properties(${name} PROPERTIES
+      INSTALL_RPATH
+        "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR};\$ORIGIN/../${PHASAR_DEPS_INSTALL_DESTINATION}/lib"
+    )
+  endif()
+
   set(install_module)
   if(PHASAR_LIB_MODULE_FILES)
     if(PHASAR_BUILD_MODULES)

--- a/cmake/phasar_macros.cmake
+++ b/cmake/phasar_macros.cmake
@@ -277,6 +277,8 @@ function(add_phasar_library name)
   add_library(phasar::${component_name} ALIAS ${name})
   set_target_properties(${name} PROPERTIES
     EXPORT_NAME ${component_name}
+    VERSION ${PHASAR_VERSION}
+    SOVERSION ${PHASAR_VERSION}
   )
 
   target_compile_features(${name} PUBLIC cxx_std_20)


### PR DESCRIPTION
After installing phasar with shared libs, the shared libraries don't find dependencies that are not installed at standard locations.
Fix is to modify the RPATH/RUNPATH and to propagate that change to all cmake targets that link against phasar.