### PR TITLE
Improve CFL Field Sensitivity

### DIFF
--- a/include/phasar/DataFlow/IfdsIde/DefaultEdgeFunctionSingletonCache.h
+++ b/include/phasar/DataFlow/IfdsIde/DefaultEdgeFunctionSingletonCache.h
@@ -13,6 +13,8 @@
 #include "phasar/DataFlow/IfdsIde/EdgeFunction.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionSingletonCache.h"
 
+#include <concepts>
+
 namespace psr {
 
 /// Default implementation of EdgeFunctionSingletonCache.
@@ -53,6 +55,7 @@ public:
   void erase(const EdgeFunctionTy &EF) noexcept override { Cache.erase(&EF); }
 
   template <typename... ArgTys>
+    requires std::constructible_from<EdgeFunctionTy, ArgTys...>
   [[nodiscard]] EdgeFunction<L> createEdgeFunction(ArgTys &&...Args) {
     return CachedEdgeFunction<EdgeFunctionTy>{
         EdgeFunctionTy{std::forward<ArgTys>(Args)...}, this};

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -156,7 +156,8 @@ struct AccessPath {
   [[nodiscard]] constexpr bool
   operator==(const AccessPath &Other) const noexcept {
     return EmptyTombstone == Other.EmptyTombstone && Loads == Other.Loads &&
-           Stores == Other.Stores && Kills == Other.Kills;
+           Stores == Other.Stores && Kills == Other.Kills &&
+           Offset == Other.Offset;
   }
 
   bool operator!=(const AccessPath &Other) const noexcept {

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -465,15 +465,13 @@ struct CFLFieldSensEdgeFunction {
 } // namespace cfl_fieldsens
 
 /// An IFDS-Problem adaptor that makes any field-insensitive IFDS analysis
-/// field-sensitive. Just wrap your IFDS problem with
-/// FieldSensAllocSitesAwareIFDSProblem and use the IterativeIDESolver instead
-/// of the IFDSSolver.
+/// field-sensitive. Just wrap your IFDS problem with CFLFieldSensIFDSProblem
+/// and use the IterativeIDESolver instead of the IFDSSolver.
 ///
 /// The only thing to change in your usual IFDS problem is not to kill data-flow
 /// facts when only parts of the fields should be killed. This is now handled by
-/// the FieldSensAllocSitesAwareIFDSProblem. For that, provide a
-/// FieldSensAllocSitesAwareIFDSProblemConfig with a proper KillsAt
-/// implementation.
+/// the CFLFieldSensIFDSProblem. For that, provide a CFLFieldSensIFDSProblem
+/// with a proper KillsAt implementation.
 class CFLFieldSensIFDSProblem
     : public IDETabulationProblem<cfl_fieldsens::IFDSDomain> {
   using Base = IDETabulationProblem<cfl_fieldsens::IFDSDomain>;
@@ -527,6 +525,7 @@ public:
              UserProblem->getZeroValue()),
         UserProblem(UserProblem), Config(std::move(Config)) {
     Mgr.reserve(UserProblem->getProjectIRDB()->getNumInstructions());
+    regCounters();
   }
 
   /// Constructs an IDETabulationProblem with the usual arguments, forwarded
@@ -624,6 +623,8 @@ private:
   makeEF(cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF);
   [[nodiscard]] EFResultPtr
   makeEFPtr(cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF);
+
+  static void regCounters() noexcept;
 
   IFDSTabulationProblem<LLVMIFDSAnalysisDomainDefault> *UserProblem{};
   cfl_fieldsens::FieldStringManager Mgr{};

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -579,6 +579,10 @@ public:
                                          uint8_t DepthKLimit,
                                          const llvm::DataLayout &DL);
 
+  EdgeFunction<l_t> getLoadEdgeFunction(d_t CurrNode, d_t PointerOp,
+                                        uint8_t DepthKLimit,
+                                        const llvm::DataLayout &DL);
+
   EdgeFunction<l_t> getNormalEdgeFunction(n_t Curr, d_t CurrNode, n_t Succ,
                                           d_t SuccNode) override;
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -21,6 +21,8 @@
 #include "phasar/Utils/Compressor.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/MapUtils.h"
+#include "phasar/Utils/SmallArraySet.h"
+#include "phasar/Utils/StrongTypeDef.h"
 #include "phasar/Utils/TypeTraits.h"
 #include "phasar/Utils/TypedVector.h"
 #include "phasar/Utils/Utilities.h"
@@ -37,21 +39,16 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace psr::cfl_fieldsens {
-
 /// \file
 /// Implements field-sensitivity after the paper "Boosting the performance
 /// of alias-aware IFDS analysis with CFL-based environment transformers" by Li
 /// et al. <https://doi.org/10.1145/3689804>
 
-// NOLINTNEXTLINE(performance-enum-size)
-enum class FieldStringNodeId : uint32_t {
-  None = 0,
-};
+PHASAR_STRONG_TYPEDEF(psr::cfl_fieldsens, uint32_t, FieldStringNodeId,
+                      None = 0);
 
-[[nodiscard]] inline llvm::hash_code hash_value(FieldStringNodeId NId) {
-  return llvm::hash_value(std::underlying_type_t<FieldStringNodeId>(NId));
-}
+PHASAR_STRONG_TYPEDEF(psr::cfl_fieldsens, uint32_t, KillSetId, Empty = 0);
+namespace psr::cfl_fieldsens {
 
 struct FieldStringNode {
   FieldStringNodeId Next{};
@@ -93,6 +90,8 @@ namespace cfl_fieldsens {
 /// Interns the Store- and Load field-strings
 class FieldStringManager {
 public:
+  static constexpr int32_t TopOffset = INT32_MIN;
+
   FieldStringManager();
 
   [[nodiscard]] FieldStringNodeId intern(FieldStringNode Nod) {
@@ -127,44 +126,65 @@ public:
     return Depth[NId];
   }
 
+  [[nodiscard]] KillSetId internKills(SmallArraySet<int32_t, 2> &&Kills) {
+    return KillsCompressor.getOrInsert(std::move(Kills));
+  }
+
+  [[nodiscard]] KillSetId addKill(KillSetId KS, int32_t Offs) {
+    if (Offs == TopOffset || KillsCompressor[KS].contains(Offs)) {
+      return KS;
+    }
+
+    auto Kills = KillsCompressor[KS];
+    Kills.insert(Offs);
+    return KillsCompressor.getOrInsert(std::move(Kills));
+  }
+
+  [[nodiscard]] bool isKilledBy(KillSetId KS, int32_t Offs) const {
+    if (Offs == TopOffset || KS == KillSetId::Empty) {
+      return false;
+    }
+    if (!KillsCompressor.inbounds(KS)) [[unlikely]] {
+      return false;
+    }
+
+    return KillsCompressor[KS].contains(Offs);
+  }
+
+  [[nodiscard]] const auto &kills(KillSetId KS) const {
+    return KillsCompressor[KS];
+  }
+
 private:
   Compressor<FieldStringNode, FieldStringNodeId> NodeCompressor{};
   TypedVector<FieldStringNodeId, uint32_t> Depth{};
+  Compressor<SmallArraySet<int32_t, 2>, KillSetId> KillsCompressor{};
 };
 
 /// A single CFL Field-Access String consisting of: gep, loads, kills, and
 /// stores
 struct AccessPath {
-  static constexpr int32_t TopOffset = INT32_MIN;
+  static constexpr int32_t TopOffset = FieldStringManager::TopOffset;
 
   FieldStringNodeId Loads{};
   FieldStringNodeId Stores{};
-  llvm::SmallDenseSet<int32_t, 2> Kills{};
+  KillSetId Kills{};
   // Add an offset for pending GEPs; INT32_MIN is Top
-  int32_t Offset = {0};
-  int32_t EmptyTombstone = 0;
+  int32_t Offset{};
 
   [[nodiscard]] bool empty() const noexcept {
     return Loads == FieldStringNodeId::None &&
-           Stores == FieldStringNodeId::None && Kills.empty() && Offset == 0;
-  }
-
-  [[nodiscard]] bool kills(int32_t Off) const {
-    return Off != TopOffset && Kills.contains(Off);
+           Stores == FieldStringNodeId::None && Kills == KillSetId::Empty &&
+           Offset == 0;
   }
 
   [[nodiscard]] constexpr bool
-  operator==(const AccessPath &Other) const noexcept {
-    return EmptyTombstone == Other.EmptyTombstone && Loads == Other.Loads &&
-           Stores == Other.Stores && Kills == Other.Kills &&
-           Offset == Other.Offset;
-  }
+  operator==(const AccessPath &Other) const noexcept = default;
 
-  bool operator!=(const AccessPath &Other) const noexcept {
-    return !(*this == Other);
+  friend size_t hash_value(const AccessPath &FieldString) noexcept {
+    return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
+                              FieldString.Kills, FieldString.Offset);
   }
-
-  friend size_t hash_value(const AccessPath &FieldString) noexcept;
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
                                        const AccessPath &FieldString);
@@ -175,26 +195,19 @@ struct AccessPath {
 struct AccessPathDMI {
   static AccessPath getEmptyKey() {
     AccessPath Ret{};
-    Ret.EmptyTombstone = 1;
+    Ret.Loads = FieldStringNodeId(UINT32_MAX);
     return Ret;
   }
   static AccessPath getTombstoneKey() {
     AccessPath Ret{};
-    Ret.EmptyTombstone = 2;
+    Ret.Loads = FieldStringNodeId(UINT32_MAX);
+    Ret.Stores = FieldStringNodeId(UINT32_MAX);
     return Ret;
   }
-  static auto getHashValue(const AccessPath &FieldString) noexcept {
+  static auto getHashValue(AccessPath FieldString) noexcept {
     return hash_value(FieldString);
   }
-  static bool isEqual(const AccessPath &L, const AccessPath &R) noexcept {
-    if (L.EmptyTombstone != R.EmptyTombstone) {
-      return false;
-    }
-    if (L.EmptyTombstone) {
-      return true;
-    }
-    return L == R;
-  }
+  static bool isEqual(AccessPath L, AccessPath R) noexcept { return L == R; }
 };
 
 /// An edge-value consisting of a set if CFL field access strings.

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -33,6 +33,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Operator.h"
@@ -449,17 +450,16 @@ struct CFLFieldSensEdgeFunction {
     return Source;
   }
 
-  friend bool operator==(CFLFieldSensEdgeFunction L,
-                         CFLFieldSensEdgeFunction R) noexcept = default;
+  constexpr friend bool
+  operator==(CFLFieldSensEdgeFunction L,
+             CFLFieldSensEdgeFunction R) noexcept = default;
 
   friend auto hash_value(CFLFieldSensEdgeFunction EF) noexcept {
     return llvm::hash_value(EF.Impl);
   }
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                       const CFLFieldSensEdgeFunction &EF) {
-    return OS << "Txn[" << EF.Impl->Transform << ']';
-  }
+                                       CFLFieldSensEdgeFunction EF);
 };
 
 } // namespace cfl_fieldsens
@@ -617,8 +617,13 @@ public:
   [[nodiscard]] const auto &base() const noexcept { return *UserProblem; }
 
 private:
+  using EFConstPtr = const cfl_fieldsens::CFLFieldSensEdgeFunctionImpl *;
+  using EFResultPtr = llvm::PointerIntPair<EFConstPtr, 2>;
+
   [[nodiscard]] EdgeFunction<l_t>
   makeEF(cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF);
+  [[nodiscard]] EFResultPtr
+  makeEFPtr(cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF);
 
   IFDSTabulationProblem<LLVMIFDSAnalysisDomainDefault> *UserProblem{};
   cfl_fieldsens::FieldStringManager Mgr{};
@@ -626,14 +631,8 @@ private:
 
   UnorderedSet<cfl_fieldsens::CFLFieldSensEdgeFunctionImpl> EFInternCache{};
 
-  using EFConstPtr = const cfl_fieldsens::CFLFieldSensEdgeFunctionImpl *;
-
-  // Values are stable pointers: into EFInternCache for CFL results, or to
-  // AllTopSingleton / AllBottomSingleton for the degenerate cases.
-  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EdgeFunction<l_t>>
-      ExtendCache;
-  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EdgeFunction<l_t>>
-      CombineCache;
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> ExtendCache;
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> CombineCache;
 
   uint8_t DepthKLimit = 5; // Original from the paper
 };

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -162,15 +162,7 @@ public:
   void reserve(size_t ExpectedCapacity) {
     NodeCompressor.reserve(ExpectedCapacity);
     Depth.reserve(ExpectedCapacity);
-    // llvm::errs() << "ExpectedCapacity: " << ExpectedCapacity << '\n';
   }
-
-  // ~FieldStringManager() {
-  //   llvm::errs() << "NodeCompressor.size(): " << NodeCompressor.size() <<
-  //   '\n'; llvm::errs() << "Depth.size(): " << Depth.size() << '\n';
-  //   llvm::errs() << "KillsCompressor.size(): " << KillsCompressor.size()
-  //                << '\n';
-  // }
 
 private:
   Compressor<FieldStringNode, FieldStringNodeId> NodeCompressor{};
@@ -198,9 +190,7 @@ struct AccessPath {
   [[nodiscard]] constexpr bool
   operator==(const AccessPath &Other) const noexcept = default;
 
-  friend size_t hash_value(const AccessPath &FieldString) noexcept {
-    // return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
-    //                           FieldString.Kills, FieldString.Offset);
+  friend constexpr size_t hash_value(const AccessPath &FieldString) noexcept {
     size_t HC = 37;
     HC = HC * 31 + size_t(FieldString.Loads);
     HC = HC * 31 + size_t(FieldString.Stores);
@@ -235,8 +225,10 @@ struct AccessPathDMI {
 
 /// An edge-value consisting of a set if CFL field access strings.
 struct IFDSEdgeValue {
+  using container_type = llvm::SmallDenseSet<AccessPath, 2, AccessPathDMI>;
+
   [[clang::require_explicit_initialization]] FieldStringManager *Mgr{};
-  llvm::SmallDenseSet<AccessPath, 2, AccessPathDMI> Paths;
+  container_type Paths;
 
   static constexpr llvm::StringLiteral LogCategory = "IFDSEdgeValue";
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -628,8 +628,8 @@ private:
 
   UnorderedSet<cfl_fieldsens::CFLFieldSensEdgeFunctionImpl> EFInternCache{};
 
-  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> ExtendCache;
-  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> CombineCache;
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> ExtendCache{};
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EFResultPtr> CombineCache{};
 
   uint8_t DepthKLimit = 5; // Original from the paper
 };

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -10,6 +10,7 @@
 #ifndef PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_FIELDSENSALLOCSITESAWAREIFDSPROBLEM_H
 #define PHASAR_PHASARLLVM_DATAFLOW_IFDSIDE_FIELDSENSALLOCSITESAWAREIFDSPROBLEM_H
 
+#include "phasar/DataFlow/IfdsIde/EdgeFunction.h"
 #include "phasar/DataFlow/IfdsIde/IDETabulationProblem.h"
 #include "phasar/DataFlow/IfdsIde/IFDSTabulationProblem.h"
 #include "phasar/Domain/BinaryDomain.h"
@@ -19,10 +20,12 @@
 #include "phasar/PhasarLLVM/Domain/LLVMAnalysisDomain.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMAliasInfo.h"
 #include "phasar/Utils/Compressor.h"
+#include "phasar/Utils/Fn.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/MapUtils.h"
 #include "phasar/Utils/SmallArraySet.h"
 #include "phasar/Utils/StrongTypeDef.h"
+#include "phasar/Utils/TableWrappers.h"
 #include "phasar/Utils/TypeTraits.h"
 #include "phasar/Utils/TypedVector.h"
 #include "phasar/Utils/Utilities.h"
@@ -154,6 +157,19 @@ public:
   [[nodiscard]] const auto &kills(KillSetId KS) const {
     return KillsCompressor[KS];
   }
+
+  void reserve(size_t ExpectedCapacity) {
+    NodeCompressor.reserve(ExpectedCapacity);
+    Depth.reserve(ExpectedCapacity);
+    // llvm::errs() << "ExpectedCapacity: " << ExpectedCapacity << '\n';
+  }
+
+  // ~FieldStringManager() {
+  //   llvm::errs() << "NodeCompressor.size(): " << NodeCompressor.size() <<
+  //   '\n'; llvm::errs() << "Depth.size(): " << Depth.size() << '\n';
+  //   llvm::errs() << "KillsCompressor.size(): " << KillsCompressor.size()
+  //                << '\n';
+  // }
 
 private:
   Compressor<FieldStringNode, FieldStringNodeId> NodeCompressor{};
@@ -383,6 +399,54 @@ bool filterFieldSensFacts(
   return true;
 }
 
+struct CFLFieldSensEdgeFunction {
+  using l_t = LatticeDomain<IFDSEdgeValue>;
+  [[clang::require_explicit_initialization]] IFDSEdgeValue Transform;
+  [[clang::require_explicit_initialization]] uint8_t DepthKLimit{};
+
+  [[nodiscard]] l_t computeTarget(l_t Source) const {
+    Source.onValue(fn<&IFDSEdgeValue::applyTransforms>, Transform, DepthKLimit);
+    return Source;
+  }
+
+  bool operator==(const CFLFieldSensEdgeFunction &Other) const noexcept {
+    assert(DepthKLimit == Other.DepthKLimit);
+    return Transform == Other.Transform;
+  }
+
+  friend auto hash_value(const CFLFieldSensEdgeFunction &EF) noexcept {
+    return hash_value(EF.Transform);
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                       const CFLFieldSensEdgeFunction &EF) {
+    return OS << "Txn[" << EF.Transform << ']';
+  }
+
+  [[nodiscard]] static auto from(IFDSEdgeValue &&Txn, uint8_t DepthKLimit) {
+    return CFLFieldSensEdgeFunction{
+        .Transform = std::move(Txn),
+        .DepthKLimit = DepthKLimit,
+    };
+  }
+
+  [[nodiscard]] static auto from(AccessPath Txn, FieldStringManager &Mgr,
+                                 uint8_t DepthKLimit) {
+    return CFLFieldSensEdgeFunction{
+        .Transform = {.Mgr = &Mgr, .Paths = {Txn}},
+        .DepthKLimit = DepthKLimit,
+    };
+  }
+
+  [[nodiscard]] static auto fromEpsilon(uint8_t DepthKLimit,
+                                        FieldStringManager &Mgr) {
+    return CFLFieldSensEdgeFunction{
+        .Transform = IFDSEdgeValue::epsilon(&Mgr),
+        .DepthKLimit = DepthKLimit,
+    };
+  }
+};
+
 } // namespace cfl_fieldsens
 
 /// An IFDS-Problem adaptor that makes any field-insensitive IFDS analysis
@@ -446,7 +510,9 @@ public:
       : Base(assertNotNull(UserProblem).getProjectIRDB(),
              assertNotNull(UserProblem).getEntryPoints(),
              UserProblem->getZeroValue()),
-        UserProblem(UserProblem), Config(std::move(Config)) {}
+        UserProblem(UserProblem), Config(std::move(Config)) {
+    Mgr.reserve(UserProblem->getProjectIRDB()->getNumInstructions());
+  }
 
   /// Constructs an IDETabulationProblem with the usual arguments, forwarded
   /// from UserProblem and tries to automatically derive the config from
@@ -536,9 +602,24 @@ public:
   [[nodiscard]] const auto &base() const noexcept { return *UserProblem; }
 
 private:
+  [[nodiscard]] EdgeFunction<l_t>
+  makeEF(cfl_fieldsens::CFLFieldSensEdgeFunction &&EF);
+
   IFDSTabulationProblem<LLVMIFDSAnalysisDomainDefault> *UserProblem{};
   cfl_fieldsens::FieldStringManager Mgr{};
   cfl_fieldsens::IFDSProblemConfig Config{};
+
+  UnorderedTable1d<cfl_fieldsens::CFLFieldSensEdgeFunction, EdgeFunction<l_t>>
+      EFInternCache{};
+
+  llvm::DenseMap<std::pair<const cfl_fieldsens::CFLFieldSensEdgeFunction *,
+                           const cfl_fieldsens::CFLFieldSensEdgeFunction *>,
+                 EdgeFunction<l_t>>
+      ExtendCache;
+  llvm::DenseMap<std::pair<const cfl_fieldsens::CFLFieldSensEdgeFunction *,
+                           const cfl_fieldsens::CFLFieldSensEdgeFunction *>,
+                 EdgeFunction<l_t>>
+      CombineCache;
 
   uint8_t DepthKLimit = 5; // Original from the paper
 };

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -182,8 +182,14 @@ struct AccessPath {
   operator==(const AccessPath &Other) const noexcept = default;
 
   friend size_t hash_value(const AccessPath &FieldString) noexcept {
-    return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
-                              FieldString.Kills, FieldString.Offset);
+    // return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
+    //                           FieldString.Kills, FieldString.Offset);
+    size_t HC = 37;
+    HC = HC * 31 + size_t(FieldString.Loads);
+    HC = HC * 31 + size_t(FieldString.Stores);
+    HC = HC * 31 + size_t(FieldString.Kills);
+    HC = HC * 31 + size_t(FieldString.Offset);
+    return HC;
   }
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
@@ -228,7 +234,7 @@ struct IFDSEdgeValue {
     return !(*this == Other);
   }
 
-  [[nodiscard]] friend auto hash_value(const IFDSEdgeValue EV) {
+  [[nodiscard]] friend auto hash_value(const IFDSEdgeValue &EV) {
     return llvm::hash_combine_range(EV.Paths.begin(), EV.Paths.end());
   }
 

--- a/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
+++ b/include/phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h
@@ -399,32 +399,22 @@ bool filterFieldSensFacts(
   return true;
 }
 
-struct CFLFieldSensEdgeFunction {
+struct CFLFieldSensEdgeFunctionImpl {
   using l_t = LatticeDomain<IFDSEdgeValue>;
   [[clang::require_explicit_initialization]] IFDSEdgeValue Transform;
   [[clang::require_explicit_initialization]] uint8_t DepthKLimit{};
 
-  [[nodiscard]] l_t computeTarget(l_t Source) const {
-    Source.onValue(fn<&IFDSEdgeValue::applyTransforms>, Transform, DepthKLimit);
-    return Source;
-  }
-
-  bool operator==(const CFLFieldSensEdgeFunction &Other) const noexcept {
+  bool operator==(const CFLFieldSensEdgeFunctionImpl &Other) const noexcept {
     assert(DepthKLimit == Other.DepthKLimit);
     return Transform == Other.Transform;
   }
 
-  friend auto hash_value(const CFLFieldSensEdgeFunction &EF) noexcept {
+  friend auto hash_value(const CFLFieldSensEdgeFunctionImpl &EF) noexcept {
     return hash_value(EF.Transform);
   }
 
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                       const CFLFieldSensEdgeFunction &EF) {
-    return OS << "Txn[" << EF.Transform << ']';
-  }
-
   [[nodiscard]] static auto from(IFDSEdgeValue &&Txn, uint8_t DepthKLimit) {
-    return CFLFieldSensEdgeFunction{
+    return CFLFieldSensEdgeFunctionImpl{
         .Transform = std::move(Txn),
         .DepthKLimit = DepthKLimit,
     };
@@ -432,7 +422,7 @@ struct CFLFieldSensEdgeFunction {
 
   [[nodiscard]] static auto from(AccessPath Txn, FieldStringManager &Mgr,
                                  uint8_t DepthKLimit) {
-    return CFLFieldSensEdgeFunction{
+    return CFLFieldSensEdgeFunctionImpl{
         .Transform = {.Mgr = &Mgr, .Paths = {Txn}},
         .DepthKLimit = DepthKLimit,
     };
@@ -440,10 +430,35 @@ struct CFLFieldSensEdgeFunction {
 
   [[nodiscard]] static auto fromEpsilon(uint8_t DepthKLimit,
                                         FieldStringManager &Mgr) {
-    return CFLFieldSensEdgeFunction{
+    return CFLFieldSensEdgeFunctionImpl{
         .Transform = IFDSEdgeValue::epsilon(&Mgr),
         .DepthKLimit = DepthKLimit,
     };
+  }
+};
+
+struct CFLFieldSensEdgeFunction {
+  using l_t = LatticeDomain<IFDSEdgeValue>;
+  [[clang::require_explicit_initialization]] const CFLFieldSensEdgeFunctionImpl
+      *Impl{};
+
+  [[nodiscard]] l_t computeTarget(l_t Source) const {
+    assert(Impl != nullptr);
+    Source.onValue(fn<&IFDSEdgeValue::applyTransforms>, Impl->Transform,
+                   Impl->DepthKLimit);
+    return Source;
+  }
+
+  friend bool operator==(CFLFieldSensEdgeFunction L,
+                         CFLFieldSensEdgeFunction R) noexcept = default;
+
+  friend auto hash_value(CFLFieldSensEdgeFunction EF) noexcept {
+    return llvm::hash_value(EF.Impl);
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                       const CFLFieldSensEdgeFunction &EF) {
+    return OS << "Txn[" << EF.Impl->Transform << ']';
   }
 };
 
@@ -603,22 +618,21 @@ public:
 
 private:
   [[nodiscard]] EdgeFunction<l_t>
-  makeEF(cfl_fieldsens::CFLFieldSensEdgeFunction &&EF);
+  makeEF(cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF);
 
   IFDSTabulationProblem<LLVMIFDSAnalysisDomainDefault> *UserProblem{};
   cfl_fieldsens::FieldStringManager Mgr{};
   cfl_fieldsens::IFDSProblemConfig Config{};
 
-  UnorderedTable1d<cfl_fieldsens::CFLFieldSensEdgeFunction, EdgeFunction<l_t>>
-      EFInternCache{};
+  UnorderedSet<cfl_fieldsens::CFLFieldSensEdgeFunctionImpl> EFInternCache{};
 
-  llvm::DenseMap<std::pair<const cfl_fieldsens::CFLFieldSensEdgeFunction *,
-                           const cfl_fieldsens::CFLFieldSensEdgeFunction *>,
-                 EdgeFunction<l_t>>
+  using EFConstPtr = const cfl_fieldsens::CFLFieldSensEdgeFunctionImpl *;
+
+  // Values are stable pointers: into EFInternCache for CFL results, or to
+  // AllTopSingleton / AllBottomSingleton for the degenerate cases.
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EdgeFunction<l_t>>
       ExtendCache;
-  llvm::DenseMap<std::pair<const cfl_fieldsens::CFLFieldSensEdgeFunction *,
-                           const cfl_fieldsens::CFLFieldSensEdgeFunction *>,
-                 EdgeFunction<l_t>>
+  llvm::DenseMap<std::pair<EFConstPtr, EFConstPtr>, EdgeFunction<l_t>>
       CombineCache;
 
   uint8_t DepthKLimit = 5; // Original from the paper

--- a/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
+++ b/include/phasar/PhasarLLVM/Utils/LLVMShorthands.h
@@ -374,6 +374,12 @@ getPointerIndicesOfType(const llvm::DIType *Ty, const llvm::DataLayout &DL);
 getPointerIndicesOfType(const llvm::DIType *Ty, const llvm::DataLayout &DL,
                         PointerIndicesCache &PIC);
 
+[[nodiscard]] bool walkLoadChainTo(const llvm::Value *Start,
+                                   const llvm::Value *Target,
+                                   const llvm::DataLayout &DL,
+                                   uint32_t MaxDepth,
+                                   llvm::function_ref<void(int64_t)> OnDeref);
+
 /**
  * Retrieves String annotation value as per
  * <https://llvm.org/docs/LangRef.html#llvm-var-annotation-intrinsic>

--- a/include/phasar/Utils/Compressor.h
+++ b/include/phasar/Utils/Compressor.h
@@ -224,6 +224,9 @@ private:
       assert(Elem != nullptr);
       if constexpr (has_llvm_dense_map_info<T>) {
         return llvm::DenseMapInfo<T>::getHashValue(*Elem);
+      } else if constexpr (is_llvm_hashable_v<T>) {
+        using llvm::hash_value;
+        return hash_value(*Elem);
       } else {
         return std::hash<T>{}(*Elem);
       }

--- a/include/phasar/Utils/SmallArraySet.h
+++ b/include/phasar/Utils/SmallArraySet.h
@@ -1,0 +1,359 @@
+#pragma once
+
+/******************************************************************************
+ * Copyright (c) 2026 Fabian Schiebel.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of LICENSE.txt.
+ *
+ * Contributors:
+ *     Fabian Schiebel and others
+ *****************************************************************************/
+
+#include "phasar/Utils/ByRef.h"
+#include "phasar/Utils/Utilities.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
+
+#include <algorithm>
+#include <concepts>
+#include <functional>
+#include <initializer_list>
+#include <numeric>
+#include <type_traits>
+
+namespace psr {
+
+/// \brief Simple set container similar to the upcoming std::flat_set but only
+/// uses  sorting+binary-search, once the size exceeds a fixed threshold. Below
+/// the threshold unique-insertion + lookup is handled via linear search.
+///
+/// Should work well, if the expected size is small.
+/// Use the static methods fromSorted() and fromSortedUniqued(), to speedup
+/// construction,. if you can make some assumptions about the incoming data.
+template <typename T,
+          unsigned N =
+              llvm::CalculateSmallVectorDefaultInlinedElements<T>::value>
+class SmallArraySet : private llvm::SmallVector<T, N> {
+public:
+  using typename llvm::SmallVector<T, N>::value_type;
+  using typename llvm::SmallVector<T, N>::iterator;
+  using typename llvm::SmallVector<T, N>::const_iterator;
+  using typename llvm::SmallVector<T, N>::const_reference;
+  using typename llvm::SmallVector<T, N>::reference;
+  using typename llvm::SmallVector<T, N>::const_pointer;
+  using typename llvm::SmallVector<T, N>::pointer;
+  using typename llvm::SmallVector<T, N>::difference_type;
+
+  static constexpr size_t LinearThreshold = std::max<size_t>(1, 64 / sizeof(T));
+
+  SmallArraySet() noexcept = default;
+  SmallArraySet(std::initializer_list<T> IList)
+      : llvm::SmallVector<T, N>(IList) {
+    psr::sortUnique(base());
+  }
+
+  explicit SmallArraySet(llvm::ArrayRef<T> Elems)
+      : llvm::SmallVector<T, N>(Elems) {
+    psr::sortUnique(base());
+  }
+
+  [[nodiscard]] static SmallArraySet
+  fromSorted(llvm::SmallVectorImpl<T> &&Vec) {
+    assert(std::ranges::is_sorted(Vec) && "Vec is not sorted");
+    SmallArraySet Ret(std::move(Vec), /*PreSortedAndUniqued=*/std::true_type{});
+
+    Ret.base().erase(std::unique(begin(), end()), end());
+
+    return Ret;
+  }
+
+  [[nodiscard]] static SmallArraySet
+  fromSortedUniqued(llvm::SmallVectorImpl<T> &&Vec) {
+    assert(std::ranges::is_sorted(Vec) && "Vec is not sorted");
+    assert(std::ranges::adjacent_find(Vec) == Vec.end() &&
+           "Vec is not uniqued");
+
+    SmallArraySet Ret(std::move(Vec), /*PreSortedAndUniqued=*/std::true_type{});
+    return Ret;
+  }
+
+  // Note: default the special member functions to explicitly make the move ctor
+  // noexcept
+  SmallArraySet(const SmallArraySet &) = default;
+  SmallArraySet(SmallArraySet &&) noexcept = default;
+  SmallArraySet &operator=(const SmallArraySet &) = default;
+  SmallArraySet &operator=(SmallArraySet &&) noexcept = default;
+  ~SmallArraySet() = default;
+
+  [[nodiscard]] operator llvm::ArrayRef<T>() const noexcept { return base(); }
+
+  using llvm::SmallVector<T, N>::begin;
+  using llvm::SmallVector<T, N>::end;
+  using llvm::SmallVector<T, N>::size;
+  using llvm::SmallVector<T, N>::empty;
+  using llvm::SmallVector<T, N>::reserve;
+  using llvm::SmallVector<T, N>::operator==;
+  using llvm::SmallVector<T, N>::operator!=;
+
+  // Without inline, clang may not inline this, even in O3
+  // NOLINTNEXTLINE(readability-redundant-inline-specifier)
+  inline bool insert(ByConstRef<T> Val) {
+    const auto Size = this->size();
+    const auto Begin = this->begin();
+    const auto End = this->end();
+
+    if (Size < LinearThreshold) [[likely]] {
+      if (std::find(Begin, End, Val) != End) {
+        return false;
+      }
+
+      this->push_back(Val);
+
+      if (Size + 1 == LinearThreshold) [[unlikely]] {
+        std::ranges::sort(base());
+      }
+
+      return true;
+    }
+
+    return insertImpl(Val);
+  }
+
+  // Assume, the new Val is not in the set yet
+  void insertUnique(T Val) {
+    assert(!contains(Val));
+    if (this->size() < LinearThreshold || Val > this->back()) {
+      this->push_back(std::move(Val));
+      return;
+    }
+    insertImpl(Val);
+  }
+
+  void insert(const SmallArraySet &Other) {
+    const auto Size = size();
+    const auto OtherSize = Other.size();
+
+    llvm::ArrayRef<T> OtherArr = Other;
+
+    if (OtherSize <= Size && Size + OtherSize <= LinearThreshold) {
+      size_t I = 0;
+      for (; I != OtherSize; ++I) {
+        const auto End = this->end();
+        ByConstRef<T> Val = OtherArr[I];
+        if (std::find(this->begin(), End, Val) != End) {
+          continue;
+        }
+        if (this->size() == LinearThreshold) {
+          break;
+        }
+        this->push_back(Val);
+      }
+      if (I == OtherSize) {
+        if (this->size() == LinearThreshold) [[unlikely]] {
+          std::ranges::sort(base());
+        }
+        return;
+      }
+
+      OtherArr = OtherArr.slice(I);
+    }
+
+    insertImpl(OtherArr);
+  }
+
+  void insertAll(auto &&Range) {
+    size_t EstimatedRngSize = SIZE_MAX;
+    if constexpr (requires() {
+                    { Range.size() } -> std::convertible_to<size_t>;
+                  }) {
+      EstimatedRngSize = Range.size();
+    }
+
+    if (size() < LinearThreshold && EstimatedRngSize < LinearThreshold) {
+      for (auto &&Elem : Range) {
+        insert(PSR_FWD(Elem));
+      }
+      return;
+    }
+
+    this->append(llvm::adl_begin(Range), llvm::adl_end(Range));
+    psr::sortUnique(base());
+  }
+
+  [[nodiscard]] SmallArraySet setUnion(const SmallArraySet &Other) const {
+
+    const auto Size = size();
+    const auto OtherSize = Other.size();
+    if (std::min(Size, OtherSize) < LinearThreshold) {
+      const auto ThisSmaller = Size < OtherSize;
+      const auto &Smaller = ThisSmaller ? *this : Other;
+      const auto &Larger = ThisSmaller ? Other : *this;
+      auto Merged = Larger;
+      Merged.insert(Smaller);
+      return Merged;
+    }
+
+    SmallArraySet Merged{};
+    Merged.resize_for_overwrite(size() + Other.size());
+    auto LastOut = std::set_union(begin(), end(), Other.begin(), Other.end(),
+                                  Merged.begin());
+    Merged.base().erase(LastOut, Merged.end());
+    return Merged;
+  }
+
+  bool intersectWith(const SmallArraySet &Other) {
+    const auto Size = size();
+    const auto OtherSize = Other.size();
+
+    if (Size < LinearThreshold || OtherSize > Size) {
+      auto It = std::ranges::remove_if(
+          base(), [&Other](const auto &Elem) { return !Other.contains(Elem); });
+      base().erase(It.begin(), It.end());
+      return Size != size();
+    }
+
+    // TODO: Optimize
+
+    SmallArraySet Merged{};
+    Merged.resize_for_overwrite(std::min(Size, OtherSize));
+
+    auto [Unused1, Unused2, LastOut] =
+        std::ranges::set_intersection(*this, Other, Merged.begin());
+    Merged.base().erase(LastOut, Merged.end());
+    *this = std::move(Merged);
+    return Size != size();
+  }
+
+  [[nodiscard]] SmallArraySet
+  setIntersection(const SmallArraySet &Other) const {
+    const auto Size = size();
+    const auto OtherSize = Other.size();
+
+    if (std::min(Size, OtherSize) < LinearThreshold) {
+      auto Ret = Size < OtherSize ? *this : Other;
+      const auto &Larger = Size < OtherSize ? Other : *this;
+      auto It = std::ranges::remove_if(
+          Ret, [&Larger](const auto &Elem) { return !Larger.contains(Elem); });
+      Ret.base().erase(It.begin(), It.end());
+      return Ret;
+    }
+
+    SmallArraySet Merged{};
+    Merged.resize_for_overwrite(std::min(Size, OtherSize));
+
+    auto [Unused1, Unused2, LastOut] =
+        std::ranges::set_intersection(*this, Other, Merged.begin());
+    Merged.base().erase(LastOut, Merged.end());
+    return Merged;
+  }
+
+  [[nodiscard]] bool contains(ByConstRef<T> Val) const noexcept {
+    if (this->size() < LinearThreshold) {
+      return llvm::is_contained(base(), Val);
+    }
+
+    return std::ranges::binary_search(base(), Val);
+  }
+
+  void sort() {
+    if (size() >= LinearThreshold) {
+      // Always sorted
+      return;
+    }
+
+    std::ranges::sort(base());
+  }
+
+  LLVM_ATTRIBUTE_ALWAYS_INLINE void foreach (
+      std::invocable<const T &> auto Handler) const {
+    for (const auto &Elem : base()) {
+      std::invoke(Handler, Elem);
+    }
+  }
+
+  [[nodiscard]] friend auto hash_value(const SmallArraySet &Set) noexcept {
+    if (Set.size() < LinearThreshold) {
+      if constexpr (std::is_trivially_copyable_v<T>) {
+        T Arr[LinearThreshold]{};
+        memcpy(&Arr, Set.data(), Set.size_in_bytes());
+        std::ranges::sort(Arr, Arr + Set.size());
+        return llvm::hash_combine_range(Arr, Arr + Set.size());
+      } else {
+        // Some reduction that ignores the order
+        return std::transform_reduce(Set.begin(), Set.end(), 37,
+                                     std::bit_xor<>{}, [](ByConstRef<T> Val) {
+                                       using llvm::hash_value;
+                                       return hash_value(Val);
+                                     });
+      }
+    } else {
+      return llvm::hash_combine_range(Set.begin(), Set.end());
+    }
+  }
+
+  [[nodiscard]] bool operator==(const SmallArraySet &Other) const noexcept {
+    if (size() != Other.size()) {
+      return false;
+    }
+
+    if (size() < LinearThreshold) {
+      if (hash_value(*this) != hash_value(Other)) {
+        // Some pre-check to avoid the quadratic loop.
+        // XXX: Need to measure, whether this actually helps
+        return false;
+      }
+
+      for (const auto &Val : Other) {
+        if (!contains(Val)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    return std::equal(begin(), end(), Other.begin());
+  }
+
+private:
+  explicit SmallArraySet(llvm::SmallVectorImpl<T> &&Elems,
+                         std::true_type /*PreSortedAndUniqued*/)
+      : llvm::SmallVector<T, N>(std::move(Elems)) {}
+
+  bool insertImpl(ByConstRef<T> Val) {
+    const auto It = std::ranges::lower_bound(base(), Val);
+    if (It != this->end() && *It == Val) {
+      return false;
+    }
+
+    base().insert(It, Val);
+    return true;
+  }
+
+  void insertImpl(llvm::ArrayRef<T> OtherArr) {
+    if (OtherArr.size() < 3) {
+      // For small sizes, it is probably better to insert the elements
+      // one-by-one, instead of using std::sort.
+      // TODO: Find good threshold
+
+      for (const auto &Val : OtherArr) {
+        insert(Val);
+      }
+      return;
+    }
+
+    this->append(OtherArr.begin(), OtherArr.end());
+    psr::sortUnique(base());
+  }
+
+  [[nodiscard]] constexpr auto &base() noexcept {
+    return static_cast<llvm::SmallVectorImpl<T> &>(*this);
+  }
+  [[nodiscard]] constexpr const auto &base() const noexcept {
+    return static_cast<const llvm::SmallVectorImpl<T> &>(*this);
+  }
+};
+} // namespace psr

--- a/include/phasar/Utils/TableWrappers.h
+++ b/include/phasar/Utils/TableWrappers.h
@@ -51,6 +51,9 @@ template <typename K> struct Hasher {
   size_t operator()(ByConstRef<K> Key) const noexcept {
     if constexpr (has_getHashCode<K>::value) {
       return Key.getHashCode();
+    } else if constexpr (is_llvm_hashable_v<K>) {
+      using llvm::hash_value;
+      return hash_value(Key);
     } else {
       return std::hash<K>{}(Key);
     }
@@ -396,7 +399,7 @@ public:
 
   void
   clear() noexcept(std::is_nothrow_default_constructible_v<decltype(Set)>) {
-    std::unordered_set<T, Hasher> Empty{};
+    std::unordered_set<T, detail::Hasher<T>> Empty{};
     swap(Set, Empty);
   }
 
@@ -443,17 +446,7 @@ public:
   }
 
 private:
-  struct Hasher {
-    size_t operator()(ByConstRef<T> Key) const noexcept {
-      if constexpr (has_getHashCode<T>::value) {
-        return Key.getHashCode();
-      } else {
-        return std::hash<T>{}(Key);
-      }
-    }
-  };
-
-  std::unordered_set<T, Hasher> Set;
+  std::unordered_set<T, detail::Hasher<T>> Set;
 };
 
 template <typename K, typename V> class DenseTable1d {

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -135,7 +135,12 @@ void intersectWith(ContainerTy &Dest, const OtherContainerTy &Src) {
     if (Src.count(*It)) {
       ++It;
     } else {
-      It = Dest.erase(It);
+      if constexpr (std::is_void_v<decltype(Dest.erase(It))>) {
+        auto OldIt = It++;
+        Dest.erase(OldIt);
+      } else {
+        It = Dest.erase(It);
+      }
     }
   }
 }

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -311,18 +311,6 @@ struct SecondFn {
   }
 };
 
-template <is_llvm_printable_v T>
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                              const std::optional<T> &Opt) {
-  if (Opt) {
-    OS << *Opt;
-  } else {
-    OS << "<none>";
-  }
-
-  return OS;
-}
-
 template <typename T>
   requires(!std::is_pointer_v<T>)
 LLVM_ATTRIBUTE_ALWAYS_INLINE T &assertNotNull(T &Value) {

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -17,6 +17,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <functional>
 #include <optional>
 #include <set>
 #include <string>
@@ -358,6 +359,16 @@ constexpr void sortUnique(auto &Range, CompareFn Cmp = {}) {
   auto End = llvm::adl_end(Range);
   std::sort(It, End, std::move(Cmp));
   Range.erase(std::unique(It, End), End);
+}
+
+/// \brief Similar to std::minmax, but returns by value
+template <typename T>
+[[nodiscard]] constexpr std::pair<T, T> minmaxVal(T First, T Second) noexcept {
+  if (std::less<T>{}(Second, First)) {
+    return {std::move(Second), std::move(First)};
+  }
+
+  return {std::move(First), std::move(Second)};
 }
 
 } // namespace psr

--- a/include/phasar/Utils/Utilities.h
+++ b/include/phasar/Utils/Utilities.h
@@ -352,6 +352,14 @@ template <typename T> void assertAllNotNull([[maybe_unused]] const T &Range) {
   }
 }
 
+template <typename CompareFn = std::less<>>
+constexpr void sortUnique(auto &Range, CompareFn Cmp = {}) {
+  auto It = llvm::adl_begin(Range);
+  auto End = llvm::adl_end(Range);
+  std::sort(It, End, std::move(Cmp));
+  Range.erase(std::unique(It, End), End);
+}
+
 } // namespace psr
 
 #endif

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -444,9 +444,8 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
   // Also match when ValueOp is a zero-offset GEP of CurrNode (e.g. the -O0
   // arraydecay pattern where `%arraydecay = gep arr, 0, 0` is stored but the
   // tainted fact is `arr` itself).
-  auto [ValueBase, ValueGepOff] = getBaseAndOffset(ValueOp, DL);
-  const bool IsValueCurrNode =
-      ValueOp == CurrNode || (ValueGepOff == 0 && ValueBase == CurrNode);
+  const auto *ValueBase = ValueOp->stripPointerCastsAndAliases();
+  const bool IsValueCurrNode = ValueOp == CurrNode || ValueBase == CurrNode;
 
   if (IsValueCurrNode && CurrNode != SuccNode && FoundSuccNode) {
     // Store: prepend innermost first so the outermost becomes the HEAD.
@@ -461,6 +460,33 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
 
   // unaffected by the store
   return EdgeIdentity<l_t>{};
+}
+
+auto CFLFieldSensIFDSProblem::getLoadEdgeFunction(d_t CurrNode, d_t PointerOp,
+                                                  uint8_t DepthKLimit,
+                                                  const llvm::DataLayout &DL)
+    -> EdgeFunction<l_t> {
+
+  const auto *ZeroOffsBase = PointerOp->stripPointerCastsAndAliases();
+  if (CurrNode == PointerOp || CurrNode == ZeroOffsBase) {
+    // Note: Offsets handled in GEP below
+    AccessPath FieldString{};
+    FieldString.Loads = Mgr.prepend(/*Offset*/ 0, FieldString.Loads);
+    return makeEF(
+        CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
+  }
+
+  // In case CurrNode!=PointerOp, we filter llvm values for allocation sites.
+  // GEPs are no alloc-sites!
+  // => we must handle the offsetting here in the load, without relying it being
+  //    handled in the GEP-EF
+
+  auto [BasePtr, Offset] = getBaseAndOffset(ZeroOffsBase, DL);
+
+  AccessPath FieldString{};
+  FieldString.Loads = Mgr.prepend(Offset, FieldString.Stores);
+  return makeEF(
+      CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
 }
 
 auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
@@ -487,14 +513,10 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
   if (Curr == SuccNode) {
 
-    if (llvm::isa<llvm::LoadInst>(Curr)) {
-      // Load
-
-      // Note: Offsets handled in GEP below
-      AccessPath FieldString{};
-      FieldString.Loads = Mgr.prepend(/*Offset*/ 0, FieldString.Loads);
-      return makeEF(
-          CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
+    if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
+      return getLoadEdgeFunction(CurrNode, Load->getPointerOperand(),
+                                 DepthKLimit,
+                                 IRDB->getModule()->getDataLayout());
     }
 
     if (const auto *Gep = llvm::dyn_cast<llvm::GEPOperator>(Curr)) {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -3,10 +3,10 @@
 #include "phasar/DataFlow/IfdsIde/EdgeFunction.h"
 #include "phasar/DataFlow/IfdsIde/EdgeFunctionUtils.h"
 #include "phasar/Domain/LatticeDomain.h"
-#include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
 #include "phasar/Utils/Lazy.h"
 #include "phasar/Utils/Logger.h"
+#include "phasar/Utils/PAMMMacros.h"
 #include "phasar/Utils/Printer.h"
 #include "phasar/Utils/Utilities.h"
 
@@ -668,8 +668,8 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
                       AccessPathDMI>
       ToInsert;
   ToInsert.reserve(Paths.size()); // retained across .clear() calls below
-  // Merge stores
 
+  // Merge stores
   for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
     auto It = IIt++;
     if (It->Stores != FieldStringNodeId::None) {
@@ -689,7 +689,6 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
   }
 
   // Merge geps
-
   ToInsert.clear();
   for (const AccessPath &AP : Paths) {
     auto NoOffs = AP;
@@ -706,7 +705,6 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
   }
 
   // Merge loads
-
   ToInsert.clear();
   for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
     auto It = IIt++;
@@ -727,7 +725,6 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
   }
 
   // Merge Kills
-
   ToInsert.clear();
   for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
     auto It = IIt++;
@@ -740,7 +737,6 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
   for (auto &&[Approx, OrigPaths] : ToInsert) {
     if (OrigPaths.size() > 2) {
       auto KillSet = Mgr.kills(OrigPaths.front().Kills);
-      // ApproxMut.Kills = OrigPaths.front().Kills;
       for (const auto &AP : llvm::drop_begin(OrigPaths)) {
         KillSet.intersectWith(Mgr.kills(AP.Kills));
       }
@@ -782,6 +778,19 @@ getResultEF(llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *, 2> Ptr) {
   }
 }
 
+void CFLFieldSensIFDSProblem::regCounters() noexcept {
+  REG_COUNTER("ExtendCache Refs", 0, Full);
+  REG_COUNTER("ExtendCache Misses", 0, Full);
+
+  REG_COUNTER("CombineCache Refs", 0, Full);
+  REG_COUNTER("CombineCache Misses", 0, Full);
+  REG_COUNTER("Combine CallsTotal", 0, Full);
+  REG_COUNTER("Combine LIdentity", 0, Full);
+  REG_COUNTER("Combine LIdentitySlow", 0, Full);
+  REG_COUNTER("Combine RIdentity", 0, Full);
+  REG_COUNTER("Combine RIdentitySlow", 0, Full);
+}
+
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                                      const EdgeFunction<l_t> &R)
     -> EdgeFunction<l_t> {
@@ -794,7 +803,7 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
 
     if (!FldSensL || !FldSensR) {
-      llvm::report_fatal_error("[FieldSensAllocSitesAwareIFDSProblem::extend]: "
+      llvm::report_fatal_error("[CFLFieldSensIFDSProblem::extend]: "
                                "Unexpected edge functions: " +
                                llvm::Twine(to_string(L)) + " EXTEND " +
                                llvm::Twine(to_string(R)));
@@ -804,13 +813,11 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
       return L;
     }
 
-    static size_t ExtendCacheRefs = 0;
-    static size_t ExtendCacheMisses = 0;
+    INC_COUNTER("ExtendCache Refs", 1, Full);
 
-    ++ExtendCacheRefs;
     auto [It, Inserted] = ExtendCache.try_emplace(
         std::pair{FldSensL->Impl, FldSensR->Impl}, lazy{[&]() -> EFResultPtr {
-          ++ExtendCacheMisses;
+          INC_COUNTER("ExtendCache Misses", 1, Full);
 
           auto Txn = FldSensL->Impl->Transform;
           Txn.applyTransforms(FldSensR->Impl->Transform, DepthKLimit);
@@ -830,13 +837,6 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
               CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
         }});
 
-    static scope_exit PrintCacheEfficiency = [] {
-      llvm::errs() << "ExtendCache Refs:\t" << ExtendCacheRefs << '\n';
-      llvm::errs() << "ExtendCache Hits:\t"
-                   << (ExtendCacheRefs - ExtendCacheMisses) << '\n';
-      llvm::errs() << "ExtendCache Misses:\t" << ExtendCacheMisses << '\n';
-    };
-
     return getResultEF(It->second);
   }();
 
@@ -855,38 +855,20 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
     return Dflt;
   }
   auto Ret = [&]() -> EdgeFunction<l_t> {
-    static size_t CombineCacheRefs = 0;
-    static size_t CombineCacheMisses = 0;
-    static size_t CombineCallsTotal = 0;
-    static size_t CombineLIdentity = 0;
-    static size_t CombineLIdentitySlow = 0;
-    static size_t CombineRIdentity = 0;
-    static size_t CombineRIdentitySlow = 0;
-    static scope_exit PrintCacheEfficiency = [] {
-      llvm::errs() << "CombineCache Refs:\t" << CombineCacheRefs << '\n';
-      llvm::errs() << "CombineCache Hits:\t"
-                   << (CombineCacheRefs - CombineCacheMisses) << '\n';
-      llvm::errs() << "CombineCache Misses:\t" << CombineCacheMisses << '\n';
-      llvm::errs() << "CombineCallsTotal:\t" << CombineCallsTotal << '\n';
-      llvm::errs() << "CombineLIdentity:\t" << CombineLIdentity << '\n';
-      llvm::errs() << "CombineLIdentitySlow:\t" << CombineLIdentitySlow << '\n';
-      llvm::errs() << "CombineRIdentity:\t" << CombineRIdentity << '\n';
-      llvm::errs() << "CombineRIdentitySlow:\t" << CombineRIdentitySlow << '\n';
-    };
-
-    ++CombineCallsTotal;
+    INC_COUNTER("Combine CallsTotal", 1, Full);
 
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
     if (FldSensL) {
       if (FldSensR) {
 
-        ++CombineCacheRefs;
+        INC_COUNTER("CombineCache Refs", 1, Full);
         auto [CacheIt, CacheInserted] = CombineCache.try_emplace(
             psr::minmaxVal(FldSensL->Impl, FldSensR->Impl),
             lazy{[this, FldSensL{*FldSensL},
                   FldSensR{*FldSensR}]() -> EFResultPtr {
-              ++CombineCacheMisses;
+              INC_COUNTER("CombineCache Misses", 1, Full);
+
               // A complicated way of expressing set-union of LPaths and RPaths.
               // Reason being that we don't want to unnecessarily copy the sets.
               // Rather, we like just incrementing the ref-count of L or R if
@@ -931,24 +913,24 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
       }
 
       if (R.isa<EdgeIdentity<l_t>>()) {
-        ++CombineRIdentity;
+        INC_COUNTER("Combine RIdentity", 1, Full);
         if (FldSensL->Impl->Transform.Paths.contains(AccessPath{})) {
           return L;
         }
 
-        ++CombineRIdentitySlow;
+        INC_COUNTER("Combine RIdentitySlow", 1, Full);
         auto Txn = FldSensL->Impl->Transform;
         Txn.Paths.insert(AccessPath{});
         return makeEF(
             CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
       }
     } else if (FldSensR && L.isa<EdgeIdentity<l_t>>()) {
-      ++CombineLIdentity;
+      INC_COUNTER("Combine LIdentity", 1, Full);
       if (FldSensR->Impl->Transform.Paths.contains(AccessPath{})) {
         return R;
       }
 
-      ++CombineLIdentitySlow;
+      INC_COUNTER("Combine LIdentitySlow", 1, Full);
       auto Txn = FldSensR->Impl->Transform;
       Txn.Paths.insert(AccessPath{});
       return makeEF(

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -753,6 +753,7 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
 static constexpr ptrdiff_t BreadthKLimit = 5;
 static constexpr ptrdiff_t WidenKLimit = 128;
 
+static constexpr unsigned AllEFPtrId = 0;
 static constexpr unsigned AllBottomId = 1;
 static constexpr unsigned AllTopId = 2;
 
@@ -769,22 +770,32 @@ allTopPtr() noexcept {
 }
 
 [[nodiscard]] static EdgeFunction<l_t>
-getResultEF(llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *, 2> Ptr) {
+getResultEF(llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *, 2>
+                Ptr) noexcept {
+  PAMM_GET_INSTANCE;
   switch (Ptr.getInt()) {
-  case AllBottomId:
-    return AllBottom<l_t>{};
-  case AllTopId:
-    return AllTop<l_t>{};
-  default:
+  [[likely]] case AllEFPtrId:
+    INC_COUNTER("getResultEF Ptr", 1, Full);
     assert(Ptr.getPointer() != nullptr);
-    assert(Ptr.getPointer() == Ptr.getOpaqueValue());
+    assert(Ptr.getPointer() == Ptr.getOpaqueValue() &&
+           "Zero-tag does not pollute the alignment bits");
     return CFLFieldSensEdgeFunction{
         static_cast<const CFLFieldSensEdgeFunctionImpl *>(
             Ptr.getOpaqueValue())};
+  case AllBottomId:
+    INC_COUNTER("getResultEF Bot", 1, Full);
+    return AllBottom<l_t>{};
+  case AllTopId:
+    INC_COUNTER("getResultEF Top", 1, Full);
+    return AllTop<l_t>{};
+  default:
+    llvm_unreachable("All valid tags should be handled explicitly");
   }
 }
 
 void CFLFieldSensIFDSProblem::regCounters() noexcept {
+  PAMM_GET_INSTANCE;
+
   REG_COUNTER("ExtendCache Refs", 0, Full);
   REG_COUNTER("ExtendCache Misses", 0, Full);
 
@@ -795,6 +806,10 @@ void CFLFieldSensIFDSProblem::regCounters() noexcept {
   REG_COUNTER("Combine LIdentitySlow", 0, Full);
   REG_COUNTER("Combine RIdentity", 0, Full);
   REG_COUNTER("Combine RIdentitySlow", 0, Full);
+
+  REG_COUNTER("getResultEF Top", 0, Full);
+  REG_COUNTER("getResultEF Bot", 0, Full);
+  REG_COUNTER("getResultEF Ptr", 0, Full);
 }
 
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
@@ -818,6 +833,8 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
     if (FldSensR->Impl->Transform.isEpsilon()) {
       return L;
     }
+
+    PAMM_GET_INSTANCE;
 
     INC_COUNTER("ExtendCache Refs", 1, Full);
 
@@ -861,6 +878,7 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
     return Dflt;
   }
   auto Ret = [&]() -> EdgeFunction<l_t> {
+    PAMM_GET_INSTANCE;
     INC_COUNTER("Combine CallsTotal", 1, Full);
 
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
@@ -873,6 +891,7 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
             psr::minmaxVal(FldSensL->Impl, FldSensR->Impl),
             lazy{[this, FldSensL{*FldSensL},
                   FldSensR{*FldSensR}]() -> EFResultPtr {
+              PAMM_GET_INSTANCE;
               INC_COUNTER("CombineCache Misses", 1, Full);
 
               // A complicated way of expressing set-union of LPaths and RPaths.

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -5,14 +5,13 @@
 #include "phasar/Domain/LatticeDomain.h"
 #include "phasar/PhasarLLVM/DB/LLVMProjectIRDB.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
-#include "phasar/Utils/Fn.h"
+#include "phasar/Utils/Lazy.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/Printer.h"
 #include "phasar/Utils/Utilities.h"
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/DataLayout.h"
@@ -26,8 +25,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <functional>
-#include <numeric>
 #include <type_traits>
 #include <utility>
 
@@ -80,62 +77,6 @@ constexpr static int32_t addOffsets(int32_t L, int32_t R) noexcept {
 
   return Sum;
 }
-
-struct CFLFieldSensEdgeFunction {
-  using l_t = LatticeDomain<IFDSEdgeValue>;
-  [[clang::require_explicit_initialization]] IFDSEdgeValue Transform;
-  [[clang::require_explicit_initialization]] uint8_t DepthKLimit{};
-
-  [[nodiscard]] l_t computeTarget(l_t Source) const {
-    Source.onValue(fn<&IFDSEdgeValue::applyTransforms>, Transform, DepthKLimit);
-    return Source;
-  }
-
-  static EdgeFunction<l_t>
-  compose(EdgeFunctionRef<CFLFieldSensEdgeFunction> /*This*/,
-          const EdgeFunction<l_t> & /*SecondFunction*/) {
-    llvm::report_fatal_error("Use extend() instead!");
-  }
-
-  static EdgeFunction<l_t>
-  join(EdgeFunctionRef<CFLFieldSensEdgeFunction> /*This*/,
-       const EdgeFunction<l_t> & /*OtherFunction*/) {
-    llvm::report_fatal_error("Use combine() instead!");
-  }
-
-  bool operator==(const CFLFieldSensEdgeFunction &Other) const noexcept {
-    assert(DepthKLimit == Other.DepthKLimit);
-    return Transform == Other.Transform;
-  }
-
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                       const CFLFieldSensEdgeFunction &EF) {
-    return OS << "Txn[" << EF.Transform << ']';
-  }
-
-  [[nodiscard]] static auto from(IFDSEdgeValue &&Txn, uint8_t DepthKLimit) {
-    return CFLFieldSensEdgeFunction{
-        .Transform = std::move(Txn),
-        .DepthKLimit = DepthKLimit,
-    };
-  }
-
-  [[nodiscard]] static auto from(AccessPath Txn, FieldStringManager &Mgr,
-                                 uint8_t DepthKLimit) {
-    return CFLFieldSensEdgeFunction{
-        .Transform = {.Mgr = &Mgr, .Paths = {Txn}},
-        .DepthKLimit = DepthKLimit,
-    };
-  }
-
-  [[nodiscard]] static auto fromEpsilon(uint8_t DepthKLimit,
-                                        FieldStringManager &Mgr) {
-    return CFLFieldSensEdgeFunction{
-        .Transform = IFDSEdgeValue::epsilon(&Mgr),
-        .DepthKLimit = DepthKLimit,
-    };
-  }
-};
 
 [[nodiscard]] std::string storesToString(const AccessPath &AP,
                                          const FieldStringManager &Mgr) {
@@ -497,6 +438,15 @@ cfl_fieldsens::makeInitialSeeds(
   return {std::move(Ret)};
 }
 
+EdgeFunction<l_t>
+CFLFieldSensIFDSProblem::makeEF(cfl_fieldsens::CFLFieldSensEdgeFunction &&EF) {
+  auto [It, Inserted] = EFInternCache.insert(std::move(EF), nullptr);
+  if (Inserted) {
+    It->second = cfl_fieldsens::CFLFieldSensEdgeFunction(It->first);
+  }
+  return It->second;
+}
+
 auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
                                                    d_t PointerOp, d_t ValueOp,
                                                    uint8_t DepthKLimit,
@@ -520,7 +470,8 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
     // Kill
     AccessPath FieldString{};
     FieldString.Kills = Mgr.addKill(FieldString.Kills, Offset);
-    return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
+    return makeEF(
+        CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
   }
 
   // Also match when ValueOp is a zero-offset GEP of CurrNode (e.g. the -O0
@@ -537,7 +488,8 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
     for (int32_t DerefOffset : llvm::reverse(DerefOffsets)) {
       FieldString.Stores = Mgr.prepend(DerefOffset, FieldString.Stores);
     }
-    return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
+    return makeEF(
+        CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
   }
 
   // unaffected by the store
@@ -557,7 +509,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
   if (isZeroValue(CurrNode) && !isZeroValue(SuccNode)) {
     // Gen from zero
 
-    return CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr);
+    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
   }
 
   if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
@@ -578,7 +530,8 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
       AccessPath FieldString{};
       FieldString.Loads = Mgr.prepend(Offset, FieldString.Loads);
-      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
+      return makeEF(
+          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
     }
 
     if (const auto *Gep = llvm::dyn_cast<llvm::GEPOperator>(Curr)) {
@@ -587,7 +540,8 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
       AccessPath FieldString{};
       FieldString.Offset = OffsVal;
-      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
+      return makeEF(
+          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
     }
   }
 
@@ -608,7 +562,7 @@ auto CFLFieldSensIFDSProblem::getCallEdgeFunction(n_t CallSite, d_t SrcNode,
   if (isZeroValue(SrcNode) && !isZeroValue(DestNode)) {
     // Gen from zero
 
-    return CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr);
+    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // This is naturally identity
@@ -628,7 +582,7 @@ auto CFLFieldSensIFDSProblem::getReturnEdgeFunction(
   if (isZeroValue(ExitNode) && !isZeroValue(RetNode)) {
     // Gen from zero
 
-    return CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr);
+    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
   }
 
   return EdgeIdentity<l_t>{};
@@ -658,7 +612,7 @@ auto CFLFieldSensIFDSProblem::getCallToRetEdgeFunction(
   if (isZeroValue(CallNode) && !isZeroValue(RetSiteNode)) {
     // Gen from zero
 
-    return CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr);
+    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // This naturally identity
@@ -686,14 +640,15 @@ auto CFLFieldSensIFDSProblem::getSummaryEdgeFunction(n_t Curr, d_t CurrNode,
 
       AccessPath FieldString{};
       FieldString.Kills = Mgr.addKill(FieldString.Kills, *KillOffs);
-      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
+      return makeEF(
+          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
     }
   }
 
   if (isZeroValue(CurrNode) && !isZeroValue(SuccNode)) {
     // Gen from zero
 
-    return CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr);
+    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // TODO: Is that correct? -- We may need to handle field-indirections here
@@ -702,101 +657,91 @@ auto CFLFieldSensIFDSProblem::getSummaryEdgeFunction(n_t Curr, d_t CurrNode,
 }
 
 static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
+  llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
+                      AccessPathDMI>
+      ToInsert;
   // Merge stores
-  {
-    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
-                        AccessPathDMI>
-        ToInsert;
-    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
-      auto It = IIt++;
-      if (It->Stores != FieldStringNodeId::None) {
-        AccessPath Approx = *It;
-        auto StoresHead = Mgr[Approx.Stores];
-        Approx.Stores = Mgr.prepend(AccessPath::TopOffset, StoresHead.Next);
-        ToInsert[Approx].push_back(*It);
-        Paths.erase(It);
-      }
+
+  for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+    auto It = IIt++;
+    if (It->Stores != FieldStringNodeId::None) {
+      AccessPath Approx = *It;
+      auto StoresHead = Mgr[Approx.Stores];
+      Approx.Stores = Mgr.prepend(AccessPath::TopOffset, StoresHead.Next);
+      ToInsert[Approx].push_back(*It);
+      Paths.erase(It);
     }
-    for (auto &&[Approx, OrigPaths] : ToInsert) {
-      if (OrigPaths.size() > 2) {
-        Paths.insert(Approx);
-      } else {
-        Paths.insert(OrigPaths.begin(), OrigPaths.end());
-      }
+  }
+  for (auto &&[Approx, OrigPaths] : ToInsert) {
+    if (OrigPaths.size() > 2) {
+      Paths.insert(Approx);
+    } else {
+      Paths.insert(OrigPaths.begin(), OrigPaths.end());
     }
   }
 
   // Merge geps
-  {
-    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
-                        AccessPathDMI>
-        ToInsert;
-    for (const AccessPath &AP : Paths) {
-      auto NoOffs = AP;
-      NoOffs.Offset = AccessPath::TopOffset;
-      ToInsert[NoOffs].push_back(AP);
-    }
-    Paths.clear();
-    for (auto &&[Approx, OrigPaths] : ToInsert) {
-      if (OrigPaths.size() > 2) {
-        Paths.insert(Approx);
-      } else {
-        Paths.insert(OrigPaths.begin(), OrigPaths.end());
-      }
+
+  ToInsert.clear();
+  for (const AccessPath &AP : Paths) {
+    auto NoOffs = AP;
+    NoOffs.Offset = AccessPath::TopOffset;
+    ToInsert[NoOffs].push_back(AP);
+  }
+  Paths.clear();
+  for (auto &&[Approx, OrigPaths] : ToInsert) {
+    if (OrigPaths.size() > 2) {
+      Paths.insert(Approx);
+    } else {
+      Paths.insert(OrigPaths.begin(), OrigPaths.end());
     }
   }
 
   // Merge loads
-  {
-    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
-                        AccessPathDMI>
-        ToInsert;
-    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
-      auto It = IIt++;
-      if (It->Loads != FieldStringNodeId::None) {
-        AccessPath Approx = *It;
-        auto LoadsHead = Mgr[Approx.Loads];
-        Approx.Loads = Mgr.prepend(AccessPath::TopOffset, LoadsHead.Next);
-        ToInsert[Approx].push_back(*It);
-        Paths.erase(It);
-      }
+
+  ToInsert.clear();
+  for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+    auto It = IIt++;
+    if (It->Loads != FieldStringNodeId::None) {
+      AccessPath Approx = *It;
+      auto LoadsHead = Mgr[Approx.Loads];
+      Approx.Loads = Mgr.prepend(AccessPath::TopOffset, LoadsHead.Next);
+      ToInsert[Approx].push_back(*It);
+      Paths.erase(It);
     }
-    for (auto &&[Approx, OrigPaths] : ToInsert) {
-      if (OrigPaths.size() > 2) {
-        Paths.insert(Approx);
-      } else {
-        Paths.insert(OrigPaths.begin(), OrigPaths.end());
-      }
+  }
+  for (auto &&[Approx, OrigPaths] : ToInsert) {
+    if (OrigPaths.size() > 2) {
+      Paths.insert(Approx);
+    } else {
+      Paths.insert(OrigPaths.begin(), OrigPaths.end());
     }
   }
 
   // Merge Kills
-  {
-    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
-                        AccessPathDMI>
-        ToInsert;
-    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
-      auto It = IIt++;
 
-      AccessPath Approx = *It;
-      Approx.Kills = {};
-      ToInsert[Approx].push_back(*It);
-      Paths.erase(It);
-    }
-    for (auto &&[Approx, OrigPaths] : ToInsert) {
-      if (OrigPaths.size() > 2) {
-        auto KillSet = Mgr.kills(OrigPaths.front().Kills);
-        // ApproxMut.Kills = OrigPaths.front().Kills;
-        for (const auto &AP : llvm::drop_begin(OrigPaths)) {
-          KillSet.intersectWith(Mgr.kills(AP.Kills));
-        }
+  ToInsert.clear();
+  for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+    auto It = IIt++;
 
-        auto ApproxMut = Approx;
-        ApproxMut.Kills = Mgr.internKills(std::move(KillSet));
-        Paths.insert(std::move(ApproxMut));
-      } else {
-        Paths.insert(OrigPaths.begin(), OrigPaths.end());
+    AccessPath Approx = *It;
+    Approx.Kills = {};
+    ToInsert[Approx].push_back(*It);
+    Paths.erase(It);
+  }
+  for (auto &&[Approx, OrigPaths] : ToInsert) {
+    if (OrigPaths.size() > 2) {
+      auto KillSet = Mgr.kills(OrigPaths.front().Kills);
+      // ApproxMut.Kills = OrigPaths.front().Kills;
+      for (const auto &AP : llvm::drop_begin(OrigPaths)) {
+        KillSet.intersectWith(Mgr.kills(AP.Kills));
       }
+
+      auto ApproxMut = Approx;
+      ApproxMut.Kills = Mgr.internKills(std::move(KillSet));
+      Paths.insert(std::move(ApproxMut));
+    } else {
+      Paths.insert(OrigPaths.begin(), OrigPaths.end());
     }
   }
 }
@@ -815,36 +760,55 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
 
-    if (FldSensL && FldSensR) {
-      if (FldSensR->Transform.isEpsilon()) {
-        return L;
-      }
+    static size_t ExtendCacheRefs = 0;
+    static size_t ExtendCacheMisses = 0;
 
-      if (FldSensL->Transform.Paths.empty()) {
-        return L;
-      }
+    ++ExtendCacheRefs;
+    auto [It, Inserted] = ExtendCache.try_emplace(
+        std::pair{FldSensL, FldSensR}, lazy{[&]() -> EdgeFunction<l_t> {
+          ++ExtendCacheMisses;
+          if (FldSensL && FldSensR) {
+            if (FldSensR->Transform.isEpsilon()) {
+              return L;
+            }
 
-      auto Txn = FldSensL->Transform;
-      Txn.applyTransforms(FldSensR->Transform, DepthKLimit);
+            if (FldSensL->Transform.Paths.empty()) {
+              return L;
+            }
 
-      if (Txn.Paths.empty()) {
-        return AllTop<l_t>{};
-      }
+            auto Txn = FldSensL->Transform;
+            Txn.applyTransforms(FldSensR->Transform, DepthKLimit);
 
-      if (Txn.Paths.size() > BreadthKLimit) {
-        klimitPaths(Txn.Paths, Mgr);
-        if (Txn.Paths.size() > WidenKLimit) {
-          return AllBottom<l_t>{};
-        }
-      }
+            if (Txn.Paths.empty()) {
+              return AllTop<l_t>{};
+            }
 
-      return CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit);
-    }
+            if (Txn.Paths.size() > BreadthKLimit) {
+              klimitPaths(Txn.Paths, Mgr);
+              if (Txn.Paths.size() > WidenKLimit) {
+                return AllBottom<l_t>{};
+              }
+            }
 
-    llvm::report_fatal_error("[FieldSensAllocSitesAwareIFDSProblem::extend]: "
-                             "Unexpected edge functions: " +
-                             llvm::Twine(to_string(L)) + " EXTEND " +
-                             llvm::Twine(to_string(R)));
+            return makeEF(
+                CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
+          }
+
+          llvm::report_fatal_error(
+              "[FieldSensAllocSitesAwareIFDSProblem::extend]: "
+              "Unexpected edge functions: " +
+              llvm::Twine(to_string(L)) + " EXTEND " +
+              llvm::Twine(to_string(R)));
+        }});
+
+    static scope_exit PrintCacheEfficiency = [] {
+      llvm::errs() << "ExtendCache Refs:\t" << ExtendCacheRefs << '\n';
+      llvm::errs() << "ExtendCache Hits:\t"
+                   << (ExtendCacheRefs - ExtendCacheMisses) << '\n';
+      llvm::errs() << "ExtendCache Misses:\t" << ExtendCacheMisses << '\n';
+    };
+
+    return It->second;
   }();
 
   if (!L.isa<EdgeIdentity<l_t>>() && !R.isa<EdgeIdentity<l_t>>()) {
@@ -867,44 +831,63 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
 
     if (FldSensL) {
       if (FldSensR) {
-        // A complicated way of expressing set-union of LPaths and RPaths.
-        // Reason being that we don't want to unnecessarily copy the sets.
-        // Rather, we like just incrementing the ref-count of L or R if somehow
-        // possible.
 
-        const auto &LPaths = FldSensL->Transform.Paths;
-        const auto &RPaths = FldSensR->Transform.Paths;
-        const auto LeftSz = LPaths.size();
-        const auto RightSz = RPaths.size();
-        const auto LeftSmaller = LeftSz < RightSz;
+        static size_t CombineCacheRefs = 0;
+        static size_t CombineCacheMisses = 0;
 
-        if (LeftSz && RightSz) {
-          const auto &Larger = LeftSmaller ? RPaths : LPaths;
-          const auto &Smaller = LeftSmaller ? LPaths : RPaths;
+        ++CombineCacheRefs;
+        auto [CacheIt, CacheInserted] = CombineCache.try_emplace(
+            psr::minmaxVal(FldSensL, FldSensR),
+            lazy{[&]() -> EdgeFunction<l_t> {
+              ++CombineCacheMisses;
+              // A complicated way of expressing set-union of LPaths and RPaths.
+              // Reason being that we don't want to unnecessarily copy the sets.
+              // Rather, we like just incrementing the ref-count of L or R if
+              // somehow possible.
 
-          auto It = Smaller.begin();
-          const auto End = Smaller.end();
+              const auto &LPaths = FldSensL->Transform.Paths;
+              const auto &RPaths = FldSensR->Transform.Paths;
+              const auto LeftSz = LPaths.size();
+              const auto RightSz = RPaths.size();
+              const auto LeftSmaller = LeftSz < RightSz;
 
-          for (; It != End; ++It) {
-            if (!Larger.contains(*It)) {
-              auto Union = Larger;
-              Union.insert(It, End);
+              if (LeftSz && RightSz) {
+                const auto &Larger = LeftSmaller ? RPaths : LPaths;
+                const auto &Smaller = LeftSmaller ? LPaths : RPaths;
 
-              // NOTE: No k-limit in combine()!!! Otherwise, we loose
-              // monotonicity of the lattice!
+                auto It = Smaller.begin();
+                const auto End = Smaller.end();
 
-              if (Union.size() > WidenKLimit) {
-                return AllBottom<l_t>{};
+                for (; It != End; ++It) {
+                  if (!Larger.contains(*It)) {
+                    auto Union = Larger;
+                    Union.insert(It, End);
+
+                    // NOTE: No k-limit in combine()!!! Otherwise, we loose
+                    // monotonicity of the lattice!
+
+                    if (Union.size() > WidenKLimit) {
+                      return AllBottom<l_t>{};
+                    }
+
+                    return makeEF(CFLFieldSensEdgeFunction::from(
+                        IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},
+                        DepthKLimit));
+                  }
+                }
               }
 
-              return CFLFieldSensEdgeFunction::from(
-                  IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},
-                  DepthKLimit);
-            }
-          }
-        }
+              return LeftSmaller ? R : L;
+            }});
 
-        return LeftSmaller ? R : L;
+        static scope_exit PrintCacheEfficiency = [] {
+          llvm::errs() << "CombineCache Refs:\t" << CombineCacheRefs << '\n';
+          llvm::errs() << "CombineCache Hits:\t"
+                       << (CombineCacheRefs - CombineCacheMisses) << '\n';
+          llvm::errs() << "CombineCache Misses:\t" << CombineCacheMisses
+                       << '\n';
+        };
+        return CacheIt->second;
       }
 
       if (R.isa<EdgeIdentity<l_t>>()) {
@@ -914,7 +897,8 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
 
         auto Txn = FldSensL->Transform;
         Txn.Paths.insert(AccessPath{});
-        return CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit);
+        return makeEF(
+            CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
       }
     } else if (FldSensR && L.isa<EdgeIdentity<l_t>>()) {
       if (FldSensR->Transform.Paths.contains(AccessPath{})) {
@@ -923,7 +907,8 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
 
       auto Txn = FldSensR->Transform;
       Txn.Paths.insert(AccessPath{});
-      return CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit);
+      return makeEF(
+          CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
     }
 
     llvm::errs() << "COMBINE " << L << " X " << R << " ==> AllBottom\n";

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -39,6 +39,8 @@ FieldStringManager::FieldStringManager() {
   NodeCompressor.insertDummy(
       FieldStringNode{.Next = FieldStringNodeId::None, .Offset = 0});
   Depth.push_back(0);
+  // Empty kill-set has index 0
+  KillsCompressor.getOrInsert({});
 }
 
 llvm::SmallVector<int32_t>
@@ -118,15 +120,12 @@ struct CFLFieldSensEdgeFunction {
     };
   }
 
-  [[nodiscard]] static auto from(AccessPath &&Txn, FieldStringManager &Mgr,
+  [[nodiscard]] static auto from(AccessPath Txn, FieldStringManager &Mgr,
                                  uint8_t DepthKLimit) {
-    // Avoid initializer_list as it prevents moving
-    auto Ret = CFLFieldSensEdgeFunction{
-        .Transform = {.Mgr = &Mgr, .Paths = {}},
+    return CFLFieldSensEdgeFunction{
+        .Transform = {.Mgr = &Mgr, .Paths = {Txn}},
         .DepthKLimit = DepthKLimit,
     };
-    Ret.Transform.Paths.insert(std::move(Txn));
-    return Ret;
   }
 
   [[nodiscard]] static auto fromEpsilon(uint8_t DepthKLimit,
@@ -170,7 +169,7 @@ struct CFLFieldSensEdgeFunction {
   if (F.Stores == FieldStringNodeId::None) {
     auto Offs = F.Offset + Field;
 
-    if (F.kills(Offs)) {
+    if (Mgr.isKilledBy(F.Kills, Offs)) {
       return false;
     }
 
@@ -183,7 +182,7 @@ struct CFLFieldSensEdgeFunction {
     }
 
     F.Loads = Mgr.prepend(Offs, F.Loads);
-    F.Kills.clear();
+    F.Kills = KillSetId::Empty;
     return true;
   }
 
@@ -218,7 +217,7 @@ struct CFLFieldSensEdgeFunction {
       return true;
     }
 
-    F.Kills.insert(Offs);
+    F.Kills = Mgr.addKill(F.Kills, Offs);
     PHASAR_LOG_LEVEL_CAT(DEBUG, IFDSEdgeValue::LogCategory, "> add K" << Offs);
     return true;
   }
@@ -269,6 +268,7 @@ void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
   const auto TxnOffset = Txn.Offset;
   const auto TxnLoads = EV.Mgr->getFullFieldString(Txn.Loads);
   const auto TxnStores = EV.Mgr->getFullFieldString(Txn.Stores);
+  const auto Kills = EV.Mgr->kills(Txn.Kills); // safety copy
 
   for (const auto &F : Save) {
     auto Copy = F;
@@ -285,7 +285,7 @@ void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
         }
       }
 
-      for (auto Kl : Txn.Kills) {
+      for (auto Kl : Kills) {
         if (!applyOneGepAndKill(*EV.Mgr, Copy, Kl, DepthKLimit)) {
           return false;
         }
@@ -301,9 +301,23 @@ void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
     }();
 
     if (Retain) {
-      EV.Paths.insert(std::move(Copy));
+      EV.Paths.insert(Copy);
     }
   }
+}
+
+static auto &printOffset(llvm::raw_ostream &OS, int32_t Offset,
+                         bool WithSign = false) {
+
+  if (WithSign && (Offset > 0 || Offset == AccessPath::TopOffset)) {
+    OS << '+';
+  }
+  if (Offset == AccessPath::TopOffset) {
+    OS << 'T';
+  } else {
+    OS << Offset;
+  }
+  return OS;
 }
 } // namespace
 
@@ -345,14 +359,6 @@ void IFDSEdgeValue::applyTransforms(const IFDSEdgeValue &Txns,
   *this = std::move(Ret);
 }
 
-size_t psr::cfl_fieldsens::hash_value(const AccessPath &FieldString) noexcept {
-  // Xor does not care about the order
-  auto HCK = std::reduce(FieldString.Kills.begin(), FieldString.Kills.end(), 0,
-                         std::bit_xor<>{});
-  return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
-                            FieldString.Offset, HCK);
-}
-
 llvm::raw_ostream &
 psr::cfl_fieldsens::operator<<(llvm::raw_ostream &OS,
                                const AccessPath &FieldString) {
@@ -361,19 +367,15 @@ psr::cfl_fieldsens::operator<<(llvm::raw_ostream &OS,
   }
 
   if (FieldString.Offset) {
-    if (FieldString.Offset > 0) {
-      OS << '+';
-    }
-
-    OS << FieldString.Offset << '.';
+    printOffset(OS, FieldString.Offset, true) << '.';
   }
 
   if (FieldString.Loads != FieldStringNodeId::None) {
     OS << "L#" << uint32_t(FieldString.Loads) << '.';
   }
 
-  for (auto Kl : FieldString.Kills) {
-    OS << 'K' << Kl << '.';
+  if (FieldString.Kills != KillSetId::Empty) {
+    OS << "K#" << uint32_t(FieldString.Kills) << '.';
   }
 
   if (FieldString.Stores != FieldStringNodeId::None) {
@@ -391,23 +393,19 @@ void AccessPath::print(llvm::raw_ostream &OS,
   }
 
   if (Offset != 0) {
-    if (Offset > 0) {
-      OS << '+';
-    }
-
-    OS << Offset << '.';
+    printOffset(OS, Offset, true) << '.';
   }
 
   for (auto Ld : Mgr.getFullFieldString(Loads)) {
-    OS << 'L' << Ld << '.';
+    printOffset(OS << 'L', Ld) << '.';
   }
 
-  for (auto Kl : Kills) {
-    OS << 'K' << Kl << '.';
+  for (auto Kl : Mgr.kills(Kills)) {
+    printOffset(OS << 'K', Kl) << '.';
   }
 
   for (auto St : Mgr.getFullFieldString(Stores)) {
-    OS << 'S' << St << '.';
+    printOffset(OS << 'S', St) << '.';
   }
 }
 
@@ -467,9 +465,8 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
   if (CurrNode == SuccNode && FoundSuccNode) {
     // Kill
     AccessPath FieldString{};
-    FieldString.Kills.insert(Offset);
-    return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
-                                          DepthKLimit);
+    FieldString.Kills = Mgr.addKill(FieldString.Kills, Offset);
+    return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
   }
 
   // Also match when ValueOp is a zero-offset GEP of CurrNode (e.g. the -O0
@@ -486,8 +483,7 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
     for (int32_t DerefOffset : llvm::reverse(DerefOffsets)) {
       FieldString.Stores = Mgr.prepend(DerefOffset, FieldString.Stores);
     }
-    return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
-                                          DepthKLimit);
+    return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
   }
 
   // unaffected by the store
@@ -528,8 +524,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
       AccessPath FieldString{};
       FieldString.Loads = Mgr.prepend(Offset, FieldString.Loads);
-      return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
-                                            DepthKLimit);
+      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
     }
 
     if (const auto *Gep = llvm::dyn_cast<llvm::GEPOperator>(Curr)) {
@@ -538,8 +533,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
       AccessPath FieldString{};
       FieldString.Offset = OffsVal;
-      return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
-                                            DepthKLimit);
+      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
     }
   }
 
@@ -637,9 +631,8 @@ auto CFLFieldSensIFDSProblem::getSummaryEdgeFunction(n_t Curr, d_t CurrNode,
                                                   << *KillOffs);
 
       AccessPath FieldString{};
-      FieldString.Kills.insert(*KillOffs);
-      return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
-                                            DepthKLimit);
+      FieldString.Kills = Mgr.addKill(FieldString.Kills, *KillOffs);
+      return CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit);
     }
   }
 
@@ -666,7 +659,7 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
         AccessPath Approx = *It;
         auto StoresHead = Mgr[Approx.Stores];
         Approx.Stores = Mgr.prepend(AccessPath::TopOffset, StoresHead.Next);
-        ToInsert[std::move(Approx)].push_back(*It);
+        ToInsert[Approx].push_back(*It);
         Paths.erase(It);
       }
     }
@@ -738,12 +731,14 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
     }
     for (auto &&[Approx, OrigPaths] : ToInsert) {
       if (OrigPaths.size() > 2) {
-        auto ApproxMut = Approx;
-        ApproxMut.Kills = OrigPaths.front().Kills;
+        auto KillSet = Mgr.kills(OrigPaths.front().Kills);
+        // ApproxMut.Kills = OrigPaths.front().Kills;
         for (const auto &AP : llvm::drop_begin(OrigPaths)) {
-          intersectWith(ApproxMut.Kills, AP.Kills);
+          KillSet.intersectWith(Mgr.kills(AP.Kills));
         }
 
+        auto ApproxMut = Approx;
+        ApproxMut.Kills = Mgr.internKills(std::move(KillSet));
         Paths.insert(std::move(ApproxMut));
       } else {
         Paths.insert(OrigPaths.begin(), OrigPaths.end());
@@ -753,7 +748,7 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
 }
 
 static constexpr ptrdiff_t BreadthKLimit = 5;
-static constexpr ptrdiff_t WidenLimit = 1024;
+static constexpr ptrdiff_t WidenKLimit = 1024;
 
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                                      const EdgeFunction<l_t> &R)
@@ -785,6 +780,11 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
       if (Txn.Paths.size() > BreadthKLimit) {
         klimitPaths(Txn.Paths, Mgr);
       }
+
+      if (Txn.Paths.size() > WidenKLimit) {
+        return AllBottom<l_t>{};
+      }
+
       return CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit);
     }
 
@@ -838,14 +838,8 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
               auto Union = Larger;
               Union.insert(It, End);
 
-              if (Union.size() > BreadthKLimit) {
-                // llvm::errs() << "Union.size(): " << Union.size() << '\n';
-                klimitPaths(Union, Mgr);
-
-                if (Union.size() > WidenLimit) {
-                  return AllBottom<l_t>{};
-                }
-              }
+              // NOTE: No k-limit in combine()!!! Otherwise, we loose
+              // monotonicity of the lattice!
 
               return CFLFieldSensEdgeFunction::from(
                   IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -94,13 +94,12 @@ constexpr static int32_t addOffsets(int32_t L, int32_t R) noexcept {
 [[nodiscard]] auto applyOneGepAndStore(FieldStringManager &Mgr, AccessPath &F,
                                        int32_t Field, uint8_t DepthKLimit) {
   if (Mgr.depth(F.Stores) == DepthKLimit) {
-    // TODO: Optimize:
+    // XXX: Optimize:
     auto Full = Mgr.getFullFieldString(F.Stores);
     Full.erase(Full.begin());
     F.Stores = Mgr.fromFullFieldString(Full);
   }
   F.Stores = Mgr.prepend(Field, F.Stores);
-  // F.Stores = Mgr.prepend(std::exchange(F.Offset, 0) + Field, F.Stores);
   return std::true_type{};
 }
 
@@ -116,7 +115,6 @@ constexpr static int32_t addOffsets(int32_t L, int32_t R) noexcept {
 
     F.Offset = 0;
 
-    // TODO: Is this application of k-limiting correct here?
     // cf. Section 4.2.3 "K-Limiting" in the paper
     if (Mgr.depth(F.Loads) == DepthKLimit) {
       return true;
@@ -131,16 +129,12 @@ constexpr static int32_t addOffsets(int32_t L, int32_t R) noexcept {
 
   if (StoresHead.Offset != Field &&
       StoresHead.Offset != AccessPath::TopOffset) {
-    // F.print(llvm::errs() << "For AccesPath ", Mgr);
-    // llvm::errs() << ": Load " << Field << " invalid offset\n";
     return false;
   }
 
   assert(StoresHead.Offset == Field ||
          StoresHead.Offset == AccessPath::TopOffset);
-  // F.Offset = 0;
   F.Stores = StoresHead.Next;
-  // llvm::errs() << "> pop_back\n";
   return true;
 }
 
@@ -190,9 +184,53 @@ constexpr static int32_t addOffsets(int32_t L, int32_t R) noexcept {
   return std::true_type{};
 }
 
+static void applyTransformImpl(const IFDSEdgeValue::container_type &EV,
+                               IFDSEdgeValue::container_type &Into,
+                               FieldStringManager &Mgr, const AccessPath &Txn,
+                               uint8_t DepthKLimit) {
+  const auto TxnOffset = Txn.Offset;
+  const auto TxnLoads = Mgr.getFullFieldString(Txn.Loads);
+  const auto TxnStores = Mgr.getFullFieldString(Txn.Stores);
+  const auto Kills = Mgr.kills(Txn.Kills); // safety copy
+
+  for (const auto &F : EV) {
+    auto Copy = F;
+    bool Retain = [&] {
+      if (TxnOffset) {
+        if (!applyOneGep(Mgr, Copy, TxnOffset, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto Ld : TxnLoads) {
+        if (!applyOneGepAndLoad(Mgr, Copy, Ld, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto Kl : Kills) {
+        if (!applyOneGepAndKill(Mgr, Copy, Kl, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto St : TxnStores) {
+        if (!applyOneGepAndStore(Mgr, Copy, St, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      return true;
+    }();
+
+    if (Retain) {
+      Into.insert(Copy);
+    }
+  }
+}
+
 void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
                     uint8_t DepthKLimit) {
-
   if (EV.Paths.empty() || Txn.empty()) {
     // Nothing to be done here
     return;
@@ -206,50 +244,13 @@ void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
   auto Save = std::exchange(EV.Paths, {});
   EV.Paths.reserve(Save.size());
 
-  const auto TxnOffset = Txn.Offset;
-  const auto TxnLoads = EV.Mgr->getFullFieldString(Txn.Loads);
-  const auto TxnStores = EV.Mgr->getFullFieldString(Txn.Stores);
-  const auto Kills = EV.Mgr->kills(Txn.Kills); // safety copy
-
-  for (const auto &F : Save) {
-    auto Copy = F;
-    bool Retain = [&] {
-      if (TxnOffset) {
-        if (!applyOneGep(*EV.Mgr, Copy, TxnOffset, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto Ld : TxnLoads) {
-        if (!applyOneGepAndLoad(*EV.Mgr, Copy, Ld, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto Kl : Kills) {
-        if (!applyOneGepAndKill(*EV.Mgr, Copy, Kl, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto St : TxnStores) {
-        if (!applyOneGepAndStore(*EV.Mgr, Copy, St, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      return true;
-    }();
-
-    if (Retain) {
-      EV.Paths.insert(Copy);
-    }
-  }
+  applyTransformImpl(Save, EV.Paths, *EV.Mgr, Txn, DepthKLimit);
 }
 
 void applyTransformInto(const IFDSEdgeValue &EV, IFDSEdgeValue &Into,
                         const AccessPath &Txn, uint8_t DepthKLimit) {
   assert(&EV != &Into);
+  assert(EV.Mgr == Into.Mgr);
   if (EV.Paths.empty() || Txn.empty()) {
     // Nothing to be done here
     return;
@@ -259,45 +260,7 @@ void applyTransformInto(const IFDSEdgeValue &EV, IFDSEdgeValue &Into,
     return;
   }
 
-  const auto TxnOffset = Txn.Offset;
-  const auto TxnLoads = EV.Mgr->getFullFieldString(Txn.Loads);
-  const auto TxnStores = EV.Mgr->getFullFieldString(Txn.Stores);
-  const auto Kills = EV.Mgr->kills(Txn.Kills); // safety copy
-
-  for (const auto &F : EV.Paths) {
-    auto Copy = F;
-    bool Retain = [&] {
-      if (TxnOffset) {
-        if (!applyOneGep(*EV.Mgr, Copy, TxnOffset, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto Ld : TxnLoads) {
-        if (!applyOneGepAndLoad(*EV.Mgr, Copy, Ld, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto Kl : Kills) {
-        if (!applyOneGepAndKill(*EV.Mgr, Copy, Kl, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      for (auto St : TxnStores) {
-        if (!applyOneGepAndStore(*EV.Mgr, Copy, St, DepthKLimit)) {
-          return false;
-        }
-      }
-
-      return true;
-    }();
-
-    if (Retain) {
-      Into.Paths.insert(Copy);
-    }
-  }
+  applyTransformImpl(EV.Paths, Into.Paths, *EV.Mgr, Txn, DepthKLimit);
 }
 
 static auto &printOffset(llvm::raw_ostream &OS, int32_t Offset,
@@ -342,9 +305,6 @@ void IFDSEdgeValue::applyTransforms(const IFDSEdgeValue &Txns,
 
   for (++It; It != End; ++It) {
     if (!It->empty()) {
-      // auto Tmp = *this;
-      // applyTransform(Tmp, *It, DepthKLimit);
-      // Ret.Paths.insert(Tmp.Paths.begin(), Tmp.Paths.end());
       applyTransformInto(*this, Ret, *It, DepthKLimit);
     } else {
       Ret.Paths.insert(Paths.begin(), Paths.end());
@@ -462,10 +422,10 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
   auto [BasePtr, Offset] = getBaseAndOffset(PointerOp, DL);
 
   // Trace the pointer chain from BasePtr toward SuccNode. DerefOffsets[0] is
-  // the outermost GEP offset (closest to SuccNode). The -O0 alloca-copy
-  // pattern is stripped transparently. The Stores chain is built with
-  // the outermost offset as HEAD so applyOneGepAndLoad matches in traversal
-  // order (outermost first, matching the actual memory access sequence).
+  // the outermost GEP offset (closest to SuccNode). The Stores chain is built
+  // with the outermost offset as HEAD so applyOneGepAndLoad matches in
+  // traversal order (outermost first, matching the actual memory access
+  // sequence).
   llvm::SmallVector<int32_t> DerefOffsets;
   const bool FoundSuccNode = walkLoadChainTo(
       BasePtr, SuccNode, DL, DepthKLimit, [&](int64_t ByteOffset) {
@@ -527,16 +487,12 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
 
   if (Curr == SuccNode) {
 
-    if (const auto *Load = llvm::dyn_cast<llvm::LoadInst>(Curr)) {
+    if (llvm::isa<llvm::LoadInst>(Curr)) {
       // Load
 
-      auto [BasePtr, Offset] = getBaseAndOffset(
-          Load->getPointerOperand(), IRDB->getModule()->getDataLayout());
-
-      // TODO;: How to deal with BasePtr?
-
+      // Note: Offsets handled in GEP below
       AccessPath FieldString{};
-      FieldString.Loads = Mgr.prepend(Offset, FieldString.Loads);
+      FieldString.Loads = Mgr.prepend(/*Offset*/ 0, FieldString.Loads);
       return makeEF(
           CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
     }
@@ -917,7 +873,7 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
                     auto Union = Larger;
                     Union.insert(It, End);
 
-                    // NOTE: No k-limit in combine()!!! Otherwise, we loose
+                    // NOTE: No k-limit in combine()!!! Otherwise, we may loose
                     // monotonicity of the lattice!
 
                     if (Union.size() > WidenKLimit) {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -24,7 +24,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstring>
 #include <type_traits>
 #include <utility>
 
@@ -476,8 +475,8 @@ auto CFLFieldSensIFDSProblem::getLoadEdgeFunction(d_t CurrNode, d_t PointerOp,
         CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
   }
 
-  // In case CurrNode!=PointerOp, we filter llvm values for allocation sites.
-  // GEPs are no alloc-sites!
+  // In case CurrNode!=PointerOp, we are filtering llvm values for allocation
+  // sites. GEPs are no alloc-sites!
   // => we must handle the offsetting here in the load, without relying it being
   //    handled in the GEP-EF
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -438,13 +438,10 @@ cfl_fieldsens::makeInitialSeeds(
   return {std::move(Ret)};
 }
 
-EdgeFunction<l_t>
-CFLFieldSensIFDSProblem::makeEF(cfl_fieldsens::CFLFieldSensEdgeFunction &&EF) {
-  auto [It, Inserted] = EFInternCache.insert(std::move(EF), nullptr);
-  if (Inserted) {
-    It->second = cfl_fieldsens::CFLFieldSensEdgeFunction(It->first);
-  }
-  return It->second;
+EdgeFunction<l_t> CFLFieldSensIFDSProblem::makeEF(
+    cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF) {
+  auto It = EFInternCache.insert(std::move(EF));
+  return CFLFieldSensEdgeFunction{&*It.first};
 }
 
 auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
@@ -471,7 +468,7 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
     AccessPath FieldString{};
     FieldString.Kills = Mgr.addKill(FieldString.Kills, Offset);
     return makeEF(
-        CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
+        CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
   }
 
   // Also match when ValueOp is a zero-offset GEP of CurrNode (e.g. the -O0
@@ -489,7 +486,7 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
       FieldString.Stores = Mgr.prepend(DerefOffset, FieldString.Stores);
     }
     return makeEF(
-        CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
+        CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
   }
 
   // unaffected by the store
@@ -509,7 +506,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
   if (isZeroValue(CurrNode) && !isZeroValue(SuccNode)) {
     // Gen from zero
 
-    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
+    return makeEF(CFLFieldSensEdgeFunctionImpl::fromEpsilon(DepthKLimit, Mgr));
   }
 
   if (const auto *Store = llvm::dyn_cast<llvm::StoreInst>(Curr)) {
@@ -531,7 +528,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
       AccessPath FieldString{};
       FieldString.Loads = Mgr.prepend(Offset, FieldString.Loads);
       return makeEF(
-          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
+          CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
     }
 
     if (const auto *Gep = llvm::dyn_cast<llvm::GEPOperator>(Curr)) {
@@ -541,7 +538,7 @@ auto CFLFieldSensIFDSProblem::getNormalEdgeFunction(n_t Curr, d_t CurrNode,
       AccessPath FieldString{};
       FieldString.Offset = OffsVal;
       return makeEF(
-          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
+          CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
     }
   }
 
@@ -562,7 +559,7 @@ auto CFLFieldSensIFDSProblem::getCallEdgeFunction(n_t CallSite, d_t SrcNode,
   if (isZeroValue(SrcNode) && !isZeroValue(DestNode)) {
     // Gen from zero
 
-    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
+    return makeEF(CFLFieldSensEdgeFunctionImpl::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // This is naturally identity
@@ -582,7 +579,7 @@ auto CFLFieldSensIFDSProblem::getReturnEdgeFunction(
   if (isZeroValue(ExitNode) && !isZeroValue(RetNode)) {
     // Gen from zero
 
-    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
+    return makeEF(CFLFieldSensEdgeFunctionImpl::fromEpsilon(DepthKLimit, Mgr));
   }
 
   return EdgeIdentity<l_t>{};
@@ -612,7 +609,7 @@ auto CFLFieldSensIFDSProblem::getCallToRetEdgeFunction(
   if (isZeroValue(CallNode) && !isZeroValue(RetSiteNode)) {
     // Gen from zero
 
-    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
+    return makeEF(CFLFieldSensEdgeFunctionImpl::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // This naturally identity
@@ -641,14 +638,14 @@ auto CFLFieldSensIFDSProblem::getSummaryEdgeFunction(n_t Curr, d_t CurrNode,
       AccessPath FieldString{};
       FieldString.Kills = Mgr.addKill(FieldString.Kills, *KillOffs);
       return makeEF(
-          CFLFieldSensEdgeFunction::from(FieldString, Mgr, DepthKLimit));
+          CFLFieldSensEdgeFunctionImpl::from(FieldString, Mgr, DepthKLimit));
     }
   }
 
   if (isZeroValue(CurrNode) && !isZeroValue(SuccNode)) {
     // Gen from zero
 
-    return makeEF(CFLFieldSensEdgeFunction::fromEpsilon(DepthKLimit, Mgr));
+    return makeEF(CFLFieldSensEdgeFunctionImpl::fromEpsilon(DepthKLimit, Mgr));
   }
 
   // TODO: Is that correct? -- We may need to handle field-indirections here
@@ -660,6 +657,7 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
   llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
                       AccessPathDMI>
       ToInsert;
+  ToInsert.reserve(Paths.size()); // retained across .clear() calls below
   // Merge stores
 
   for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
@@ -760,45 +758,46 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
 
+    if (!FldSensL || !FldSensR) {
+      llvm::report_fatal_error("[FieldSensAllocSitesAwareIFDSProblem::extend]: "
+                               "Unexpected edge functions: " +
+                               llvm::Twine(to_string(L)) + " EXTEND " +
+                               llvm::Twine(to_string(R)));
+    }
+
+    if (FldSensR->Impl->Transform.isEpsilon()) {
+      return L;
+    }
+
+    if (FldSensL->Impl->Transform.Paths.empty()) {
+      return L;
+    }
+
     static size_t ExtendCacheRefs = 0;
     static size_t ExtendCacheMisses = 0;
 
     ++ExtendCacheRefs;
     auto [It, Inserted] = ExtendCache.try_emplace(
-        std::pair{FldSensL, FldSensR}, lazy{[&]() -> EdgeFunction<l_t> {
+        std::pair{FldSensL->Impl, FldSensR->Impl},
+        lazy{[&]() -> EdgeFunction<l_t> {
           ++ExtendCacheMisses;
-          if (FldSensL && FldSensR) {
-            if (FldSensR->Transform.isEpsilon()) {
-              return L;
-            }
 
-            if (FldSensL->Transform.Paths.empty()) {
-              return L;
-            }
+          auto Txn = FldSensL->Impl->Transform;
+          Txn.applyTransforms(FldSensR->Impl->Transform, DepthKLimit);
 
-            auto Txn = FldSensL->Transform;
-            Txn.applyTransforms(FldSensR->Transform, DepthKLimit);
-
-            if (Txn.Paths.empty()) {
-              return AllTop<l_t>{};
-            }
-
-            if (Txn.Paths.size() > BreadthKLimit) {
-              klimitPaths(Txn.Paths, Mgr);
-              if (Txn.Paths.size() > WidenKLimit) {
-                return AllBottom<l_t>{};
-              }
-            }
-
-            return makeEF(
-                CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
+          if (Txn.Paths.empty()) {
+            return AllTop<l_t>{};
           }
 
-          llvm::report_fatal_error(
-              "[FieldSensAllocSitesAwareIFDSProblem::extend]: "
-              "Unexpected edge functions: " +
-              llvm::Twine(to_string(L)) + " EXTEND " +
-              llvm::Twine(to_string(R)));
+          if (Txn.Paths.size() > BreadthKLimit) {
+            klimitPaths(Txn.Paths, Mgr);
+            if (Txn.Paths.size() > WidenKLimit) {
+              return AllBottom<l_t>{};
+            }
+          }
+
+          return makeEF(
+              CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
         }});
 
     static scope_exit PrintCacheEfficiency = [] {
@@ -826,18 +825,35 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
     return Dflt;
   }
   auto Ret = [&]() -> EdgeFunction<l_t> {
+    static size_t CombineCacheRefs = 0;
+    static size_t CombineCacheMisses = 0;
+    static size_t CombineCallsTotal = 0;
+    static size_t CombineLIdentity = 0;
+    static size_t CombineLIdentitySlow = 0;
+    static size_t CombineRIdentity = 0;
+    static size_t CombineRIdentitySlow = 0;
+    static scope_exit PrintCacheEfficiency = [] {
+      llvm::errs() << "CombineCache Refs:\t" << CombineCacheRefs << '\n';
+      llvm::errs() << "CombineCache Hits:\t"
+                   << (CombineCacheRefs - CombineCacheMisses) << '\n';
+      llvm::errs() << "CombineCache Misses:\t" << CombineCacheMisses << '\n';
+      llvm::errs() << "CombineCallsTotal:\t" << CombineCallsTotal << '\n';
+      llvm::errs() << "CombineLIdentity:\t" << CombineLIdentity << '\n';
+      llvm::errs() << "CombineLIdentitySlow:\t" << CombineLIdentitySlow << '\n';
+      llvm::errs() << "CombineRIdentity:\t" << CombineRIdentity << '\n';
+      llvm::errs() << "CombineRIdentitySlow:\t" << CombineRIdentitySlow << '\n';
+    };
+
+    ++CombineCallsTotal;
+
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
-
     if (FldSensL) {
       if (FldSensR) {
 
-        static size_t CombineCacheRefs = 0;
-        static size_t CombineCacheMisses = 0;
-
         ++CombineCacheRefs;
         auto [CacheIt, CacheInserted] = CombineCache.try_emplace(
-            psr::minmaxVal(FldSensL, FldSensR),
+            psr::minmaxVal(FldSensL->Impl, FldSensR->Impl),
             lazy{[&]() -> EdgeFunction<l_t> {
               ++CombineCacheMisses;
               // A complicated way of expressing set-union of LPaths and RPaths.
@@ -845,8 +861,8 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
               // Rather, we like just incrementing the ref-count of L or R if
               // somehow possible.
 
-              const auto &LPaths = FldSensL->Transform.Paths;
-              const auto &RPaths = FldSensR->Transform.Paths;
+              const auto &LPaths = FldSensL->Impl->Transform.Paths;
+              const auto &RPaths = FldSensR->Impl->Transform.Paths;
               const auto LeftSz = LPaths.size();
               const auto RightSz = RPaths.size();
               const auto LeftSmaller = LeftSz < RightSz;
@@ -870,7 +886,7 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
                       return AllBottom<l_t>{};
                     }
 
-                    return makeEF(CFLFieldSensEdgeFunction::from(
+                    return makeEF(CFLFieldSensEdgeFunctionImpl::from(
                         IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},
                         DepthKLimit));
                   }
@@ -880,35 +896,32 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
               return LeftSmaller ? R : L;
             }});
 
-        static scope_exit PrintCacheEfficiency = [] {
-          llvm::errs() << "CombineCache Refs:\t" << CombineCacheRefs << '\n';
-          llvm::errs() << "CombineCache Hits:\t"
-                       << (CombineCacheRefs - CombineCacheMisses) << '\n';
-          llvm::errs() << "CombineCache Misses:\t" << CombineCacheMisses
-                       << '\n';
-        };
         return CacheIt->second;
       }
 
       if (R.isa<EdgeIdentity<l_t>>()) {
-        if (FldSensL->Transform.Paths.contains(AccessPath{})) {
+        ++CombineRIdentity;
+        if (FldSensL->Impl->Transform.Paths.contains(AccessPath{})) {
           return L;
         }
 
-        auto Txn = FldSensL->Transform;
+        ++CombineRIdentitySlow;
+        auto Txn = FldSensL->Impl->Transform;
         Txn.Paths.insert(AccessPath{});
         return makeEF(
-            CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
+            CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
       }
     } else if (FldSensR && L.isa<EdgeIdentity<l_t>>()) {
-      if (FldSensR->Transform.Paths.contains(AccessPath{})) {
+      ++CombineLIdentity;
+      if (FldSensR->Impl->Transform.Paths.contains(AccessPath{})) {
         return R;
       }
 
-      auto Txn = FldSensR->Transform;
+      ++CombineLIdentitySlow;
+      auto Txn = FldSensR->Impl->Transform;
       Txn.Paths.insert(AccessPath{});
       return makeEF(
-          CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit));
+          CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
     }
 
     llvm::errs() << "COMBINE " << L << " X " << R << " ==> AllBottom\n";

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -753,28 +753,34 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
 static constexpr ptrdiff_t BreadthKLimit = 5;
 static constexpr ptrdiff_t WidenKLimit = 128;
 
+static constexpr unsigned AllBottomId = 1;
+static constexpr unsigned AllTopId = 2;
+
 [[nodiscard]] static llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *,
                                           2>
 allBotPtr() noexcept {
-  return {nullptr, 1};
+  return {nullptr, AllBottomId};
 }
 
 [[nodiscard]] static llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *,
                                           2>
 allTopPtr() noexcept {
-  return {nullptr, 2};
+  return {nullptr, AllTopId};
 }
 
 [[nodiscard]] static EdgeFunction<l_t>
 getResultEF(llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *, 2> Ptr) {
   switch (Ptr.getInt()) {
-  case 1:
+  case AllBottomId:
     return AllBottom<l_t>{};
-  case 2:
+  case AllTopId:
     return AllTop<l_t>{};
   default:
     assert(Ptr.getPointer() != nullptr);
-    return CFLFieldSensEdgeFunction{Ptr.getPointer()};
+    assert(Ptr.getPointer() == Ptr.getOpaqueValue());
+    return CFLFieldSensEdgeFunction{
+        static_cast<const CFLFieldSensEdgeFunctionImpl *>(
+            Ptr.getOpaqueValue())};
   }
 }
 

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -438,10 +438,20 @@ cfl_fieldsens::makeInitialSeeds(
   return {std::move(Ret)};
 }
 
+llvm::raw_ostream &cfl_fieldsens::operator<<(llvm::raw_ostream &OS,
+                                             CFLFieldSensEdgeFunction EF) {
+  return OS << "Txn[" << EF.Impl->Transform << ']';
+}
+
 EdgeFunction<l_t> CFLFieldSensIFDSProblem::makeEF(
     cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF) {
   auto It = EFInternCache.insert(std::move(EF));
   return CFLFieldSensEdgeFunction{&*It.first};
+}
+auto CFLFieldSensIFDSProblem::makeEFPtr(
+    cfl_fieldsens::CFLFieldSensEdgeFunctionImpl &&EF) -> EFResultPtr {
+  auto It = EFInternCache.insert(std::move(EF));
+  return EFResultPtr{&*It.first};
 }
 
 auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
@@ -747,6 +757,31 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
 static constexpr ptrdiff_t BreadthKLimit = 5;
 static constexpr ptrdiff_t WidenKLimit = 128;
 
+[[nodiscard]] static llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *,
+                                          2>
+allBotPtr() noexcept {
+  return {nullptr, 1};
+}
+
+[[nodiscard]] static llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *,
+                                          2>
+allTopPtr() noexcept {
+  return {nullptr, 2};
+}
+
+[[nodiscard]] static EdgeFunction<l_t>
+getResultEF(llvm::PointerIntPair<const CFLFieldSensEdgeFunctionImpl *, 2> Ptr) {
+  switch (Ptr.getInt()) {
+  case 1:
+    return AllBottom<l_t>{};
+  case 2:
+    return AllTop<l_t>{};
+  default:
+    assert(Ptr.getPointer() != nullptr);
+    return CFLFieldSensEdgeFunction{Ptr.getPointer()};
+  }
+}
+
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                                      const EdgeFunction<l_t> &R)
     -> EdgeFunction<l_t> {
@@ -769,34 +804,29 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
       return L;
     }
 
-    if (FldSensL->Impl->Transform.Paths.empty()) {
-      return L;
-    }
-
     static size_t ExtendCacheRefs = 0;
     static size_t ExtendCacheMisses = 0;
 
     ++ExtendCacheRefs;
     auto [It, Inserted] = ExtendCache.try_emplace(
-        std::pair{FldSensL->Impl, FldSensR->Impl},
-        lazy{[&]() -> EdgeFunction<l_t> {
+        std::pair{FldSensL->Impl, FldSensR->Impl}, lazy{[&]() -> EFResultPtr {
           ++ExtendCacheMisses;
 
           auto Txn = FldSensL->Impl->Transform;
           Txn.applyTransforms(FldSensR->Impl->Transform, DepthKLimit);
 
           if (Txn.Paths.empty()) {
-            return AllTop<l_t>{};
+            return allTopPtr();
           }
 
           if (Txn.Paths.size() > BreadthKLimit) {
             klimitPaths(Txn.Paths, Mgr);
             if (Txn.Paths.size() > WidenKLimit) {
-              return AllBottom<l_t>{};
+              return allBotPtr();
             }
           }
 
-          return makeEF(
+          return makeEFPtr(
               CFLFieldSensEdgeFunctionImpl::from(std::move(Txn), DepthKLimit));
         }});
 
@@ -807,7 +837,7 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
       llvm::errs() << "ExtendCache Misses:\t" << ExtendCacheMisses << '\n';
     };
 
-    return It->second;
+    return getResultEF(It->second);
   }();
 
   if (!L.isa<EdgeIdentity<l_t>>() && !R.isa<EdgeIdentity<l_t>>()) {
@@ -854,15 +884,16 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
         ++CombineCacheRefs;
         auto [CacheIt, CacheInserted] = CombineCache.try_emplace(
             psr::minmaxVal(FldSensL->Impl, FldSensR->Impl),
-            lazy{[&]() -> EdgeFunction<l_t> {
+            lazy{[this, FldSensL{*FldSensL},
+                  FldSensR{*FldSensR}]() -> EFResultPtr {
               ++CombineCacheMisses;
               // A complicated way of expressing set-union of LPaths and RPaths.
               // Reason being that we don't want to unnecessarily copy the sets.
               // Rather, we like just incrementing the ref-count of L or R if
               // somehow possible.
 
-              const auto &LPaths = FldSensL->Impl->Transform.Paths;
-              const auto &RPaths = FldSensR->Impl->Transform.Paths;
+              const auto &RPaths = FldSensR.Impl->Transform.Paths;
+              const auto &LPaths = FldSensL.Impl->Transform.Paths;
               const auto LeftSz = LPaths.size();
               const auto RightSz = RPaths.size();
               const auto LeftSmaller = LeftSz < RightSz;
@@ -883,20 +914,20 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
                     // monotonicity of the lattice!
 
                     if (Union.size() > WidenKLimit) {
-                      return AllBottom<l_t>{};
+                      return allBotPtr();
                     }
 
-                    return makeEF(CFLFieldSensEdgeFunctionImpl::from(
+                    return makeEFPtr(CFLFieldSensEdgeFunctionImpl::from(
                         IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},
                         DepthKLimit));
                   }
                 }
               }
 
-              return LeftSmaller ? R : L;
+              return EFResultPtr{LeftSmaller ? FldSensR.Impl : FldSensL.Impl};
             }});
 
-        return CacheIt->second;
+        return getResultEF(CacheIt->second);
       }
 
       if (R.isa<EdgeIdentity<l_t>>()) {

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -306,6 +306,59 @@ void applyTransform(IFDSEdgeValue &EV, const AccessPath &Txn,
   }
 }
 
+void applyTransformInto(const IFDSEdgeValue &EV, IFDSEdgeValue &Into,
+                        const AccessPath &Txn, uint8_t DepthKLimit) {
+  assert(&EV != &Into);
+  if (EV.Paths.empty() || Txn.empty()) {
+    // Nothing to be done here
+    return;
+  }
+  if (EV.isEpsilon()) {
+    Into.Paths.insert(Txn);
+    return;
+  }
+
+  const auto TxnOffset = Txn.Offset;
+  const auto TxnLoads = EV.Mgr->getFullFieldString(Txn.Loads);
+  const auto TxnStores = EV.Mgr->getFullFieldString(Txn.Stores);
+  const auto Kills = EV.Mgr->kills(Txn.Kills); // safety copy
+
+  for (const auto &F : EV.Paths) {
+    auto Copy = F;
+    bool Retain = [&] {
+      if (TxnOffset) {
+        if (!applyOneGep(*EV.Mgr, Copy, TxnOffset, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto Ld : TxnLoads) {
+        if (!applyOneGepAndLoad(*EV.Mgr, Copy, Ld, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto Kl : Kills) {
+        if (!applyOneGepAndKill(*EV.Mgr, Copy, Kl, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      for (auto St : TxnStores) {
+        if (!applyOneGepAndStore(*EV.Mgr, Copy, St, DepthKLimit)) {
+          return false;
+        }
+      }
+
+      return true;
+    }();
+
+    if (Retain) {
+      Into.Paths.insert(Copy);
+    }
+  }
+}
+
 static auto &printOffset(llvm::raw_ostream &OS, int32_t Offset,
                          bool WithSign = false) {
 
@@ -348,9 +401,10 @@ void IFDSEdgeValue::applyTransforms(const IFDSEdgeValue &Txns,
 
   for (++It; It != End; ++It) {
     if (!It->empty()) {
-      auto Tmp = *this;
-      applyTransform(Tmp, *It, DepthKLimit);
-      Ret.Paths.insert(Tmp.Paths.begin(), Tmp.Paths.end());
+      // auto Tmp = *this;
+      // applyTransform(Tmp, *It, DepthKLimit);
+      // Ret.Paths.insert(Tmp.Paths.begin(), Tmp.Paths.end());
+      applyTransformInto(*this, Ret, *It, DepthKLimit);
     } else {
       Ret.Paths.insert(Paths.begin(), Paths.end());
     }
@@ -748,7 +802,7 @@ static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
 }
 
 static constexpr ptrdiff_t BreadthKLimit = 5;
-static constexpr ptrdiff_t WidenKLimit = 1024;
+static constexpr ptrdiff_t WidenKLimit = 128;
 
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                                      const EdgeFunction<l_t> &R)
@@ -779,10 +833,9 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
 
       if (Txn.Paths.size() > BreadthKLimit) {
         klimitPaths(Txn.Paths, Mgr);
-      }
-
-      if (Txn.Paths.size() > WidenKLimit) {
-        return AllBottom<l_t>{};
+        if (Txn.Paths.size() > WidenKLimit) {
+          return AllBottom<l_t>{};
+        }
       }
 
       return CFLFieldSensEdgeFunction::from(std::move(Txn), DepthKLimit);
@@ -794,10 +847,10 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                              llvm::Twine(to_string(R)));
   }();
 
-  // if (!L.isa<EdgeIdentity<l_t>>() && !R.isa<EdgeIdentity<l_t>>()) {
-  PHASAR_LOG_LEVEL_CAT(DEBUG, LogCategory,
-                       "EXTEND " << L << " X " << R << " ==> " << Ret);
-  // }
+  if (!L.isa<EdgeIdentity<l_t>>() && !R.isa<EdgeIdentity<l_t>>()) {
+    PHASAR_LOG_LEVEL_CAT(DEBUG, LogCategory,
+                         "EXTEND " << L << " X " << R << " ==> " << Ret);
+  }
 
   return Ret;
 }
@@ -805,11 +858,10 @@ auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
 auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
                                       const EdgeFunction<l_t> &R)
     -> EdgeFunction<l_t> {
+  if (auto Dflt = defaultJoinOrNullNoId(L, R)) {
+    return Dflt;
+  }
   auto Ret = [&]() -> EdgeFunction<l_t> {
-    if (auto Dflt = defaultJoinOrNullNoId(L, R)) {
-      return Dflt;
-    }
-
     const auto *FldSensL = L.dyn_cast<CFLFieldSensEdgeFunction>();
     const auto *FldSensR = R.dyn_cast<CFLFieldSensEdgeFunction>();
 
@@ -840,6 +892,10 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
 
               // NOTE: No k-limit in combine()!!! Otherwise, we loose
               // monotonicity of the lattice!
+
+              if (Union.size() > WidenKLimit) {
+                return AllBottom<l_t>{};
+              }
 
               return CFLFieldSensEdgeFunction::from(
                   IFDSEdgeValue{.Mgr = &Mgr, .Paths = std::move(Union)},
@@ -875,8 +931,12 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
     return AllBottom<l_t>{};
   }();
 
-  PHASAR_LOG_LEVEL_CAT(DEBUG, LogCategory,
-                       "COMBINE " << L << " X " << R << " ==> " << Ret);
+  if (L != R) {
+    PHASAR_LOG_LEVEL_CAT(DEBUG, LogCategory,
+                         "COMBINE " << L << " X " << R << " ==> " << Ret
+                                    << "; Ret==L: " << (Ret == L)
+                                    << "; Ret==R: " << (Ret == R));
+  }
 
   return Ret;
 }

--- a/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
+++ b/lib/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.cpp
@@ -8,6 +8,7 @@
 #include "phasar/Utils/Fn.h"
 #include "phasar/Utils/Logger.h"
 #include "phasar/Utils/Printer.h"
+#include "phasar/Utils/Utilities.h"
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseSet.h"
@@ -158,15 +159,16 @@ struct CFLFieldSensEdgeFunction {
     Full.erase(Full.begin());
     F.Stores = Mgr.fromFullFieldString(Full);
   }
-  F.Stores = Mgr.prepend(std::exchange(F.Offset, 0) + Field, F.Stores);
+  F.Stores = Mgr.prepend(Field, F.Stores);
+  // F.Stores = Mgr.prepend(std::exchange(F.Offset, 0) + Field, F.Stores);
   return std::true_type{};
 }
 
 // Returns whether to retain F
 [[nodiscard]] auto applyOneGepAndLoad(FieldStringManager &Mgr, AccessPath &F,
                                       int32_t Field, uint8_t DepthKLimit) {
-  auto Offs = F.Offset + Field;
   if (F.Stores == FieldStringNodeId::None) {
+    auto Offs = F.Offset + Field;
 
     if (F.kills(Offs)) {
       return false;
@@ -187,13 +189,16 @@ struct CFLFieldSensEdgeFunction {
 
   auto StoresHead = Mgr[F.Stores];
 
-  if (StoresHead.Offset != Offs && StoresHead.Offset != AccessPath::TopOffset) {
+  if (StoresHead.Offset != Field &&
+      StoresHead.Offset != AccessPath::TopOffset) {
+    // F.print(llvm::errs() << "For AccesPath ", Mgr);
+    // llvm::errs() << ": Load " << Field << " invalid offset\n";
     return false;
   }
 
-  assert(StoresHead.Offset == Offs ||
+  assert(StoresHead.Offset == Field ||
          StoresHead.Offset == AccessPath::TopOffset);
-  F.Offset = 0;
+  // F.Offset = 0;
   F.Stores = StoresHead.Next;
   // llvm::errs() << "> pop_back\n";
   return true;
@@ -201,13 +206,18 @@ struct CFLFieldSensEdgeFunction {
 
 [[nodiscard]] auto applyOneGepAndKill(FieldStringManager &Mgr, AccessPath &F,
                                       int32_t Field, uint8_t /*DepthKLimit*/) {
-  auto Offs = addOffsets(F.Offset, Field);
-  if (Offs == AccessPath::TopOffset) {
+  if (Field == AccessPath::TopOffset) {
     // We cannot kill Top
     return true;
   }
 
   if (F.Stores == FieldStringNodeId::None) {
+    auto Offs = addOffsets(F.Offset, Field);
+    if (Offs == AccessPath::TopOffset) {
+      // We cannot kill Top
+      return true;
+    }
+
     F.Kills.insert(Offs);
     PHASAR_LOG_LEVEL_CAT(DEBUG, IFDSEdgeValue::LogCategory, "> add K" << Offs);
     return true;
@@ -215,7 +225,7 @@ struct CFLFieldSensEdgeFunction {
 
   auto StoresHead = Mgr[F.Stores];
 
-  if (StoresHead.Offset == Offs) {
+  if (StoresHead.Offset == Field) {
     PHASAR_LOG_LEVEL_CAT(DEBUG, IFDSEdgeValue::LogCategory,
                          "> Kill " << storesToString(F, Mgr));
     return false;
@@ -224,7 +234,7 @@ struct CFLFieldSensEdgeFunction {
   PHASAR_LOG_LEVEL_CAT(DEBUG, IFDSEdgeValue::LogCategory,
                        "> Retain " << storesToString(F, Mgr));
 
-  assert(StoresHead.Offset != Offs);
+  assert(StoresHead.Offset != Field);
   return true;
 }
 
@@ -339,7 +349,8 @@ size_t psr::cfl_fieldsens::hash_value(const AccessPath &FieldString) noexcept {
   // Xor does not care about the order
   auto HCK = std::reduce(FieldString.Kills.begin(), FieldString.Kills.end(), 0,
                          std::bit_xor<>{});
-  return llvm::hash_combine(FieldString.Loads, FieldString.Stores, HCK);
+  return llvm::hash_combine(FieldString.Loads, FieldString.Stores,
+                            FieldString.Offset, HCK);
 }
 
 llvm::raw_ostream &
@@ -365,8 +376,8 @@ psr::cfl_fieldsens::operator<<(llvm::raw_ostream &OS,
     OS << 'K' << Kl << '.';
   }
 
-  if (FieldString.Loads != FieldStringNodeId::None) {
-    OS << "S#" << uint32_t(FieldString.Loads) << '.';
+  if (FieldString.Stores != FieldStringNodeId::None) {
+    OS << "S#" << uint32_t(FieldString.Stores) << '.';
   }
 
   return OS;
@@ -441,43 +452,40 @@ auto CFLFieldSensIFDSProblem::getStoreEdgeFunction(d_t CurrNode, d_t SuccNode,
     -> EdgeFunction<l_t> {
   auto [BasePtr, Offset] = getBaseAndOffset(PointerOp, DL);
 
-  // TODO;: How to deal with BasePtr?
+  // Trace the pointer chain from BasePtr toward SuccNode. DerefOffsets[0] is
+  // the outermost GEP offset (closest to SuccNode). The -O0 alloca-copy
+  // pattern is stripped transparently. The Stores chain is built with
+  // the outermost offset as HEAD so applyOneGepAndLoad matches in traversal
+  // order (outermost first, matching the actual memory access sequence).
+  llvm::SmallVector<int32_t> DerefOffsets;
+  const bool FoundSuccNode = walkLoadChainTo(
+      BasePtr, SuccNode, DL, DepthKLimit, [&](int64_t ByteOffset) {
+        DerefOffsets.push_back(ByteOffset != INT64_MIN ? int32_t(ByteOffset)
+                                                       : AccessPath::TopOffset);
+      });
 
-  auto [BaseBasePtr,
-        BaseOffset] = [&]() -> std::pair<const llvm::Value *, int32_t> {
-    if (BasePtr != SuccNode && llvm::isa<llvm::LoadInst>(BasePtr)) {
-      return getBaseAndOffset(
-          llvm::cast<llvm::LoadInst>(BasePtr)->getPointerOperand(), DL);
-    }
-
-    return {nullptr, INT32_MIN};
-  }();
-  if (CurrNode == SuccNode &&
-      (BasePtr == CurrNode || BaseBasePtr == CurrNode)) {
+  if (CurrNode == SuccNode && FoundSuccNode) {
     // Kill
-
     AccessPath FieldString{};
     FieldString.Kills.insert(Offset);
     return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
                                           DepthKLimit);
   }
 
-  if (ValueOp == CurrNode && CurrNode != SuccNode) {
-    // Store
+  // Also match when ValueOp is a zero-offset GEP of CurrNode (e.g. the -O0
+  // arraydecay pattern where `%arraydecay = gep arr, 0, 0` is stored but the
+  // tainted fact is `arr` itself).
+  auto [ValueBase, ValueGepOff] = getBaseAndOffset(ValueOp, DL);
+  const bool IsValueCurrNode =
+      ValueOp == CurrNode || (ValueGepOff == 0 && ValueBase == CurrNode);
 
+  if (IsValueCurrNode && CurrNode != SuccNode && FoundSuccNode) {
+    // Store: prepend innermost first so the outermost becomes the HEAD.
     AccessPath FieldString{};
-    if (BasePtr != SuccNode && llvm::isa<llvm::LoadInst>(BasePtr)) {
-      // This is a hack, to be more correct with field-insensitive alias
-      // information
-
-      if (BaseBasePtr == SuccNode) {
-        // push before Offset, or after?
-        FieldString.Stores = Mgr.prepend(BaseOffset, FieldString.Stores);
-      }
-    }
-
     FieldString.Stores = Mgr.prepend(Offset, FieldString.Stores);
-
+    for (int32_t DerefOffset : llvm::reverse(DerefOffsets)) {
+      FieldString.Stores = Mgr.prepend(DerefOffset, FieldString.Stores);
+    }
     return CFLFieldSensEdgeFunction::from(std::move(FieldString), Mgr,
                                           DepthKLimit);
   }
@@ -647,30 +655,105 @@ auto CFLFieldSensIFDSProblem::getSummaryEdgeFunction(n_t Curr, d_t CurrNode,
 }
 
 static void klimitPaths(auto &Paths, FieldStringManager &Mgr) {
-
-  llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
-                      AccessPathDMI>
-      ToInsert;
-  for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
-    auto It = IIt++;
-    if (It->Stores != FieldStringNodeId::None) {
-      AccessPath Approx = *It;
-      auto StoresHead = Mgr[Approx.Stores];
-      Approx.Stores = Mgr.prepend(AccessPath::TopOffset, StoresHead.Next);
-      ToInsert[std::move(Approx)].push_back(*It);
-      Paths.erase(It);
+  // Merge stores
+  {
+    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
+                        AccessPathDMI>
+        ToInsert;
+    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+      auto It = IIt++;
+      if (It->Stores != FieldStringNodeId::None) {
+        AccessPath Approx = *It;
+        auto StoresHead = Mgr[Approx.Stores];
+        Approx.Stores = Mgr.prepend(AccessPath::TopOffset, StoresHead.Next);
+        ToInsert[std::move(Approx)].push_back(*It);
+        Paths.erase(It);
+      }
+    }
+    for (auto &&[Approx, OrigPaths] : ToInsert) {
+      if (OrigPaths.size() > 2) {
+        Paths.insert(Approx);
+      } else {
+        Paths.insert(OrigPaths.begin(), OrigPaths.end());
+      }
     }
   }
-  for (auto &&[Approx, OrigPaths] : ToInsert) {
-    if (OrigPaths.size() > 2) {
-      Paths.insert(Approx);
-    } else {
-      Paths.insert(OrigPaths.begin(), OrigPaths.end());
+
+  // Merge geps
+  {
+    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
+                        AccessPathDMI>
+        ToInsert;
+    for (const AccessPath &AP : Paths) {
+      auto NoOffs = AP;
+      NoOffs.Offset = AccessPath::TopOffset;
+      ToInsert[NoOffs].push_back(AP);
+    }
+    Paths.clear();
+    for (auto &&[Approx, OrigPaths] : ToInsert) {
+      if (OrigPaths.size() > 2) {
+        Paths.insert(Approx);
+      } else {
+        Paths.insert(OrigPaths.begin(), OrigPaths.end());
+      }
+    }
+  }
+
+  // Merge loads
+  {
+    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
+                        AccessPathDMI>
+        ToInsert;
+    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+      auto It = IIt++;
+      if (It->Loads != FieldStringNodeId::None) {
+        AccessPath Approx = *It;
+        auto LoadsHead = Mgr[Approx.Loads];
+        Approx.Loads = Mgr.prepend(AccessPath::TopOffset, LoadsHead.Next);
+        ToInsert[Approx].push_back(*It);
+        Paths.erase(It);
+      }
+    }
+    for (auto &&[Approx, OrigPaths] : ToInsert) {
+      if (OrigPaths.size() > 2) {
+        Paths.insert(Approx);
+      } else {
+        Paths.insert(OrigPaths.begin(), OrigPaths.end());
+      }
+    }
+  }
+
+  // Merge Kills
+  {
+    llvm::SmallDenseMap<AccessPath, llvm::SmallVector<AccessPath>, 2,
+                        AccessPathDMI>
+        ToInsert;
+    for (auto IIt = Paths.begin(), End = Paths.end(); IIt != End;) {
+      auto It = IIt++;
+
+      AccessPath Approx = *It;
+      Approx.Kills = {};
+      ToInsert[Approx].push_back(*It);
+      Paths.erase(It);
+    }
+    for (auto &&[Approx, OrigPaths] : ToInsert) {
+      if (OrigPaths.size() > 2) {
+        auto ApproxMut = Approx;
+        ApproxMut.Kills = OrigPaths.front().Kills;
+        for (const auto &AP : llvm::drop_begin(OrigPaths)) {
+          intersectWith(ApproxMut.Kills, AP.Kills);
+        }
+
+        Paths.insert(std::move(ApproxMut));
+      } else {
+        Paths.insert(OrigPaths.begin(), OrigPaths.end());
+      }
     }
   }
 }
 
 static constexpr ptrdiff_t BreadthKLimit = 5;
+static constexpr ptrdiff_t WidenLimit = 1024;
 
 auto CFLFieldSensIFDSProblem::extend(const EdgeFunction<l_t> &L,
                                      const EdgeFunction<l_t> &R)
@@ -756,7 +839,12 @@ auto CFLFieldSensIFDSProblem::combine(const EdgeFunction<l_t> &L,
               Union.insert(It, End);
 
               if (Union.size() > BreadthKLimit) {
+                // llvm::errs() << "Union.size(): " << Union.size() << '\n';
                 klimitPaths(Union, Mgr);
+
+                if (Union.size() > WidenLimit) {
+                  return AllBottom<l_t>{};
+                }
               }
 
               return CFLFieldSensEdgeFunction::from(

--- a/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
+++ b/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
@@ -748,16 +748,33 @@ bool psr::walkLoadChainTo(const llvm::Value *Start, const llvm::Value *Target,
                              ? INT64_MIN // non-constant GEP
                              : Offset.getSExtValue();
 
-    // Alloca-copy pattern (-O0 IR): load from alloca uniquely storing Target.
-    // Strip transparently without recording an offset level.
+    // -O0 mem2reg artifact: clang copies every argument/local into an alloca
+    // and re-loads it at each use. If the alloca has exactly one store and
+    // that store holds Target, the load is a transparent SSA copy -- not a
+    // real dereference of Target. Skipping OnDeref here keeps the indirection
+    // depth consistent with post-mem2reg IR (where the alloca disappears).
+    // Require Offset==0 and no other stores to avoid spurious kills when the
+    // alloca is reassigned to a different pointer.
     if (const auto *AI = llvm::dyn_cast<llvm::AllocaInst>(Base);
-        AI && llvm::any_of(AI->users(), [&](const llvm::User *U) {
-          const auto *SI = llvm::dyn_cast<llvm::StoreInst>(U);
-          return SI && SI->getPointerOperand() == AI &&
-                 SI->getValueOperand() == Target;
-        })) {
-      Cur = Target;
-      break;
+        AI && Offset.isZero()) {
+      bool HasTargetStore = false;
+      bool HasOtherStore = false;
+      for (const auto *U : AI->users()) {
+        const auto *SI = llvm::dyn_cast<llvm::StoreInst>(U);
+        if (!SI || SI->getPointerOperand() != AI) {
+          continue;
+        }
+        if (SI->getValueOperand() == Target) {
+          HasTargetStore = true;
+        } else {
+          HasOtherStore = true;
+          break;
+        }
+      }
+      if (HasTargetStore && !HasOtherStore) {
+        Cur = Target;
+        break;
+      }
     }
 
     OnDeref(ByteOffset);

--- a/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
+++ b/lib/PhasarLLVM/Utils/LLVMShorthands.cpp
@@ -729,6 +729,43 @@ psr::getPointerIndicesOfType(const llvm::DIType *Ty,
   return std::move(getPointerIndicesOfType(Ty, DL, PIC));
 }
 
+bool psr::walkLoadChainTo(const llvm::Value *Start, const llvm::Value *Target,
+                          const llvm::DataLayout &DL, uint32_t MaxDepth,
+                          llvm::function_ref<void(int64_t)> OnDeref) {
+  const llvm::Value *Cur = Start;
+  for (unsigned Depth = 0; Depth < MaxDepth && Cur != Target; ++Depth) {
+    const auto *LI = llvm::dyn_cast<llvm::LoadInst>(Cur);
+    if (!LI) {
+      break;
+    }
+
+    llvm::APInt Offset(64, 0);
+    const auto *Stripped =
+        LI->getPointerOperand()->stripAndAccumulateConstantOffsets(
+            DL, Offset, /*AllowNonInbounds=*/true);
+    const auto *Base = Stripped->stripPointerCastsAndAliases();
+    int64_t ByteOffset = llvm::isa<llvm::GEPOperator>(Stripped)
+                             ? INT64_MIN // non-constant GEP
+                             : Offset.getSExtValue();
+
+    // Alloca-copy pattern (-O0 IR): load from alloca uniquely storing Target.
+    // Strip transparently without recording an offset level.
+    if (const auto *AI = llvm::dyn_cast<llvm::AllocaInst>(Base);
+        AI && llvm::any_of(AI->users(), [&](const llvm::User *U) {
+          const auto *SI = llvm::dyn_cast<llvm::StoreInst>(U);
+          return SI && SI->getPointerOperand() == AI &&
+                 SI->getValueOperand() == Target;
+        })) {
+      Cur = Target;
+      break;
+    }
+
+    OnDeref(ByteOffset);
+    Cur = Base;
+  }
+  return Cur == Target;
+}
+
 llvm::StringRef
 psr::getVarAnnotationIntrinsicName(const llvm::CallInst *CallInst) {
   const int KPointerGlobalStringIdx = 1;

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
@@ -8,6 +8,7 @@
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.h"
 #include "phasar/PhasarLLVM/Pointer/FilteredLLVMAliasSet.h"
+#include "phasar/PhasarLLVM/Pointer/LLVMAliasInfo.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMAliasSet.h"
 #include "phasar/PhasarLLVM/TaintConfig/LLVMTaintConfig.h"
 #include "phasar/PhasarLLVM/TaintConfig/TaintConfigUtilities.h"
@@ -15,6 +16,7 @@
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include "SrcCodeLocationEntry.h"
 #include "TestConfig.h"
@@ -119,7 +121,7 @@ public:
       }
 
       if (Leak.contains(Source)) {
-        Leaks[CS] = Source;
+        Leaks[CS].insert(Source);
       }
 
       if (Kill.contains(Source)) {
@@ -130,7 +132,7 @@ public:
     });
   }
 
-  llvm::DenseMap<n_t, d_t> Leaks{};
+  llvm::DenseMap<n_t, std::set<d_t>> Leaks{};
 
 private:
   const psr::LLVMTaintConfig *Config{};
@@ -138,13 +140,34 @@ private:
 
 using namespace psr::unittest;
 
-class CFLFieldSensTest : public ::testing::Test {
+template <typename T>
+T makeIFDSTA(const psr::LLVMProjectIRDB *IRDB, psr::LLVMAliasInfoRef AS,
+             const psr::LLVMTaintConfig *TC);
+
+template <>
+psr::IFDSTaintAnalysis
+makeIFDSTA<psr::IFDSTaintAnalysis>(const psr::LLVMProjectIRDB *IRDB,
+                                   psr::LLVMAliasInfoRef AS,
+                                   const psr::LLVMTaintConfig *TC) {
+  return psr::IFDSTaintAnalysis(IRDB, AS, TC, {"main"},
+                                /*TaintMainArgs=*/false,
+                                /*EnableStrongUpdateStore=*/false);
+}
+
+template <>
+ExampleTaintAnalysis
+makeIFDSTA<ExampleTaintAnalysis>(const psr::LLVMProjectIRDB *IRDB,
+                                 psr::LLVMAliasInfoRef AS,
+                                 const psr::LLVMTaintConfig *TC) {
+  return ExampleTaintAnalysis(IRDB, AS, TC, {"main"});
+}
+
+using TaintSetT = std::set<TestingSrcLocation>;
+static constexpr auto PathToLLFiles = PHASAR_BUILD_SUBFOLDER("xtaint/");
+const std::vector<std::string> EntryPoints = {"main"};
+
+template <typename ProblemT> class CFLFieldSensTest : public ::testing::Test {
 protected:
-  static constexpr auto PathToLLFiles = PHASAR_BUILD_SUBFOLDER("xtaint/");
-  const std::vector<std::string> EntryPoints = {"main"};
-
-  using TaintSetT = std::set<TestingSrcLocation>;
-
   void run(const llvm::Twine &IRFileName,
            const std::map<TestingSrcLocation, TaintSetT> &GroundTruth,
            bool ShouldDumpResults = false) {
@@ -156,10 +179,7 @@ protected:
     psr::LLVMAliasSet BaseAS(&IRDB);
     psr::FilteredLLVMAliasSet AS(&BaseAS);
     psr::LLVMTaintConfig TC(IRDB);
-    // ExampleTaintAnalysis TaintProblem(&IRDB, &AS, &TC, {"main"});
-    psr::IFDSTaintAnalysis TaintProblem(&IRDB, &AS, &TC, {"main"},
-                                        /*TaintMainArgs=*/false,
-                                        /*EnableStrongUpdateStore=*/false);
+    auto TaintProblem = makeIFDSTA<ProblemT>(&IRDB, &AS, &TC);
 
     psr::CFLFieldSensIFDSProblem FsTaintProblem(&TaintProblem);
 
@@ -202,70 +222,74 @@ protected:
   }
 };
 
-TEST_F(CFLFieldSensTest, Basic_01) {
+using ProblemTypes =
+    ::testing::Types<psr::IFDSTaintAnalysis, ExampleTaintAnalysis>;
+TYPED_TEST_SUITE(CFLFieldSensTest, ProblemTypes);
+
+TYPED_TEST(CFLFieldSensTest, Basic_01) {
 
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{8, 3, "main"},
        {LineColFunOp{8, 9, "main", llvm::Instruction::Load}}},
   };
 
-  run({PathToLLFiles + "xtaint01_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint01_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_02) {
+TYPED_TEST(CFLFieldSensTest, Basic_02) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{9, 3, "main"},
        {LineColFunOp{9, 9, "main", llvm::Instruction::Load}}},
   };
 
-  run({PathToLLFiles + "xtaint02_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint02_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_03) {
+TYPED_TEST(CFLFieldSensTest, Basic_03) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{10, 3, "main"},
        {LineColFunOp{10, 9, "main", llvm::Instruction::Load}}},
   };
 
-  run({PathToLLFiles + "xtaint03_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint03_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_04) {
+TYPED_TEST(CFLFieldSensTest, Basic_04) {
   auto Call = LineColFun{6, 3, "_Z3barPi"};
 
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {Call, {OperandOf{0, Call}}},
   };
 
-  run({PathToLLFiles + "xtaint04_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint04_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_06) {
+TYPED_TEST(CFLFieldSensTest, Basic_06) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       // no leaks expected
   };
 
-  run({PathToLLFiles + "xtaint06_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint06_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_09_1) {
+TYPED_TEST(CFLFieldSensTest, Basic_09_1) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{14, 3, "main"}, {LineColFun{14, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint09_1_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint09_1_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_09) {
+TYPED_TEST(CFLFieldSensTest, Basic_09) {
   auto SinkCall = LineColFun{16, 3, "main"};
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {SinkCall, {OperandOf{0, SinkCall}}},
   };
 
-  run({PathToLLFiles + "xtaint09_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint09_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_12) {
+TYPED_TEST(CFLFieldSensTest, Basic_12) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{19, 3, "main"}, {LineColFun{19, 8, "main"}}},
   };
@@ -273,72 +297,72 @@ TEST_F(CFLFieldSensTest, Basic_12) {
   // We sanitize an alias - since we don't have must-alias relations, we cannot
   // kill aliases at all
 
-  run({PathToLLFiles + "xtaint12_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint12_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_13) {
+TYPED_TEST(CFLFieldSensTest, Basic_13) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{17, 3, "main"}, {LineColFun{17, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint13_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint13_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_14) {
+TYPED_TEST(CFLFieldSensTest, Basic_14) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{24, 3, "main"}, {LineColFun{24, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint14_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint14_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_16) {
+TYPED_TEST(CFLFieldSensTest, Basic_16) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{13, 3, "main"}, {LineColFun{13, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint16_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint16_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_17) {
+TYPED_TEST(CFLFieldSensTest, Basic_17) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{17, 3, "main"}, {LineColFun{17, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint17_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint17_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_18) {
+TYPED_TEST(CFLFieldSensTest, Basic_18) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       // no leaks expected
   };
 
-  run({PathToLLFiles + "xtaint18_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint18_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_20) {
+TYPED_TEST(CFLFieldSensTest, Basic_20) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{12, 3, "main"}, {LineColFun{6, 7, "main"}}},
       {LineColFun{13, 3, "main"}, {LineColFun{13, 8, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint20_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint20_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_22) {
+TYPED_TEST(CFLFieldSensTest, Basic_22) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{9, 5, "main"}, {LineColFun{9, 11, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint22_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint22_cpp_dbg.ll"}, GroundTruth);
 }
 
-TEST_F(CFLFieldSensTest, Basic_23) {
+TYPED_TEST(CFLFieldSensTest, Basic_23) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{17, 5, "main"}, {LineColFun{17, 11, "main"}}},
   };
 
-  run({PathToLLFiles + "xtaint23_cpp_dbg.ll"}, GroundTruth);
+  this->run({PathToLLFiles + "xtaint23_cpp_dbg.ll"}, GroundTruth);
 }
 
 } // namespace

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
@@ -12,7 +12,6 @@
 #include "phasar/PhasarLLVM/TaintConfig/LLVMTaintConfig.h"
 #include "phasar/PhasarLLVM/TaintConfig/TaintConfigUtilities.h"
 #include "phasar/PhasarLLVM/Utils/LLVMShorthands.h"
-#include "phasar/Utils/Logger.h"
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/Instruction.h"
@@ -170,9 +169,6 @@ protected:
     psr::IterativeIDESolver Solver(&FsTaintProblem, &ICFG);
     Solver.solve();
     auto Results = Solver.getSolverResults();
-
-    // auto Results = psr::solveIDEProblem(FsTaintProblem, ICFG);
-    // Results.dumpResults(ICFG);
 
     std::map<const llvm::Instruction *, std::set<const llvm::Value *>>
         ComputedLeaks;
@@ -333,10 +329,6 @@ TEST_F(CFLFieldSensTest, Basic_22) {
   std::map<TestingSrcLocation, TaintSetT> GroundTruth = {
       {LineColFun{9, 5, "main"}, {LineColFun{9, 11, "main"}}},
   };
-
-  // psr::Logger::initializeStderrLogger(
-  //     psr::SeverityLevel::DEBUG,
-  //     psr::FieldSensAllocSitesAwareIFDSProblem::LogCategory.str());
 
   run({PathToLLFiles + "xtaint22_cpp_dbg.ll"}, GroundTruth);
 }

--- a/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
+++ b/unittests/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensTest.cpp
@@ -6,6 +6,7 @@
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/CFLFieldSensIFDSProblem.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/DefaultAllocSitesAwareIDEProblem.h"
 #include "phasar/PhasarLLVM/DataFlow/IfdsIde/LLVMZeroValue.h"
+#include "phasar/PhasarLLVM/DataFlow/IfdsIde/Problems/IFDSTaintAnalysis.h"
 #include "phasar/PhasarLLVM/Pointer/FilteredLLVMAliasSet.h"
 #include "phasar/PhasarLLVM/Pointer/LLVMAliasSet.h"
 #include "phasar/PhasarLLVM/TaintConfig/LLVMTaintConfig.h"
@@ -156,7 +157,10 @@ protected:
     psr::LLVMAliasSet BaseAS(&IRDB);
     psr::FilteredLLVMAliasSet AS(&BaseAS);
     psr::LLVMTaintConfig TC(IRDB);
-    ExampleTaintAnalysis TaintProblem(&IRDB, &AS, &TC, {"main"});
+    // ExampleTaintAnalysis TaintProblem(&IRDB, &AS, &TC, {"main"});
+    psr::IFDSTaintAnalysis TaintProblem(&IRDB, &AS, &TC, {"main"},
+                                        /*TaintMainArgs=*/false,
+                                        /*EnableStrongUpdateStore=*/false);
 
     psr::CFLFieldSensIFDSProblem FsTaintProblem(&TaintProblem);
 
@@ -176,7 +180,10 @@ protected:
     for (auto IIt = TaintProblem.Leaks.begin(), End = TaintProblem.Leaks.end();
          IIt != End;) {
       auto It = IIt++;
-      const auto &[LeakInst, LeakFact] = *It;
+      const auto &[LeakInst, LeakFacts] = *It;
+
+      ASSERT_EQ(LeakFacts.size(), 1);
+      const auto *LeakFact = *LeakFacts.begin();
 
       const auto &Res = Results.resultAt(LeakInst, LeakFact);
       if (const auto *FieldStrings = Res.getValueOrNull()) {


### PR DESCRIPTION
Improves the `CFLFieldSensIFDSProblem`  in both performance and precision:

- Improves the edge-function composition performance
- Caches edge-functions (hash-consing)
  - Caches both edge-function composition and join
- Internalizes kill-sets making `AccessPath` drastically smaller & `trivially_copyable`
- Enables strong updates for more aliases

