### PR TITLE
Fix SparseIDE with IterativeIDESolver

### DIFF
--- a/include/phasar/PhasarLLVM/ControlFlow/SparseLLVMBasedICFG.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/SparseLLVMBasedICFG.h
@@ -56,7 +56,7 @@ public:
 
   ~SparseLLVMBasedICFG();
 
-  [[nodiscard]] n_t advanceToNextUser(n_t Succ, const auto &Fact) {
+  [[nodiscard]] n_t advanceToNextUser(n_t Succ, const auto &Fact) const {
     using psr::valueOf;
     return advanceToNextUserImpl(Succ, valueOf(Fact));
   }
@@ -65,7 +65,7 @@ private:
   [[nodiscard]] const SparseLLVMBasedCFG &
   getSparseCFGImpl(const llvm::Function *Fun, const llvm::Value *Val) const;
 
-  [[nodiscard]] n_t advanceToNextUserImpl(n_t Succ, v_t Fact);
+  [[nodiscard]] n_t advanceToNextUserImpl(n_t Succ, v_t Fact) const;
 
   std::unique_ptr<SVFGCache> SparseCFGCache;
   LLVMAliasInfoRef AliasAnalysis;

--- a/include/phasar/PhasarLLVM/ControlFlow/SparseLLVMBasedICFGView.h
+++ b/include/phasar/PhasarLLVM/ControlFlow/SparseLLVMBasedICFGView.h
@@ -56,7 +56,7 @@ public:
   // To make the IDESolver happy...
   operator const LLVMBasedICFG &() const noexcept { return *ICF; }
 
-  [[nodiscard]] n_t advanceToNextUser(n_t Succ, const auto &Fact) {
+  [[nodiscard]] n_t advanceToNextUser(n_t Succ, const auto &Fact) const {
     using psr::valueOf;
     return advanceToNextUserImpl(Succ, valueOf(Fact));
   }
@@ -77,7 +77,9 @@ private:
   [[nodiscard]] const SparseLLVMBasedCFG &
   getSparseCFGImpl(const llvm::Function *Fun, const llvm::Value *Val) const;
 
-  [[nodiscard]] n_t advanceToNextUserImpl(n_t Succ, v_t Fact);
+  [[nodiscard]] n_t advanceToNextUserImpl(n_t Succ, v_t Fact) const;
+
+  [[nodiscard]] size_t getNumCallSitesImpl() const noexcept;
 
   const LLVMBasedICFG *ICF{};
   std::unique_ptr<SVFGCache> SparseCFGCache;

--- a/lib/PhasarLLVM/ControlFlow/SVFGCache.h
+++ b/lib/PhasarLLVM/ControlFlow/SVFGCache.h
@@ -40,20 +40,16 @@ struct SVFGCache {
   getOrCreate(const LLVMBasedCFG &CFG, const llvm::Function *Fun,
               const llvm::Value *Val, LLVMAliasInfoRef AliasAnalysis);
 
-  [[nodiscard]] n_t advanceToNextUser(n_t Succ, const auto &Fact,
-                                      LLVMAliasInfoRef AliasAnalysis) {
+  [[nodiscard]] static n_t advanceToNextUser(n_t Succ, const auto &Fact,
+                                             LLVMAliasInfoRef AliasAnalysis) {
     using psr::valueOf;
 
-    // XXX: Measure, whether caching actually helps here...
-    // XXX: Make thread-safe:
+    // Not memoized: the forward scan skips only very few instructions on
+    // average, which is cheaper than a lookup in a multi-million-entry map.
+    // On a small coreutils benchmark, it was about ~11% *faster* to skip the
+    // cache.
 
-    auto [It, Inserted] =
-        SameOrNextUserCache.try_emplace(std::pair{Succ, valueOf(Fact)});
-    if (Inserted) {
-      It->second =
-          SparseLLVMControlFlow::advanceToNextUser(Succ, Fact, AliasAnalysis);
-    }
-    return It->second;
+    return SparseLLVMControlFlow::advanceToNextUser(Succ, Fact, AliasAnalysis);
   }
 };
 

--- a/lib/PhasarLLVM/ControlFlow/SparseLLVMBasedICFG.cpp
+++ b/lib/PhasarLLVM/ControlFlow/SparseLLVMBasedICFG.cpp
@@ -45,7 +45,7 @@ SparseLLVMBasedICFG::getSparseCFGImpl(const llvm::Function *Fun,
   return SparseCFGCache->getOrCreate(*this, Fun, Val, AliasAnalysis);
 }
 
-auto SparseLLVMBasedICFG::advanceToNextUserImpl(n_t Succ, v_t Fact) -> n_t {
-  assert(SparseCFGCache != nullptr);
-  return SparseCFGCache->advanceToNextUser(Succ, Fact, AliasAnalysis);
+auto SparseLLVMBasedICFG::advanceToNextUserImpl(n_t Succ, v_t Fact) const
+    -> n_t {
+  return SVFGCache::advanceToNextUser(Succ, Fact, AliasAnalysis);
 }

--- a/lib/PhasarLLVM/ControlFlow/SparseLLVMBasedICFGView.cpp
+++ b/lib/PhasarLLVM/ControlFlow/SparseLLVMBasedICFGView.cpp
@@ -61,7 +61,11 @@ SparseLLVMBasedICFGView::getSparseCFGImpl(const llvm::Function *Fun,
   return SparseCFGCache->getOrCreate(*this, Fun, Val, AliasAnalysis);
 }
 
-auto SparseLLVMBasedICFGView::advanceToNextUserImpl(n_t Succ, v_t Fact) -> n_t {
-  assert(SparseCFGCache != nullptr);
-  return SparseCFGCache->advanceToNextUser(Succ, Fact, AliasAnalysis);
+auto SparseLLVMBasedICFGView::advanceToNextUserImpl(n_t Succ, v_t Fact) const
+    -> n_t {
+  return SVFGCache::advanceToNextUser(Succ, Fact, AliasAnalysis);
+}
+
+size_t SparseLLVMBasedICFGView::getNumCallSitesImpl() const noexcept {
+  return ICF->getNumCallSites();
 }


### PR DESCRIPTION
Using a sparse ICFG with the `IterativeIDESolver` did not sparsify: `advanceToNextUser()` was non-const, therefore inaccessible from a const ICFG&.

Also, `SparseLLVMBasedICFGView` was incompatible with `ICFGBase`, which requires `getNumCallSites()`.

Finally, did some quick benchmark whether caching `advanceToNextUser` helps; *it does not; it rather hurts performance*; so dropped the cache.